### PR TITLE
fix: probe extensions for extensionless include paths

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -513,24 +513,55 @@ func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val) {
 	obj.set(segments[0], childObj)
 }
 
+// includeExtensions is the list of extensions to probe when an include path
+// has no extension, per the HOCON spec (properties first, then JSON, then HOCON).
+var includeExtensions = []string{".properties", ".json", ".conf"}
+
 func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	path := inc.Path
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(r.opts.BaseDir, path)
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
+
+	paths := []string{path}
+	if filepath.Ext(path) == "" {
+		// No extension: probe known extensions per HOCON spec.
+		paths = nil
+		for _, ext := range includeExtensions {
+			paths = append(paths, path+ext)
+		}
+	}
+
+	var data []byte
+	var resolvedPath string
+	var lastErr error
+	for _, p := range paths {
+		d, err := os.ReadFile(p)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		data = d
+		resolvedPath = p
+		break
+	}
+	if data == nil {
+		msg := "cannot read include file: " + lastErr.Error()
+		if filepath.Ext(inc.Path) == "" {
+			msg = fmt.Sprintf("cannot read include file: no file found for %q (tried %v)", inc.Path, includeExtensions)
+		}
 		return nil, &ResolveError{
-			Message:  "cannot read include file: " + err.Error(),
+			Message:  msg,
 			FilePath: path,
 		}
 	}
+
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
 		return nil, err
 	}
 	childResolver := &resolver{
-		opts:          Options{BaseDir: filepath.Dir(path)},
+		opts:          Options{BaseDir: filepath.Dir(resolvedPath)},
 		resolving:     make(map[string]bool),
 		resolvedCache: make(map[string]Val),
 		priorValues:   make(map[string]Val),

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -220,9 +220,16 @@ func resolveWithDir(t *testing.T, src, baseDir string) *resolver.Result {
 	return res
 }
 
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestResolver_IncludeProbeConf(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "from-conf"`), 0o644)
+	writeFile(t, filepath.Join(dir, "sub.conf"), `x = "from-conf"`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, ok := res.Root.Get("a")
@@ -240,7 +247,7 @@ func TestResolver_IncludeProbeConf(t *testing.T) {
 
 func TestResolver_IncludeProbeJSON(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "sub.json"), []byte(`{"y": "from-json"}`), 0o644)
+	writeFile(t, filepath.Join(dir, "sub.json"), `{"y": "from-json"}`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, ok := res.Root.Get("a")
@@ -258,7 +265,7 @@ func TestResolver_IncludeProbeJSON(t *testing.T) {
 
 func TestResolver_IncludeProbeProperties(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "sub.properties"), []byte(`z = "from-props"`), 0o644)
+	writeFile(t, filepath.Join(dir, "sub.properties"), `z = "from-props"`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, ok := res.Root.Get("a")
@@ -277,8 +284,8 @@ func TestResolver_IncludeProbeProperties(t *testing.T) {
 func TestResolver_IncludeProbeOrder(t *testing.T) {
 	// When both .properties and .conf exist, .properties is found first.
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "sub.properties"), []byte(`x = "props"`), 0o644)
-	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "conf"`), 0o644)
+	writeFile(t, filepath.Join(dir, "sub.properties"), `x = "props"`)
+	writeFile(t, filepath.Join(dir, "sub.conf"), `x = "conf"`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, _ := res.Root.Get("a")
@@ -291,7 +298,7 @@ func TestResolver_IncludeProbeOrder(t *testing.T) {
 func TestResolver_IncludeWithExtensionNoProbe(t *testing.T) {
 	// When an explicit extension is given, no probing should occur.
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "direct"`), 0o644)
+	writeFile(t, filepath.Join(dir, "sub.conf"), `x = "direct"`)
 
 	res := resolveWithDir(t, `a { include "sub.conf" }`, dir)
 	obj, _ := res.Root.Get("a")

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,6 +1,8 @@
 package resolver_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -202,5 +204,111 @@ func TestResolver_ObjectPlusEqualsAppendsArray(t *testing.T) {
 	arr := v.(*resolver.ArrayVal)
 	if len(arr.Elements) != 3 {
 		t.Errorf("expected 3 elements, got %d", len(arr.Elements))
+	}
+}
+
+func resolveWithDir(t *testing.T, src, baseDir string) *resolver.Result {
+	t.Helper()
+	ast, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	res, err := resolver.Resolve(ast, resolver.Options{BaseDir: baseDir})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	return res
+}
+
+func TestResolver_IncludeProbeConf(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "from-conf"`), 0o644)
+
+	res := resolveWithDir(t, `a { include "sub" }`, dir)
+	obj, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	v, ok := obj.(*resolver.ObjectVal).Get("x")
+	if !ok {
+		t.Fatal("x not found")
+	}
+	if sv := v.(*resolver.ScalarVal); sv.V != "from-conf" {
+		t.Errorf("expected from-conf, got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeProbeJSON(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "sub.json"), []byte(`{"y": "from-json"}`), 0o644)
+
+	res := resolveWithDir(t, `a { include "sub" }`, dir)
+	obj, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	v, ok := obj.(*resolver.ObjectVal).Get("y")
+	if !ok {
+		t.Fatal("y not found")
+	}
+	if sv := v.(*resolver.ScalarVal); sv.V != "from-json" {
+		t.Errorf("expected from-json, got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeProbeProperties(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "sub.properties"), []byte(`z = "from-props"`), 0o644)
+
+	res := resolveWithDir(t, `a { include "sub" }`, dir)
+	obj, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	v, ok := obj.(*resolver.ObjectVal).Get("z")
+	if !ok {
+		t.Fatal("z not found")
+	}
+	if sv := v.(*resolver.ScalarVal); sv.V != "from-props" {
+		t.Errorf("expected from-props, got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeProbeOrder(t *testing.T) {
+	// When both .properties and .conf exist, .properties is found first.
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "sub.properties"), []byte(`x = "props"`), 0o644)
+	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "conf"`), 0o644)
+
+	res := resolveWithDir(t, `a { include "sub" }`, dir)
+	obj, _ := res.Root.Get("a")
+	v, _ := obj.(*resolver.ObjectVal).Get("x")
+	if sv := v.(*resolver.ScalarVal); sv.V != "props" {
+		t.Errorf("expected props (first probe), got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeWithExtensionNoProbe(t *testing.T) {
+	// When an explicit extension is given, no probing should occur.
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "sub.conf"), []byte(`x = "direct"`), 0o644)
+
+	res := resolveWithDir(t, `a { include "sub.conf" }`, dir)
+	obj, _ := res.Root.Get("a")
+	v, _ := obj.(*resolver.ObjectVal).Get("x")
+	if sv := v.(*resolver.ScalarVal); sv.V != "direct" {
+		t.Errorf("expected direct, got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeProbeNotFound(t *testing.T) {
+	dir := t.TempDir()
+	ast, err := parser.Parse(`a { include "nonexistent" }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Fatal("expected error for missing include, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- When `include "path"` has no file extension, the resolver now probes `.properties`, `.json`, and `.conf` in order per the HOCON spec
- Explicit extensions (e.g. `include "file.conf"`) continue to work as before with no probing
- Improved error message lists the extensions that were tried

Closes #1

## Test plan
- [x] `.conf` extension probe
- [x] `.json` extension probe
- [x] `.properties` extension probe
- [x] Probe order (`.properties` takes priority when multiple exist)
- [x] No probing when extension is explicitly given
- [x] Error when no matching file is found
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)