### PR TITLE
fix: coerce .properties include values to strings

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -556,12 +556,27 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 		}
 	}
 
+	obj, err := r.parseAndResolve(data, resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// .properties files: all values must remain strings per HOCON spec.
+	if filepath.Ext(resolvedPath) == ".properties" {
+		coerceToStrings(obj)
+	}
+
+	return obj, nil
+}
+
+// parseAndResolve parses raw HOCON/JSON data and resolves it into an ObjectVal.
+func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, error) {
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
 		return nil, err
 	}
 	childResolver := &resolver{
-		opts:          Options{BaseDir: filepath.Dir(resolvedPath)},
+		opts:          Options{BaseDir: filepath.Dir(filePath)},
 		resolving:     make(map[string]bool),
 		resolvedCache: make(map[string]Val),
 		priorValues:   make(map[string]Val),
@@ -570,9 +585,42 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	if err != nil {
 		return nil, err
 	}
-	obj2, err := childResolver.resolveSubstitutions(obj, obj)
-	if err != nil {
-		return nil, err
+	return childResolver.resolveSubstitutions(obj, obj)
+}
+
+// coerceToStrings converts all scalar values in obj to strings, recursively.
+// Used for .properties files where all values are strings per spec.
+func coerceToStrings(obj *ObjectVal) {
+	for _, k := range obj.Keys() {
+		v, _ := obj.Get(k)
+		switch vv := v.(type) {
+		case *ScalarVal:
+			if vv.V == nil {
+				vv.V = "null"
+			} else if _, ok := vv.V.(string); !ok {
+				vv.V = fmt.Sprintf("%v", vv.V)
+			}
+		case *ObjectVal:
+			coerceToStrings(vv)
+		case *ArrayVal:
+			coerceArrayToStrings(vv)
+		}
 	}
-	return obj2, nil
+}
+
+func coerceArrayToStrings(arr *ArrayVal) {
+	for i, elem := range arr.Elements {
+		switch vv := elem.(type) {
+		case *ScalarVal:
+			if vv.V == nil {
+				arr.Elements[i] = &ScalarVal{V: "null"}
+			} else if _, ok := vv.V.(string); !ok {
+				arr.Elements[i] = &ScalarVal{V: fmt.Sprintf("%v", vv.V)}
+			}
+		case *ObjectVal:
+			coerceToStrings(vv)
+		case *ArrayVal:
+			coerceArrayToStrings(vv)
+		}
+	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -308,6 +308,57 @@ func TestResolver_IncludeWithExtensionNoProbe(t *testing.T) {
 	}
 }
 
+func TestResolver_IncludePropertiesValuesAreStrings(t *testing.T) {
+	dir := t.TempDir()
+	// .properties values should remain strings even if they look like bool/int/float/null.
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+a = true
+b = 42
+c = 3.14
+d = null
+`)
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+	o := obj.(*resolver.ObjectVal)
+
+	cases := []struct{ key, want string }{
+		{"a", "true"},
+		{"b", "42"},
+		{"c", "3.14"},
+		{"d", "null"},
+	}
+	for _, tc := range cases {
+		v, ok := o.Get(tc.key)
+		if !ok {
+			t.Errorf("key %q not found", tc.key)
+			continue
+		}
+		sv := v.(*resolver.ScalarVal)
+		s, ok := sv.V.(string)
+		if !ok {
+			t.Errorf("key %q: expected string type, got %T (%v)", tc.key, sv.V, sv.V)
+			continue
+		}
+		if s != tc.want {
+			t.Errorf("key %q: expected %q, got %q", tc.key, tc.want, s)
+		}
+	}
+}
+
+func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
+	// Even with explicit .properties extension, values should be strings.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `val = true`)
+
+	res := resolveWithDir(t, `x { include "sub.properties" }`, dir)
+	obj, _ := res.Root.Get("x")
+	v, _ := obj.(*resolver.ObjectVal).Get("val")
+	sv := v.(*resolver.ScalarVal)
+	if _, ok := sv.V.(string); !ok {
+		t.Errorf("expected string, got %T (%v)", sv.V, sv.V)
+	}
+}
+
 func TestResolver_IncludeProbeNotFound(t *testing.T) {
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "nonexistent" }`)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -359,6 +359,83 @@ func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
 	}
 }
 
+func TestResolver_IncludePropertiesNestedObject(t *testing.T) {
+	// Nested objects in .properties files should also have string values.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+inner {
+  a = 42
+  b = true
+}
+`)
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+	inner, _ := obj.(*resolver.ObjectVal).Get("inner")
+	o := inner.(*resolver.ObjectVal)
+
+	v1, _ := o.Get("a")
+	if sv := v1.(*resolver.ScalarVal); sv.V != "42" {
+		t.Errorf("nested a: expected string \"42\", got %T %v", sv.V, sv.V)
+	}
+	v2, _ := o.Get("b")
+	if sv := v2.(*resolver.ScalarVal); sv.V != "true" {
+		t.Errorf("nested b: expected string \"true\", got %T %v", sv.V, sv.V)
+	}
+}
+
+func TestResolver_IncludePropertiesArray(t *testing.T) {
+	// Arrays in .properties files should have string elements,
+	// including nested objects and arrays.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+arr = [1, true, 3.14, null]
+nested = [{a = 42}, [false]]
+`)
+
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+
+	// Simple array
+	v, _ := obj.(*resolver.ObjectVal).Get("arr")
+	arr := v.(*resolver.ArrayVal)
+	expected := []string{"1", "true", "3.14", "null"}
+	for i, want := range expected {
+		sv := arr.Elements[i].(*resolver.ScalarVal)
+		if s, ok := sv.V.(string); !ok || s != want {
+			t.Errorf("arr[%d]: expected string %q, got %T %v", i, want, sv.V, sv.V)
+		}
+	}
+
+	// Nested array with object and sub-array
+	v2, _ := obj.(*resolver.ObjectVal).Get("nested")
+	nested := v2.(*resolver.ArrayVal)
+	// First element: object {a = 42} → a should be string "42"
+	innerObj := nested.Elements[0].(*resolver.ObjectVal)
+	va, _ := innerObj.Get("a")
+	if sv := va.(*resolver.ScalarVal); sv.V != "42" {
+		t.Errorf("nested[0].a: expected string \"42\", got %T %v", sv.V, sv.V)
+	}
+	// Second element: array [false] → should be string "false"
+	innerArr := nested.Elements[1].(*resolver.ArrayVal)
+	sv := innerArr.Elements[0].(*resolver.ScalarVal)
+	if s, ok := sv.V.(string); !ok || s != "false" {
+		t.Errorf("nested[1][0]: expected string \"false\", got %T %v", sv.V, sv.V)
+	}
+}
+
+func TestResolver_IncludeExplicitExtensionNotFound(t *testing.T) {
+	// Explicit extension that doesn't exist should error.
+	dir := t.TempDir()
+	ast, err := parser.Parse(`a { include "missing.conf" }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Fatal("expected error for missing include file")
+	}
+}
+
 func TestResolver_IncludeProbeNotFound(t *testing.T) {
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "nonexistent" }`)


### PR DESCRIPTION
## Summary
- When including `.properties` files (via explicit extension or extensionless probe), all scalar values are now coerced to strings per the HOCON spec
- Affects bool (`true`→`"true"`), int (`42`→`"42"`), float (`3.14`→`"3.14"`), and null (`null`→`"null"`)
- Works for both probed includes (`include "sub"`) and explicit includes (`include "sub.properties"`)

Closes #5

## Test plan
- [x] `.properties` values (bool, int, float, null) are all strings
- [x] Explicit `.properties` extension also coerces to strings
- [x] All existing tests pass
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)