### PR TITLE
fix: extensionless include merges all matching files

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -523,46 +523,52 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 		path = filepath.Join(r.opts.BaseDir, path)
 	}
 
-	paths := []string{path}
-	if filepath.Ext(path) == "" {
-		// No extension: probe known extensions per HOCON spec.
-		paths = nil
-		for _, ext := range includeExtensions {
-			paths = append(paths, path+ext)
-		}
+	// Single file with explicit extension.
+	if filepath.Ext(path) != "" {
+		return r.loadIncludeFile(path)
 	}
 
-	var data []byte
-	var resolvedPath string
-	var lastErr error
-	for _, p := range paths {
-		d, err := os.ReadFile(p)
+	// No extension: probe all known extensions and merge all found files.
+	// Per HOCON spec, .properties first, then .json, then .conf (HOCON last).
+	merged := newObjectVal()
+	found := false
+	for _, ext := range includeExtensions {
+		p := path + ext
+		obj, err := r.loadIncludeFile(p)
 		if err != nil {
-			lastErr = err
-			continue
+			continue // file not found — skip
 		}
-		data = d
-		resolvedPath = p
-		break
+		found = true
+		// Later files override earlier ones: pass new obj as dst (winner).
+		merged = deepMerge(obj, merged)
 	}
-	if data == nil {
-		msg := "cannot read include file: " + lastErr.Error()
-		if filepath.Ext(inc.Path) == "" {
-			msg = fmt.Sprintf("cannot read include file: no file found for %q (tried %v)", inc.Path, includeExtensions)
-		}
+	if !found {
 		return nil, &ResolveError{
-			Message:  msg,
+			Message:  fmt.Sprintf("cannot read include file: no file found for %q (tried %v)", inc.Path, includeExtensions),
+			FilePath: path,
+		}
+	}
+	return merged, nil
+}
+
+// loadIncludeFile reads, parses, and resolves a single include file.
+// Returns an error if the file does not exist or cannot be parsed.
+func (r *resolver) loadIncludeFile(path string) (*ObjectVal, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, &ResolveError{
+			Message:  "cannot read include file: " + err.Error(),
 			FilePath: path,
 		}
 	}
 
-	obj, err := r.parseAndResolve(data, resolvedPath)
+	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
 		return nil, err
 	}
 
 	// .properties files: all values must remain strings per HOCON spec.
-	if filepath.Ext(resolvedPath) == ".properties" {
+	if filepath.Ext(path) == ".properties" {
 		coerceToStrings(obj)
 	}
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -556,12 +556,27 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 		}
 	}
 
+	obj, err := r.parseAndResolve(data, resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// .properties files: all values must remain strings per HOCON spec.
+	if filepath.Ext(resolvedPath) == ".properties" {
+		coerceToStrings(obj)
+	}
+
+	return obj, nil
+}
+
+// parseAndResolve parses raw HOCON/JSON data and resolves it into an ObjectVal.
+func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, error) {
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
 		return nil, err
 	}
 	childResolver := &resolver{
-		opts:          Options{BaseDir: filepath.Dir(resolvedPath)},
+		opts:          Options{BaseDir: filepath.Dir(filePath)},
 		resolving:     make(map[string]bool),
 		resolvedCache: make(map[string]Val),
 		priorValues:   make(map[string]Val),
@@ -570,9 +585,42 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	if err != nil {
 		return nil, err
 	}
-	obj2, err := childResolver.resolveSubstitutions(obj, obj)
-	if err != nil {
-		return nil, err
+	return childResolver.resolveSubstitutions(obj, obj)
+}
+
+// coerceToStrings converts all scalar values in obj to strings, recursively.
+// Used for .properties files where all values are strings per spec.
+func coerceToStrings(obj *ObjectVal) {
+	for _, k := range obj.Keys() {
+		v, _ := obj.Get(k)
+		switch vv := v.(type) {
+		case *ScalarVal:
+			if vv.V == nil {
+				vv.V = "null"
+			} else if _, ok := vv.V.(string); !ok {
+				vv.V = fmt.Sprintf("%v", vv.V)
+			}
+		case *ObjectVal:
+			coerceToStrings(vv)
+		case *ArrayVal:
+			coerceArrayToStrings(vv)
+		}
 	}
-	return obj2, nil
+}
+
+func coerceArrayToStrings(arr *ArrayVal) {
+	for i, elem := range arr.Elements {
+		switch vv := elem.(type) {
+		case *ScalarVal:
+			if vv.V == nil {
+				arr.Elements[i] = &ScalarVal{V: "null"}
+			} else if _, ok := vv.V.(string); !ok {
+				arr.Elements[i] = &ScalarVal{V: fmt.Sprintf("%v", vv.V)}
+			}
+		case *ObjectVal:
+			coerceToStrings(vv)
+		case *ArrayVal:
+			coerceArrayToStrings(vv)
+		}
+	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -308,6 +308,57 @@ func TestResolver_IncludeWithExtensionNoProbe(t *testing.T) {
 	}
 }
 
+func TestResolver_IncludePropertiesValuesAreStrings(t *testing.T) {
+	dir := t.TempDir()
+	// .properties values should remain strings even if they look like bool/int/float/null.
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+a = true
+b = 42
+c = 3.14
+d = null
+`)
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+	o := obj.(*resolver.ObjectVal)
+
+	cases := []struct{ key, want string }{
+		{"a", "true"},
+		{"b", "42"},
+		{"c", "3.14"},
+		{"d", "null"},
+	}
+	for _, tc := range cases {
+		v, ok := o.Get(tc.key)
+		if !ok {
+			t.Errorf("key %q not found", tc.key)
+			continue
+		}
+		sv := v.(*resolver.ScalarVal)
+		s, ok := sv.V.(string)
+		if !ok {
+			t.Errorf("key %q: expected string type, got %T (%v)", tc.key, sv.V, sv.V)
+			continue
+		}
+		if s != tc.want {
+			t.Errorf("key %q: expected %q, got %q", tc.key, tc.want, s)
+		}
+	}
+}
+
+func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
+	// Even with explicit .properties extension, values should be strings.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `val = true`)
+
+	res := resolveWithDir(t, `x { include "sub.properties" }`, dir)
+	obj, _ := res.Root.Get("x")
+	v, _ := obj.(*resolver.ObjectVal).Get("val")
+	sv := v.(*resolver.ScalarVal)
+	if _, ok := sv.V.(string); !ok {
+		t.Errorf("expected string, got %T (%v)", sv.V, sv.V)
+	}
+}
+
 func TestResolver_IncludeProbeNotFound(t *testing.T) {
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "nonexistent" }`)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -359,6 +359,83 @@ func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
 	}
 }
 
+func TestResolver_IncludePropertiesNestedObject(t *testing.T) {
+	// Nested objects in .properties files should also have string values.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+inner {
+  a = 42
+  b = true
+}
+`)
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+	inner, _ := obj.(*resolver.ObjectVal).Get("inner")
+	o := inner.(*resolver.ObjectVal)
+
+	v1, _ := o.Get("a")
+	if sv := v1.(*resolver.ScalarVal); sv.V != "42" {
+		t.Errorf("nested a: expected string \"42\", got %T %v", sv.V, sv.V)
+	}
+	v2, _ := o.Get("b")
+	if sv := v2.(*resolver.ScalarVal); sv.V != "true" {
+		t.Errorf("nested b: expected string \"true\", got %T %v", sv.V, sv.V)
+	}
+}
+
+func TestResolver_IncludePropertiesArray(t *testing.T) {
+	// Arrays in .properties files should have string elements,
+	// including nested objects and arrays.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `
+arr = [1, true, 3.14, null]
+nested = [{a = 42}, [false]]
+`)
+
+	res := resolveWithDir(t, `x { include "sub" }`, dir)
+	obj, _ := res.Root.Get("x")
+
+	// Simple array
+	v, _ := obj.(*resolver.ObjectVal).Get("arr")
+	arr := v.(*resolver.ArrayVal)
+	expected := []string{"1", "true", "3.14", "null"}
+	for i, want := range expected {
+		sv := arr.Elements[i].(*resolver.ScalarVal)
+		if s, ok := sv.V.(string); !ok || s != want {
+			t.Errorf("arr[%d]: expected string %q, got %T %v", i, want, sv.V, sv.V)
+		}
+	}
+
+	// Nested array with object and sub-array
+	v2, _ := obj.(*resolver.ObjectVal).Get("nested")
+	nested := v2.(*resolver.ArrayVal)
+	// First element: object {a = 42} → a should be string "42"
+	innerObj := nested.Elements[0].(*resolver.ObjectVal)
+	va, _ := innerObj.Get("a")
+	if sv := va.(*resolver.ScalarVal); sv.V != "42" {
+		t.Errorf("nested[0].a: expected string \"42\", got %T %v", sv.V, sv.V)
+	}
+	// Second element: array [false] → should be string "false"
+	innerArr := nested.Elements[1].(*resolver.ArrayVal)
+	sv := innerArr.Elements[0].(*resolver.ScalarVal)
+	if s, ok := sv.V.(string); !ok || s != "false" {
+		t.Errorf("nested[1][0]: expected string \"false\", got %T %v", sv.V, sv.V)
+	}
+}
+
+func TestResolver_IncludeExplicitExtensionNotFound(t *testing.T) {
+	// Explicit extension that doesn't exist should error.
+	dir := t.TempDir()
+	ast, err := parser.Parse(`a { include "missing.conf" }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Fatal("expected error for missing include file")
+	}
+}
+
 func TestResolver_IncludeProbeNotFound(t *testing.T) {
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "nonexistent" }`)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -281,17 +281,57 @@ func TestResolver_IncludeProbeProperties(t *testing.T) {
 	}
 }
 
-func TestResolver_IncludeProbeOrder(t *testing.T) {
-	// When both .properties and .conf exist, .properties is found first.
+func TestResolver_IncludeMergeAll(t *testing.T) {
+	// When multiple extensions exist, all are loaded and merged.
+	// Later formats (.conf) override earlier ones (.properties).
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "sub.properties"), `x = "props"`)
-	writeFile(t, filepath.Join(dir, "sub.conf"), `x = "conf"`)
+	writeFile(t, filepath.Join(dir, "sub.conf"), `x = "conf"
+y = "only-conf"`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, _ := res.Root.Get("a")
-	v, _ := obj.(*resolver.ObjectVal).Get("x")
-	if sv := v.(*resolver.ScalarVal); sv.V != "props" {
-		t.Errorf("expected props (first probe), got %v", sv.V)
+	o := obj.(*resolver.ObjectVal)
+
+	// x exists in both: .conf wins (parsed last per spec).
+	v, _ := o.Get("x")
+	if sv := v.(*resolver.ScalarVal); sv.V != "conf" {
+		t.Errorf("expected conf (later override), got %v", sv.V)
+	}
+	// y exists only in .conf: should be present.
+	v2, ok := o.Get("y")
+	if !ok {
+		t.Fatal("y not found — merge missed .conf-only key")
+	}
+	if sv := v2.(*resolver.ScalarVal); sv.V != "only-conf" {
+		t.Errorf("expected only-conf, got %v", sv.V)
+	}
+}
+
+func TestResolver_IncludeMergeAllWithProperties(t *testing.T) {
+	// Keys unique to .properties are preserved after merge.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub.properties"), `p = "from-props"`)
+	writeFile(t, filepath.Join(dir, "sub.conf"), `c = "from-conf"`)
+
+	res := resolveWithDir(t, `a { include "sub" }`, dir)
+	obj, _ := res.Root.Get("a")
+	o := obj.(*resolver.ObjectVal)
+
+	v1, ok1 := o.Get("p")
+	if !ok1 {
+		t.Fatal("p not found")
+	}
+	if sv := v1.(*resolver.ScalarVal); sv.V != "from-props" {
+		t.Errorf("expected from-props, got %v", sv.V)
+	}
+
+	v2, ok2 := o.Get("c")
+	if !ok2 {
+		t.Fatal("c not found")
+	}
+	if sv := v2.(*resolver.ScalarVal); sv.V != "from-conf" {
+		t.Errorf("expected from-conf, got %v", sv.V)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extensionless `include "path"` now loads **all** matching files (`.properties`, `.json`, `.conf`) and deep-merges them, instead of stopping at the first match
- Later formats override earlier ones for conflicting keys (`.conf` wins over `.properties`)
- Keys unique to each file are all preserved in the merged result
- Includes the fix from PR #6 (`.properties` values coerced to strings)

Closes #4

## Test plan
- [x] Conflicting keys: `.conf` overrides `.properties`
- [x] Unique keys from each file are preserved after merge
- [x] Single-file probes still work (`.conf` only, `.json` only, `.properties` only)
- [x] Explicit extension skips probing
- [x] Not-found error when no files match
- [x] All existing tests pass
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)