### PR TITLE
feat: add benchmarks and best practices docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,22 @@ config/
 - Use schema validation (Zod for TypeScript, struct unmarshaling for Go, Serde for Rust) to catch errors early
 
 ```go
-var cfg struct {
+conf, err := hocon.ParseString(`
+server {
+  host = "localhost"
+  port = 8080
+}
+debug = true
+`)
+if err != nil {
+    log.Fatal(err)
+}
+
+var app struct {
     Server struct { Host string; Port int } `hocon:"server"`
     Debug  bool                             `hocon:"debug"`
 }
-if err := config.Unmarshal(&cfg); err != nil {
+if err := conf.Unmarshal(&app); err != nil {
     log.Fatal(err) // fails fast on startup
 }
 ```

--- a/README.md
+++ b/README.md
@@ -206,6 +206,44 @@ Also verified via [hocon2](https://github.com/o3co/hocon2) conformance tests (77
 
 All implementations are full Lightbend HOCON spec compliant.
 
+## Best Practices
+
+### Config Structure
+
+- **Split by domain**: Separate configuration into logical units (`database.conf`, `server.conf`, `logging.conf`)
+- **Use `include` for composition**: Compose a full config from domain-specific files
+- **Avoid logic in config**: HOCON is for declarative data, not conditionals or computation
+
+### Environment Variables
+
+- **Minimize `${ENV}` usage**: Prefer `${?ENV}` (optional) with sensible defaults defined in the config itself
+- **Never require env vars for local development**: Defaults should work out of the box
+- **Document required env vars**: List them in your project's README or a `.env.example`
+
+### Dev / Prod Separation
+
+```text
+config/
+├── application.conf    # shared defaults
+├── dev.conf            # include "application.conf" + dev overrides
+└── prod.conf           # include "application.conf" + prod overrides
+```
+
+### Validation
+
+- Always validate config at application startup, not at point-of-use
+- Use schema validation (Zod for TypeScript, struct unmarshaling for Go, Serde for Rust) to catch errors early
+
+```go
+var cfg struct {
+    Server struct { Host string; Port int } `hocon:"server"`
+    Debug  bool                             `hocon:"debug"`
+}
+if err := config.Unmarshal(&cfg); err != nil {
+    log.Fatal(err) // fails fast on startup
+}
+```
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ config/
 ### Validation
 
 - Always validate config at application startup, not at point-of-use
-- Use schema validation (Zod for TypeScript, struct unmarshaling for Go, Serde for Rust) to catch errors early
+- Use schema validation (Zod for TypeScript, struct unmarshalling for Go, Serde for Rust) to catch errors early
 
 ```go
 conf, err := hocon.ParseString(`

--- a/bench_test.go
+++ b/bench_test.go
@@ -25,6 +25,9 @@ var benchSink string
 // generateConfig builds a HOCON string with totalKeys spread across maxDepth
 // groups, returning the HOCON text and a sample lookup path.
 func generateConfig(totalKeys, maxDepth int) (hocon string, samplePath string) {
+	if maxDepth > totalKeys {
+		maxDepth = totalKeys
+	}
 	var b strings.Builder
 	keysPerGroup := totalKeys / maxDepth
 	if keysPerGroup < 1 {
@@ -49,6 +52,9 @@ func generateConfig(totalKeys, maxDepth int) (hocon string, samplePath string) {
 // generateWithSubstitutions builds a HOCON string containing base keys and
 // count substitution references, returning the text and a sample lookup path.
 func generateWithSubstitutions(count int) (hocon string, samplePath string) {
+	if count <= 0 {
+		return "", ""
+	}
 	total := count * 2
 	var b strings.Builder
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/o3co/go.hocon"
 )
 
+var benchSink string
+
 // ---------------------------------------------------------------------------
 // Fixture generators (mirrors ts.hocon/tests/bench/fixtures.ts)
 // ---------------------------------------------------------------------------
@@ -165,7 +167,10 @@ func benchParse(b *testing.B, input, path string) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cfg, _ = hocon.ParseString(input)
-		_ = cfg.GetString(path)
+		cfg, err = hocon.ParseString(input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSink = cfg.GetString(path)
 	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture generators (mirrors ts.hocon/tests/bench/fixtures.ts)
+// ---------------------------------------------------------------------------
+
+// generateConfig builds a HOCON string with totalKeys spread across maxDepth
+// groups, returning the HOCON text and a sample lookup path.
+func generateConfig(totalKeys, maxDepth int) (hocon string, samplePath string) {
+	var b strings.Builder
+	keysPerGroup := totalKeys / maxDepth
+	if keysPerGroup < 1 {
+		keysPerGroup = 1
+	}
+
+	for d := 0; d < maxDepth; d++ {
+		count := keysPerGroup
+		if d == maxDepth-1 {
+			count = totalKeys - keysPerGroup*(maxDepth-1)
+		}
+		fmt.Fprintf(&b, "group%d {\n", d)
+		for i := 0; i < count; i++ {
+			fmt.Fprintf(&b, "  key%d = \"value%d_%d\"\n", i, d, i)
+		}
+		b.WriteString("}\n")
+	}
+
+	return b.String(), "group0.key0"
+}
+
+// generateWithSubstitutions builds a HOCON string containing base keys and
+// count substitution references, returning the text and a sample lookup path.
+func generateWithSubstitutions(count int) (hocon string, samplePath string) {
+	total := count * 2
+	var b strings.Builder
+
+	for i := 0; i < total; i++ {
+		fmt.Fprintf(&b, "base%d = \"value%d\"\n", i, i)
+	}
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&b, "sub%d = ${base%d}\n", i, i%total)
+	}
+
+	return b.String(), "sub0"
+}
+
+// generateDeepNested builds a deeply nested HOCON object with 5 leaf keys at
+// the innermost level, returning the text and a sample lookup path.
+func generateDeepNested(depth int) (hocon string, samplePath string) {
+	var b strings.Builder
+	indent := ""
+
+	// Open nesting levels
+	for d := 0; d < depth; d++ {
+		fmt.Fprintf(&b, "%slevel%d {\n", indent, d)
+		indent += "  "
+	}
+
+	// Leaf keys
+	for i := 0; i < 5; i++ {
+		fmt.Fprintf(&b, "%skey%d = \"deep_value%d\"\n", indent, i, i)
+	}
+
+	// Close nesting levels
+	for d := depth - 1; d >= 0; d-- {
+		indent = strings.Repeat("  ", d)
+		fmt.Fprintf(&b, "%s}\n", indent)
+	}
+
+	// Build path: level0.level1. ... .levelN-1.key0
+	parts := make([]string, depth+1)
+	for i := 0; i < depth; i++ {
+		parts[i] = fmt.Sprintf("level%d", i)
+	}
+	parts[depth] = "key0"
+
+	return b.String(), strings.Join(parts, ".")
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks — config size
+// ---------------------------------------------------------------------------
+
+func BenchmarkParseSmall(b *testing.B) {
+	input, path := generateConfig(10, 2)
+	benchParse(b, input, path)
+}
+
+func BenchmarkParseMedium(b *testing.B) {
+	input, path := generateConfig(100, 4)
+	benchParse(b, input, path)
+}
+
+func BenchmarkParseLarge(b *testing.B) {
+	input, path := generateConfig(1000, 6)
+	benchParse(b, input, path)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks — substitutions
+// ---------------------------------------------------------------------------
+
+func BenchmarkSubstitutions10(b *testing.B) {
+	input, path := generateWithSubstitutions(10)
+	benchParse(b, input, path)
+}
+
+func BenchmarkSubstitutions50(b *testing.B) {
+	input, path := generateWithSubstitutions(50)
+	benchParse(b, input, path)
+}
+
+func BenchmarkSubstitutions100(b *testing.B) {
+	input, path := generateWithSubstitutions(100)
+	benchParse(b, input, path)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks — deep nesting
+// ---------------------------------------------------------------------------
+
+func BenchmarkDeepNest5(b *testing.B) {
+	input, path := generateDeepNested(5)
+	benchParse(b, input, path)
+}
+
+func BenchmarkDeepNest10(b *testing.B) {
+	input, path := generateDeepNested(10)
+	benchParse(b, input, path)
+}
+
+func BenchmarkDeepNest20(b *testing.B) {
+	input, path := generateDeepNested(20)
+	benchParse(b, input, path)
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+func benchParse(b *testing.B, input, path string) {
+	b.Helper()
+	// Verify once before the loop so failures are visible.
+	cfg, err := hocon.ParseString(input)
+	if err != nil {
+		b.Fatalf("ParseString setup error: %v", err)
+	}
+	_ = cfg.GetString(path)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg, _ = hocon.ParseString(input)
+		_ = cfg.GetString(path)
+	}
+}


### PR DESCRIPTION
## Summary
- Add Go benchmarks matching ts.hocon patterns (small/medium/large config, substitutions 10/50/100, deep nesting 5/10/20)
- Add Best Practices section to README

## Test plan
- [ ] All existing tests pass (`go test ./...`)
- [ ] Benchmarks run (`go test -bench=. -benchmem ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)