### PR TITLE
docs: sync README.ja.md with English README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,10 +10,55 @@
 [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 仕様に完全準拠した Go ライブラリ。
 
 > **[Claude](https://claude.ai/)（Anthropic）による実装** — 設計・実装のすべてを Claude Code が担当。
+> [GitHub Copilot](https://github.com/features/copilot) および [OpenAI Codex](https://openai.com/index/openai-codex/) によるレビュー。
 
 [English](README.md)
 
 ---
+
+## クイックスタート
+
+### 1. インストール
+
+```bash
+go get github.com/o3co/go.hocon
+```
+
+Go 1.21 以上が必要。
+
+### 2. 使い方
+
+```go
+import "github.com/o3co/go.hocon"
+
+cfg, err := hocon.ParseString(`
+  server {
+    host = "localhost"
+    port = 8080
+  }
+`)
+if err != nil {
+    log.Fatal(err)
+}
+
+host := cfg.GetString("server.host")  // "localhost"
+port := cfg.GetInt("server.port")     // 8080
+```
+
+## なぜ HOCON？
+
+| | `.env` | JSON | YAML | HOCON |
+|---|---|---|---|---|
+| Comments | No | No | Yes | Yes |
+| Nesting | No | Yes | Yes | Yes |
+| References / Substitution | No | No | No | Yes (`${var}`) |
+| File inclusion | No | No | No | Yes (`include`) |
+| Object merging | No | No | Anchors (fragile) | Yes (deep merge) |
+| Optional values | No | No | No | Yes (`${?var}`) |
+| Trailing commas | N/A | No | N/A | Yes |
+| Unquoted strings | Yes | No | Yes | Yes |
+
+HOCON は YAML の可読性と JSON の構造性を兼ね備え、どちらにもない機能 — 変数参照、インクルード、ディープマージ — を提供します。設定がフラットなキーバリューペア以上のものであれば、HOCON を検討する価値があります。
 
 ## 特徴
 
@@ -24,45 +69,10 @@
 - `include "file.conf"` および `include file("file.conf")` ディレクティブ
 - トリプルクォート文字列（`"""..."""`）
 - Duration パース（`10ms`、`2s`、`1h`、`1d`）
-- バイトサイズパース（`1KB`、`1KiB`、`1MB`、…）
+- バイトサイズパース（`1KB`、`1KiB`、`1MB`、...）
 - 安全な省略値アクセスのためのジェネリック `Option[T]`
 - `hocon` 構造体タグによる Unmarshal
 - 外部依存ゼロ — 標準ライブラリのみ
-
-## インストール
-
-```bash
-go get github.com/o3co/go.hocon
-```
-
-Go 1.21 以上が必要。
-
-## クイックスタート
-
-```go
-import "github.com/o3co/go.hocon"
-
-// 文字列からパース
-cfg, err := hocon.ParseString(`
-  server {
-    host = "localhost"
-    port = 8080
-    timeout = "30s"
-  }
-`)
-
-// ファイルからパース
-cfg, err = hocon.ParseFile("application.conf")
-
-// スカラーゲッター（missing/型違い時はパニック）
-host    := cfg.GetString("server.host")        // "localhost"
-port    := cfg.GetInt("server.port")           // 8080
-timeout := cfg.GetDuration("server.timeout")   // 30 * time.Second
-
-// Option 系（パニックしない安全版）
-host := cfg.GetStringOption("server.host").OrElse("localhost")
-port := cfg.GetInt64Option("server.port").OrElse(8080)
-```
 
 ## API
 
@@ -192,12 +202,71 @@ max-size  = "512MiB"
 
 ## 仕様準拠
 
-[Lightbend 公式テストスイート](https://github.com/lightbend/config/tree/main/config/src/test/resources) で検証済み：**13/13 グループ PASS**（equiv01–equiv05 + test01–test13）。
+[Lightbend 公式テストスイート](https://github.com/lightbend/config/tree/main/config/src/test/resources) で検証済み：**13/13 グループ PASS**（equiv01-equiv05 + test01-test13）。
 
 [hocon2](https://github.com/o3co/hocon2) の準拠テスト（JSON, YAML, TOML, Properties 出力で 77/77 PASS）でも検証済み。
 
+## 関連プロジェクト
+
+| プロジェクト | 言語 | 説明 |
+|---------|----------|-------------|
+| [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | Rust 向け HOCON パーサー |
+| [ts.hocon](https://github.com/o3co/ts.hocon) | TypeScript | TypeScript/Node.js 向け HOCON パーサー |
+| [hocon2](https://github.com/o3co/hocon2) | Go | HOCON → JSON/YAML/TOML/Properties 変換 CLI ツール |
+
+すべての実装が Lightbend HOCON 仕様に完全準拠しています。
+
+## ベストプラクティス
+
+### 設定構成
+
+- **ドメインごとに分割**: 設定を論理的な単位に分けましょう（`database.conf`、`server.conf`、`logging.conf`）
+- **`include` で合成**: ドメイン別ファイルからフル設定を組み立てましょう
+- **設定にロジックを入れない**: HOCON は宣言的なデータのためのもので、条件分岐や計算には向きません
+
+### 環境変数
+
+- **`${ENV}` の使用を最小限に**: 設定ファイル自体にデフォルト値を定義し、`${?ENV}`（オプショナル）を使いましょう
+- **ローカル開発で環境変数を必須にしない**: デフォルトだけで動くようにしましょう
+- **必須の環境変数を文書化**: プロジェクトの README や `.env.example` にリストしましょう
+
+### 開発 / 本番の分離
+
+```text
+config/
+├── application.conf    # 共有デフォルト
+├── dev.conf            # include "application.conf" + 開発用オーバーライド
+└── prod.conf           # include "application.conf" + 本番用オーバーライド
+```
+
+### バリデーション
+
+- 設定のバリデーションは常にアプリケーション起動時に行い、使用時ではなく早期に検出しましょう
+- スキーマバリデーション（TypeScript は Zod、Go は struct Unmarshal、Rust は Serde）を使って早期にエラーをキャッチしましょう
+
+```go
+conf, err := hocon.ParseString(`
+server {
+  host = "localhost"
+  port = 8080
+}
+debug = true
+`)
+if err != nil {
+    log.Fatal(err)
+}
+
+var app struct {
+    Server struct { Host string; Port int } `hocon:"server"`
+    Debug  bool                             `hocon:"debug"`
+}
+if err := conf.Unmarshal(&app); err != nil {
+    log.Fatal(err) // 起動時に即座に失敗
+}
+```
+
 ## ライセンス
 
-Apache License 2.0 — [LICENSE](LICENSE) 参照。
+Apache License 2.0 — [LICENSE](LICENSE) を参照。
 
-Copyright 2026 o3co Inc.
+Copyright 2026 1o1 Co. Ltd.


### PR DESCRIPTION
## Summary
- Sync Japanese README with current English structure
- Add review attribution line (Copilot + Codex)
- Restructure: Quick Start at top (merged with Install), Why HOCON? comparison table, then Features
- Add Best Practices section
- Fix copyright to 1o1 Co. Ltd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)