### PR TITLE
fix: P0 Phase 2-4 — empty env vars, quoted paths, trailing garbage tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,13 +45,27 @@ func splitPath(path string) []string {
 	i := 0
 	for i < len(path) {
 		if path[i] == '"' {
-			end := strings.IndexByte(path[i+1:], '"')
-			if end == -1 {
-				segments = append(segments, path[i+1:])
+			i++ // skip opening quote
+			var seg []byte
+			closed := false
+			for i < len(path) {
+				if path[i] == '\\' && i+1 < len(path) {
+					seg = append(seg, path[i+1])
+					i += 2
+					continue
+				}
+				if path[i] == '"' {
+					closed = true
+					i++
+					break
+				}
+				seg = append(seg, path[i])
+				i++
+			}
+			segments = append(segments, string(seg))
+			if !closed {
 				break
 			}
-			segments = append(segments, path[i+1:i+1+end])
-			i = i + 1 + end + 1
 			if i < len(path) && path[i] == '.' {
 				i++
 			}

--- a/config.go
+++ b/config.go
@@ -41,7 +41,31 @@ func (c *Config) lookup(path string) (resolver.Val, bool) {
 }
 
 func splitPath(path string) []string {
-	return strings.Split(path, ".")
+	var segments []string
+	i := 0
+	for i < len(path) {
+		if path[i] == '"' {
+			end := strings.IndexByte(path[i+1:], '"')
+			if end == -1 {
+				segments = append(segments, path[i+1:])
+				break
+			}
+			segments = append(segments, path[i+1:i+1+end])
+			i = i + 1 + end + 1
+			if i < len(path) && path[i] == '.' {
+				i++
+			}
+		} else {
+			dot := strings.IndexByte(path[i:], '.')
+			if dot == -1 {
+				segments = append(segments, path[i:])
+				break
+			}
+			segments = append(segments, path[i:i+dot])
+			i = i + dot + 1
+		}
+	}
+	return segments
 }
 
 func lookupSegments(obj *resolver.ObjectVal, segments []string) (resolver.Val, bool) {

--- a/config_test.go
+++ b/config_test.go
@@ -257,6 +257,51 @@ clients {
 	}
 }
 
+func TestEmptyEnvVar(t *testing.T) {
+	t.Setenv("HOCON_EMPTY", "")
+	cfg, err := hocon.ParseString(`val = ${HOCON_EMPTY}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := cfg.GetString("val")
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestUnsetEnvVarOptional(t *testing.T) {
+	cfg, err := hocon.ParseString(`val = ${?HOCON_DEFINITELY_NOT_SET_XYZ}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Has("val") {
+		t.Error("expected val to not exist for unset optional env var")
+	}
+}
+
+func TestQuotedPathLookup(t *testing.T) {
+	cfg, err := hocon.ParseString(`"a.b" = 1`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Has(`"a.b"`) {
+		t.Error("expected Has to return true for quoted key")
+	}
+	if got := cfg.GetInt64(`"a.b"`); got != 1 {
+		t.Errorf("got %d, want 1", got)
+	}
+}
+
+func TestNestedQuotedPathLookup(t *testing.T) {
+	cfg, err := hocon.ParseString(`server { "web.api" { port = 8080 } }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.GetInt64(`server."web.api".port`); got != 8080 {
+		t.Errorf("got %d, want 8080", got)
+	}
+}
+
 func TestConfig_WithFallback(t *testing.T) {
 	base := mustParseCfg(t, "a=1\nb=2")
 	over := mustParseCfg(t, "b=99\nc=3")

--- a/config_test.go
+++ b/config_test.go
@@ -272,8 +272,8 @@ func TestEmptyEnvVar(t *testing.T) {
 
 func TestUnsetEnvVarOptional(t *testing.T) {
 	const envKey = "HOCON_TEST_UNSET_VAR"
-	os.Unsetenv(envKey)
-	t.Cleanup(func() { os.Unsetenv(envKey) })
+	_ = os.Unsetenv(envKey)
+	t.Cleanup(func() { _ = os.Unsetenv(envKey) })
 	cfg, err := hocon.ParseString(fmt.Sprintf(`val = ${?%s}`, envKey))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package hocon_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -270,12 +271,30 @@ func TestEmptyEnvVar(t *testing.T) {
 }
 
 func TestUnsetEnvVarOptional(t *testing.T) {
-	cfg, err := hocon.ParseString(`val = ${?HOCON_DEFINITELY_NOT_SET_XYZ}`)
+	const envKey = "HOCON_TEST_UNSET_VAR"
+	os.Unsetenv(envKey)
+	t.Cleanup(func() { os.Unsetenv(envKey) })
+	cfg, err := hocon.ParseString(fmt.Sprintf(`val = ${?%s}`, envKey))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if cfg.Has("val") {
 		t.Error("expected val to not exist for unset optional env var")
+	}
+}
+
+func TestEmptyEnvVarOptional(t *testing.T) {
+	t.Setenv("HOCON_EMPTY_OPTIONAL", "")
+	cfg, err := hocon.ParseString(`val = ${?HOCON_EMPTY_OPTIONAL}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Has("val") {
+		t.Fatal("expected val to exist for empty-but-set optional env var")
+	}
+	got := cfg.GetString("val")
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
 	}
 }
 
@@ -299,6 +318,21 @@ func TestNestedQuotedPathLookup(t *testing.T) {
 	}
 	if got := cfg.GetInt64(`server."web.api".port`); got != 8080 {
 		t.Errorf("got %d, want 8080", got)
+	}
+}
+
+func TestEscapedQuoteInPath(t *testing.T) {
+	// The lexer unescapes \" → " when parsing quoted keys.
+	// splitPath must do the same when scanning quoted segments.
+	cfg, err := hocon.ParseString(`"a\"b" = 42`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Has(`"a\"b"`) {
+		t.Error(`expected Has to return true for key with escaped quote`)
+	}
+	if got := cfg.GetInt64(`"a\"b"`); got != 42 {
+		t.Errorf("got %d, want 42", got)
 	}
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -242,3 +242,18 @@ func TestParser_UnsupportedIncludeURL(t *testing.T) {
 		t.Fatal("expected error for unsupported include form")
 	}
 }
+
+func TestBracedRootTrailingGarbage(t *testing.T) {
+	tests := []string{
+		`{ a = 1 } }`,
+		`{ a = 1 } garbage`,
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, err := parser.Parse(input)
+			if err == nil {
+				t.Errorf("expected error for trailing content: %s", input)
+			}
+		})
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -383,7 +383,7 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 		return r.resolveVal(val, root, pathStr)
 	}
 	// env var fallback
-	if ev := os.Getenv(pathStr); ev != "" {
+	if ev, ok := os.LookupEnv(pathStr); ok {
 		return &ScalarVal{V: ev}, nil
 	}
 	if n.Optional {


### PR DESCRIPTION
## Summary
- **Empty env var handling** — `os.LookupEnv` replaces `os.Getenv` to distinguish empty string from unset (Closes #22)
- **Quoted path segments** in Config lookups — keys with dots accessible via `"a.b"` syntax (Closes #13)
- **Trailing garbage tests** — explicit tests for stray `}` and garbage after braced root (Phase 1 Copilot followup)

## Test Plan
- [x] All tests passing (`go test ./...`)
- [x] TestEmptyEnvVar, TestUnsetEnvVarOptional
- [x] TestQuotedPathLookup, TestNestedQuotedPathLookup
- [x] TestBracedRootTrailingGarbage
- [x] Reviewed by Claude (code-reviewer) and Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)