### PR TITLE
feat: P1 include system hardening — required(), soft error fix, error propagation

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -429,3 +429,20 @@ func TestConfig_BOM_ParseString(t *testing.T) {
 		t.Errorf("got %q, want %q", got, "bar")
 	}
 }
+
+func TestRequiredIncludeMissingFile(t *testing.T) {
+	_, err := hocon.ParseString(`include required("nonexistent.conf")`)
+	if err == nil {
+		t.Error("expected error for missing required include")
+	}
+}
+
+func TestOptionalIncludeMissingFile(t *testing.T) {
+	cfg, err := hocon.ParseString("include \"nonexistent.conf\"\na = 1")
+	if err != nil {
+		t.Fatalf("non-required missing include should not error: %v", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("got %d, want 1", got)
+	}
+}

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -79,9 +79,12 @@ func (n *SubstNode) Col() int { return n.col }
 
 // IncludeNode represents an include directive.
 // Only file-based includes are supported in v1.0.
+// Required=true means the file must exist (include required(...) form);
+// Required=false means missing files are silently ignored per HOCON spec.
 type IncludeNode struct {
 	pos
-	Path string
+	Path     string
+	Required bool
 }
 
 func (n *IncludeNode) node() {}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -166,6 +166,14 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 			return nil, fmt.Errorf("parse error at line %d, col %d: expected '(' after 'required' in include directive", line, col)
 		}
 		p.advance() // consume '('
+
+		// re-check for unsupported forms inside required(...): url(...) classpath(...)
+		if p.current.Type == lexer.TokenString {
+			switch p.current.Value {
+			case "url", "classpath":
+				return nil, fmt.Errorf("parse error at line %d, col %d: include required(%s(...)) is not supported in v1.0", line, col, p.current.Value)
+			}
+		}
 	}
 
 	// support: include "file.conf" and include file("file.conf")

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -156,8 +156,21 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 			return nil, fmt.Errorf("parse error at line %d, col %d: include %s(...) is not supported in v1.0", line, col, p.current.Value)
 		}
 	}
+
+	// detect include required(...) form
+	required := false
+	if p.current.Type == lexer.TokenString && !p.current.IsQuoted && p.current.Value == "required" {
+		required = true
+		p.advance() // consume "required"
+		if p.current.Type != lexer.TokenLParen {
+			return nil, fmt.Errorf("parse error at line %d, col %d: expected '(' after 'required' in include directive", line, col)
+		}
+		p.advance() // consume '('
+	}
+
 	// support: include "file.conf" and include file("file.conf")
-	if p.current.Type == lexer.TokenString && p.current.Value == "file" {
+	var path string
+	if p.current.Type == lexer.TokenString && !p.current.IsQuoted && p.current.Value == "file" {
 		p.advance() // consume "file"
 		// expect '('
 		if p.current.Type != lexer.TokenLParen {
@@ -167,20 +180,29 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		if p.current.Type != lexer.TokenString {
 			return nil, fmt.Errorf("parse error at line %d, col %d: expected filename string in include file(...)", line, col)
 		}
-		path := p.current.Value
+		path = p.current.Value
 		p.advance() // consume path
 		if p.current.Type != lexer.TokenRParen {
 			return nil, fmt.Errorf("parse error at line %d, col %d: expected ')' after filename in include file(...)", line, col)
 		}
 		p.advance() // consume ')'
-		return &IncludeNode{pos: pos{line, col}, Path: path}, nil
+	} else {
+		if p.current.Type != lexer.TokenString {
+			return nil, fmt.Errorf("parse error at line %d, col %d: expected filename after include", line, col)
+		}
+		path = p.current.Value
+		p.advance()
 	}
-	if p.current.Type != lexer.TokenString {
-		return nil, fmt.Errorf("parse error at line %d, col %d: expected filename after include", line, col)
+
+	// if we consumed 'required(', close the outer paren
+	if required {
+		if p.current.Type != lexer.TokenRParen {
+			return nil, fmt.Errorf("parse error at line %d, col %d: expected ')' to close required(...) in include directive", line, col)
+		}
+		p.advance() // consume ')'
 	}
-	path := p.current.Value
-	p.advance()
-	return &IncludeNode{pos: pos{line, col}, Path: path}, nil
+
+	return &IncludeNode{pos: pos{line, col}, Path: path, Required: required}, nil
 }
 
 func (p *parser) parseField() (*FieldNode, error) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -150,7 +150,8 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 	p.advance() // consume "include"
 	p.skipNewlines()
 	// check for unsupported forms: url(...) classpath(...)
-	if p.current.Type == lexer.TokenString {
+	// Only match unquoted tokens — a quoted "url" is a valid filename.
+	if p.current.Type == lexer.TokenString && !p.current.IsQuoted {
 		switch p.current.Value {
 		case "url", "classpath":
 			return nil, fmt.Errorf("parse error at line %d, col %d: include %s(...) is not supported in v1.0", line, col, p.current.Value)
@@ -168,7 +169,8 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		p.advance() // consume '('
 
 		// re-check for unsupported forms inside required(...): url(...) classpath(...)
-		if p.current.Type == lexer.TokenString {
+		// Only match unquoted tokens — include required("url") is a valid file path.
+		if p.current.Type == lexer.TokenString && !p.current.IsQuoted {
 			switch p.current.Value {
 			case "url", "classpath":
 				return nil, fmt.Errorf("parse error at line %d, col %d: include required(%s(...)) is not supported in v1.0", line, col, p.current.Value)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -295,6 +295,26 @@ func TestParser_IncludeNotRequired(t *testing.T) {
 	}
 }
 
+func TestParser_IncludeRequiredUrlNotSupported(t *testing.T) {
+	_, err := parser.Parse(`include required(url("http://example.com"))`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %s", err.Error())
+	}
+}
+
+func TestParser_IncludeRequiredClasspathNotSupported(t *testing.T) {
+	_, err := parser.Parse(`include required(classpath("reference.conf"))`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %s", err.Error())
+	}
+}
+
 func TestBracedRootTrailingGarbage(t *testing.T) {
 	tests := []string{
 		`{ a = 1 } }`,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -243,6 +243,13 @@ func TestParser_UnsupportedIncludeURL(t *testing.T) {
 	}
 }
 
+func TestParser_UnsupportedIncludeClasspath(t *testing.T) {
+	_, err := parser.Parse(`include classpath("reference.conf")`)
+	if err == nil {
+		t.Fatal("expected error for unsupported include classpath() form")
+	}
+}
+
 func TestParser_IncludeRequired(t *testing.T) {
 	obj := mustParse(t, `include required("base.conf")`)
 	if len(obj.Fields) != 1 {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -315,6 +315,61 @@ func TestParser_IncludeRequiredClasspathNotSupported(t *testing.T) {
 	}
 }
 
+// TestParser_IncludeQuotedUrlNotError verifies that a quoted filename that
+// happens to be "url" is treated as a plain file path, not an unsupported form.
+func TestParser_IncludeQuotedUrlNotError(t *testing.T) {
+	// include "url" — "url" is a quoted string, so it must be accepted as a filename.
+	obj := mustParse(t, `include "url"`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "url" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+}
+
+// TestParser_IncludeRequiredQuotedUrlNotError verifies that include required("url")
+// is accepted as a valid file path include, not rejected as url(...) form.
+func TestParser_IncludeRequiredQuotedUrlNotError(t *testing.T) {
+	obj := mustParse(t, `include required("url")`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "url" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+	if !inc.Required {
+		t.Error("expected Required=true")
+	}
+}
+
+// TestParser_IncludeRequiredQuotedClasspathNotError verifies that include required("classpath")
+// is accepted as a valid file path include, not rejected as classpath(...) form.
+func TestParser_IncludeRequiredQuotedClasspathNotError(t *testing.T) {
+	obj := mustParse(t, `include required("classpath")`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "classpath" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+	if !inc.Required {
+		t.Error("expected Required=true")
+	}
+}
+
 func TestBracedRootTrailingGarbage(t *testing.T) {
 	tests := []string{
 		`{ a = 1 } }`,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -243,6 +243,51 @@ func TestParser_UnsupportedIncludeURL(t *testing.T) {
 	}
 }
 
+func TestParser_IncludeRequired(t *testing.T) {
+	obj := mustParse(t, `include required("base.conf")`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field (include), got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "base.conf" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+	if !inc.Required {
+		t.Error("expected Required=true for include required(...)")
+	}
+}
+
+func TestParser_IncludeRequiredFile(t *testing.T) {
+	obj := mustParse(t, `include required(file("base.conf"))`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field (include), got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "base.conf" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+	if !inc.Required {
+		t.Error("expected Required=true for include required(file(...))")
+	}
+}
+
+func TestParser_IncludeNotRequired(t *testing.T) {
+	obj := mustParse(t, `include "base.conf"`)
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Required {
+		t.Error("expected Required=false for plain include")
+	}
+}
+
 func TestBracedRootTrailingGarbage(t *testing.T) {
 	tests := []string{
 		`{ a = 1 } }`,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -525,7 +525,7 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 
 	// Single file with explicit extension.
 	if filepath.Ext(path) != "" {
-		return r.loadIncludeFile(path)
+		return r.loadIncludeFile(path, inc.Required)
 	}
 
 	// No extension: probe all known extensions and merge all found files.
@@ -534,7 +534,7 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	found := false
 	for _, ext := range includeExtensions {
 		p := path + ext
-		obj, err := r.loadIncludeFile(p)
+		obj, err := r.loadIncludeFile(p, true) // always required per-file; missing handled below
 		if err != nil {
 			continue // file not found — skip
 		}
@@ -543,19 +543,27 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 		merged = deepMerge(obj, merged)
 	}
 	if !found {
-		return nil, &ResolveError{
-			Message:  fmt.Sprintf("cannot read include file: no file found for %q (tried %v)", inc.Path, includeExtensions),
-			FilePath: path,
+		if inc.Required {
+			return nil, &ResolveError{
+				Message:  fmt.Sprintf("cannot read include file: no file found for %q (tried %v)", inc.Path, includeExtensions),
+				FilePath: path,
+			}
 		}
+		// Non-required: silently return empty object per HOCON spec.
+		return newObjectVal(), nil
 	}
 	return merged, nil
 }
 
 // loadIncludeFile reads, parses, and resolves a single include file.
-// Returns an error if the file does not exist or cannot be parsed.
-func (r *resolver) loadIncludeFile(path string) (*ObjectVal, error) {
+// When required=false a missing file is silently ignored (returns empty object).
+func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if !required {
+			// Non-required include: silently ignore missing file per HOCON spec.
+			return newObjectVal(), nil
+		}
 		return nil, &ResolveError{
 			Message:  "cannot read include file: " + err.Error(),
 			FilePath: path,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -534,9 +534,14 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	found := false
 	for _, ext := range includeExtensions {
 		p := path + ext
-		obj, err := r.loadIncludeFile(p, true) // always required per-file; missing handled below
+		if _, err := os.Stat(p); err != nil {
+			// File does not exist (or is not accessible): skip to next extension.
+			continue
+		}
+		// File exists — load it; any error here is a real parse/resolve error.
+		obj, err := r.loadIncludeFile(p, true)
 		if err != nil {
-			continue // file not found — skip
+			return nil, err
 		}
 		found = true
 		// Later files override earlier ones: pass new obj as dst (winner).

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -535,8 +535,15 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 	for _, ext := range includeExtensions {
 		p := path + ext
 		if _, err := os.Stat(p); err != nil {
-			// File does not exist (or is not accessible): skip to next extension.
-			continue
+			if os.IsNotExist(err) {
+				// File does not exist: skip to next extension.
+				continue
+			}
+			// Permission error or other I/O failure — propagate.
+			return nil, &ResolveError{
+				Message:  "cannot stat include file: " + err.Error(),
+				FilePath: p,
+			}
 		}
 		// File exists — load it; any error here is a real parse/resolve error.
 		obj, err := r.loadIncludeFile(p, true)
@@ -565,10 +572,12 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if !required {
+		if !required && os.IsNotExist(err) {
 			// Non-required include: silently ignore missing file per HOCON spec.
 			return newObjectVal(), nil
 		}
+		// For required includes, or non-ENOENT errors on optional includes,
+		// always propagate (permission errors etc. should not be silently swallowed).
 		return nil, &ResolveError{
 			Message:  "cannot read include file: " + err.Error(),
 			FilePath: path,

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -464,26 +464,53 @@ nested = [{a = 42}, [false]]
 }
 
 func TestResolver_IncludeExplicitExtensionNotFound(t *testing.T) {
-	// Explicit extension that doesn't exist should error.
+	// Non-required include with explicit extension: missing file is silently ignored per HOCON spec.
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "missing.conf" }`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err != nil {
+		t.Fatalf("non-required missing include should not error: %v", err)
+	}
+}
+
+func TestResolver_IncludeRequiredExplicitExtensionNotFound(t *testing.T) {
+	// required() include with explicit extension: missing file must error.
+	dir := t.TempDir()
+	ast, err := parser.Parse(`a { include required("missing.conf") }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
 	if err == nil {
-		t.Fatal("expected error for missing include file")
+		t.Fatal("expected error for missing required include file")
 	}
 }
 
 func TestResolver_IncludeProbeNotFound(t *testing.T) {
+	// Non-required extensionless include: no files found should silently return empty per HOCON spec.
 	dir := t.TempDir()
 	ast, err := parser.Parse(`a { include "nonexistent" }`)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err != nil {
+		t.Fatalf("non-required missing include should not error: %v", err)
+	}
+}
+
+func TestResolver_IncludeRequiredProbeNotFound(t *testing.T) {
+	// required() extensionless include: no files found must error.
+	dir := t.TempDir()
+	ast, err := parser.Parse(`a { include required("nonexistent") }`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
 	if err == nil {
-		t.Fatal("expected error for missing include, got nil")
+		t.Fatal("expected error for missing required extensionless include")
 	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -514,3 +514,19 @@ func TestResolver_IncludeRequiredProbeNotFound(t *testing.T) {
 		t.Fatal("expected error for missing required extensionless include")
 	}
 }
+
+func TestResolver_IncludeProbingPropagatesParseError(t *testing.T) {
+	// A parse error in a file that EXISTS (during extension probing) must propagate,
+	// not be silently swallowed as if the file were missing.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "broken.conf"), `{ invalid = }`)
+
+	ast, err := parser.Parse(`include "broken"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Error("expected parse error from broken include file to propagate, got nil")
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -515,6 +515,27 @@ func TestResolver_IncludeRequiredProbeNotFound(t *testing.T) {
 	}
 }
 
+// TestResolver_IncludeOptionalNonEnoentErrorPropagates verifies that a non-required
+// include whose ReadFile fails with a non-ENOENT error (e.g. "is a directory")
+// propagates the error instead of silently returning an empty object.
+func TestResolver_IncludeOptionalNonEnoentErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	// Create a subdirectory with the target name + ".conf" — reading a directory is not ENOENT.
+	subDir := filepath.Join(dir, "subdir.conf")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ast, err := parser.Parse(`include "subdir.conf"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Error("expected error when ReadFile fails with non-ENOENT, got nil")
+	}
+}
+
 func TestResolver_IncludeProbingPropagatesParseError(t *testing.T) {
 	// A parse error in a file that EXISTS (during extension probing) must propagate,
 	// not be silently swallowed as if the file were missing.


### PR DESCRIPTION
## Summary
- **`include required("file")`** support — errors when file is missing, per HOCON spec
- **Missing includes now silently ignored** — was always erroring (Closes #21)
- **Parse error propagation** in extension probing — file-not-found skipped, parse errors propagate (Closes #23)
- **`include required(url/classpath)`** explicit error message
- **url/classpath test coverage** confirmed

## Test Plan
- [x] All tests passing (`go test ./...`, `golangci-lint`)
- [x] Parser: required() with bare path, file() form, required(url/classpath) error
- [x] Resolver: required missing → error, optional missing → silent ignore
- [x] Probing: os.Stat check before load — parse errors propagate
- [x] Deterministic tests with t.TempDir()

🤖 Generated with [Claude Code](https://claude.com/claude-code)