### PR TITLE
fix: P1 lexer/parser spec compliance — unicode escapes, unknown escapes, .properties parser

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -446,3 +446,39 @@ func TestOptionalIncludeMissingFile(t *testing.T) {
 		t.Errorf("got %d, want 1", got)
 	}
 }
+
+func TestIncludePropertiesFile(t *testing.T) {
+	dir := t.TempDir()
+	propsFile := filepath.Join(dir, "app.properties")
+	// Use ! comment and a URL value — both are legal .properties but invalid HOCON.
+	os.WriteFile(propsFile, []byte(
+		"! bang comment\n"+
+			"server.host=localhost\n"+
+			"server.port=8080\n"+
+			"debug=true\n"+
+			"endpoint=http://example.com/api",
+	), 0644)
+	mainFile := filepath.Join(dir, "main.conf")
+	os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\napp = 1", propsFile)), 0644)
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.GetString("server.host"); got != "localhost" {
+		t.Errorf("server.host=%q, want localhost", got)
+	}
+	if got := cfg.GetString("server.port"); got != "8080" {
+		t.Errorf("server.port=%q, want 8080 (string)", got)
+	}
+	if got := cfg.GetString("debug"); got != "true" {
+		t.Errorf("debug=%q, want true (string)", got)
+	}
+	if got := cfg.GetString("endpoint"); got != "http://example.com/api" {
+		t.Errorf("endpoint=%q, want http://example.com/api", got)
+	}
+	if got := cfg.GetInt64("app"); got != 1 {
+		t.Errorf("app=%d, want 1", got)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -451,15 +452,20 @@ func TestIncludePropertiesFile(t *testing.T) {
 	dir := t.TempDir()
 	propsFile := filepath.Join(dir, "app.properties")
 	// Use ! comment and a URL value — both are legal .properties but invalid HOCON.
-	os.WriteFile(propsFile, []byte(
+	if err := os.WriteFile(propsFile, []byte(
 		"! bang comment\n"+
 			"server.host=localhost\n"+
 			"server.port=8080\n"+
 			"debug=true\n"+
 			"endpoint=http://example.com/api",
-	), 0644)
+	), 0644); err != nil {
+		t.Fatal(err)
+	}
 	mainFile := filepath.Join(dir, "main.conf")
-	os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\napp = 1", propsFile)), 0644)
+	slashPropsFile := strings.ReplaceAll(propsFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\napp = 1", slashPropsFile)), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	cfg, err := hocon.ParseFile(mainFile)
 	if err != nil {

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -9,6 +9,8 @@
 package lexer
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -241,9 +243,22 @@ func (l *Lexer) readString(line, col int) Token {
 				sb.WriteByte('"')
 			case '\\':
 				sb.WriteByte('\\')
+			case 'u':
+				hex := make([]rune, 0, 4)
+				for i := 0; i < 4; i++ {
+					ch, ok := l.peek()
+					if !ok {
+						return Token{Type: TokenError, Value: "invalid unicode escape: unexpected end", Line: line, Col: col}
+					}
+					if !isHexDigit(ch) {
+						return Token{Type: TokenError, Value: fmt.Sprintf("invalid unicode escape: non-hex char '%c'", ch), Line: line, Col: col}
+					}
+					hex = append(hex, l.advance())
+				}
+				codePoint, _ := strconv.ParseInt(string(hex), 16, 32)
+				sb.WriteRune(rune(codePoint))
 			default:
-				sb.WriteRune('\\')
-				sb.WriteRune(next)
+				return Token{Type: TokenError, Value: fmt.Sprintf("unknown escape sequence: \\%c", next), Line: line, Col: col}
 			}
 			continue
 		}
@@ -398,6 +413,10 @@ const unquotedForbidden = `$"{}[]:=,+#\^?!@&()`
 
 func isUnquotedForbidden(ch rune) bool {
 	return unicode.IsSpace(ch) || strings.ContainsRune(unquotedForbidden, ch)
+}
+
+func isHexDigit(ch rune) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
 }
 
 func (l *Lexer) readUnquoted(prefix string, line, col int) Token {

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -203,3 +203,48 @@ func TestLexer_LineCol(t *testing.T) {
 		t.Errorf("a: line=%d col=%d, want 1,1", tok.Line, tok.Col)
 	}
 }
+
+func TestUnicodeEscape(t *testing.T) {
+	tests := []struct{ input, want string }{
+		{`"\u0041"`, "A"},
+		{`"\u00e9"`, "é"},
+	}
+	for _, tc := range tests {
+		tokens := tokenize(tc.input)
+		if tokens[0].Value != tc.want {
+			t.Errorf("tokenize(%s) = %q, want %q", tc.input, tokens[0].Value, tc.want)
+		}
+	}
+}
+
+func TestUnicodeEscapeInvalid(t *testing.T) {
+	tests := []string{`"\uZZZZ"`, `"\u41"`, `"\u"`}
+	for _, input := range tests {
+		tokens := tokenize(input)
+		hasError := false
+		for _, tok := range tokens {
+			if tok.Type == lexer.TokenError {
+				hasError = true
+			}
+		}
+		if !hasError {
+			t.Errorf("expected error for %s", input)
+		}
+	}
+}
+
+func TestUnknownEscapeError(t *testing.T) {
+	tests := []string{`"hello\qworld"`, `"\a"`}
+	for _, input := range tests {
+		tokens := tokenize(input)
+		hasError := false
+		for _, tok := range tokens {
+			if tok.Type == lexer.TokenError {
+				hasError = true
+			}
+		}
+		if !hasError {
+			t.Errorf("expected error for unknown escape in %s", input)
+		}
+	}
+}

--- a/internal/properties/properties.go
+++ b/internal/properties/properties.go
@@ -1,0 +1,37 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package properties provides a parser for Java .properties files.
+// It handles key=value and key:value syntax, comments (#, !), and whitespace trimming.
+package properties
+
+import "strings"
+
+// Parse parses a .properties file into a flat map of key-value string pairs.
+// Keys and values are trimmed of surrounding whitespace.
+// Lines starting with '#' or '!' are treated as comments and skipped.
+// Both '=' and ':' are accepted as key-value separators.
+func Parse(input string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(input, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "!") {
+			continue
+		}
+		sepIdx := strings.IndexAny(trimmed, "=:")
+		if sepIdx == -1 {
+			continue
+		}
+		key := strings.TrimSpace(trimmed[:sepIdx])
+		value := strings.TrimSpace(trimmed[sepIdx+1:])
+		if key != "" {
+			result[key] = value
+		}
+	}
+	return result
+}

--- a/internal/properties/properties_test.go
+++ b/internal/properties/properties_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package properties
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	result := Parse("host=localhost\nport=8080")
+	if result["host"] != "localhost" {
+		t.Errorf("host=%q", result["host"])
+	}
+	if result["port"] != "8080" {
+		t.Errorf("port=%q", result["port"])
+	}
+}
+
+func TestParseColon(t *testing.T) {
+	result := Parse("host:localhost")
+	if result["host"] != "localhost" {
+		t.Errorf("host=%q", result["host"])
+	}
+}
+
+func TestParseComments(t *testing.T) {
+	result := Parse("# comment\n! also\nkey=val")
+	if len(result) != 1 || result["key"] != "val" {
+		t.Errorf("unexpected: %v", result)
+	}
+}
+
+func TestParseTrim(t *testing.T) {
+	result := Parse("  key  =  value  ")
+	if result["key"] != "value" {
+		t.Errorf("key=%q", result["key"])
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	result := Parse("\n\nkey=val\n\n")
+	if result["key"] != "val" {
+		t.Errorf("key=%q", result["key"])
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -618,33 +619,20 @@ func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, er
 	return childResolver.resolveSubstitutions(obj, obj)
 }
 
-// coerceToStrings converts all scalar values in obj to strings, recursively.
-// Used for .properties files where all values are strings per spec.
-func coerceToStrings(obj *ObjectVal) {
-	for _, k := range obj.Keys() {
-		v, _ := obj.Get(k)
-		switch vv := v.(type) {
-		case *ScalarVal:
-			if vv.V == nil {
-				vv.V = "null"
-			} else if _, ok := vv.V.(string); !ok {
-				vv.V = fmt.Sprintf("%v", vv.V)
-			}
-		case *ObjectVal:
-			coerceToStrings(vv)
-		case *ArrayVal:
-			coerceArrayToStrings(vv)
-		}
-	}
-}
-
 // propsToObjectVal converts a flat map[string]string (from a .properties file)
 // into a nested ObjectVal. Dotted keys are expanded into nested objects:
 // "server.host" = "x" becomes {server: {host: "x"}}.
 // All leaf values are ScalarVal with string type, per .properties spec.
 func propsToObjectVal(props map[string]string) *ObjectVal {
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	root := newObjectVal()
-	for key, value := range props {
+	for _, key := range keys {
+		value := props[key]
 		parts := strings.Split(key, ".")
 		cur := root
 		for i, part := range parts {
@@ -666,21 +654,4 @@ func propsToObjectVal(props map[string]string) *ObjectVal {
 		}
 	}
 	return root
-}
-
-func coerceArrayToStrings(arr *ArrayVal) {
-	for i, elem := range arr.Elements {
-		switch vv := elem.(type) {
-		case *ScalarVal:
-			if vv.V == nil {
-				arr.Elements[i] = &ScalarVal{V: "null"}
-			} else if _, ok := vv.V.(string); !ok {
-				arr.Elements[i] = &ScalarVal{V: fmt.Sprintf("%v", vv.V)}
-			}
-		case *ObjectVal:
-			coerceToStrings(vv)
-		case *ArrayVal:
-			coerceArrayToStrings(vv)
-		}
-	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/o3co/go.hocon/internal/parser"
+	"github.com/o3co/go.hocon/internal/properties"
 )
 
 // Val is a resolved value.
@@ -584,14 +585,15 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 		}
 	}
 
+	// .properties files: use dedicated parser instead of HOCON lexer.
+	// Standard .properties syntax (e.g. ! comments, URL values) is not valid HOCON.
+	if filepath.Ext(path) == ".properties" {
+		return propsToObjectVal(properties.Parse(string(data))), nil
+	}
+
 	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
 		return nil, err
-	}
-
-	// .properties files: all values must remain strings per HOCON spec.
-	if filepath.Ext(path) == ".properties" {
-		coerceToStrings(obj)
 	}
 
 	return obj, nil
@@ -634,6 +636,36 @@ func coerceToStrings(obj *ObjectVal) {
 			coerceArrayToStrings(vv)
 		}
 	}
+}
+
+// propsToObjectVal converts a flat map[string]string (from a .properties file)
+// into a nested ObjectVal. Dotted keys are expanded into nested objects:
+// "server.host" = "x" becomes {server: {host: "x"}}.
+// All leaf values are ScalarVal with string type, per .properties spec.
+func propsToObjectVal(props map[string]string) *ObjectVal {
+	root := newObjectVal()
+	for key, value := range props {
+		parts := strings.Split(key, ".")
+		cur := root
+		for i, part := range parts {
+			if i == len(parts)-1 {
+				cur.set(part, &ScalarVal{V: value})
+			} else {
+				existing, ok := cur.values[part]
+				if !ok {
+					child := newObjectVal()
+					cur.set(part, child)
+					cur = child
+				} else if child, ok := existing.(*ObjectVal); ok {
+					cur = child
+				} else {
+					// Conflict: scalar already set for this segment — leaf wins, skip.
+					break
+				}
+			}
+		}
+	}
+	return root
 }
 
 func coerceArrayToStrings(arr *ArrayVal) {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -265,7 +265,8 @@ func TestResolver_IncludeProbeJSON(t *testing.T) {
 
 func TestResolver_IncludeProbeProperties(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "sub.properties"), `z = "from-props"`)
+	// .properties files do not use quote delimiters; value is the literal text.
+	writeFile(t, filepath.Join(dir, "sub.properties"), `z = from-props`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
 	obj, ok := res.Root.Get("a")
@@ -311,7 +312,8 @@ y = "only-conf"`)
 func TestResolver_IncludeMergeAllWithProperties(t *testing.T) {
 	// Keys unique to .properties are preserved after merge.
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "sub.properties"), `p = "from-props"`)
+	// .properties files do not use quote delimiters; value is the literal text.
+	writeFile(t, filepath.Join(dir, "sub.properties"), `p = from-props`)
 	writeFile(t, filepath.Join(dir, "sub.conf"), `c = "from-conf"`)
 
 	res := resolveWithDir(t, `a { include "sub" }`, dir)
@@ -400,17 +402,19 @@ func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
 }
 
 func TestResolver_IncludePropertiesNestedObject(t *testing.T) {
-	// Nested objects in .properties files should also have string values.
+	// Dotted keys in .properties files expand into nested ObjectVal hierarchy.
+	// All leaf values must be strings per .properties spec.
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "sub.properties"), `
-inner {
-  a = 42
-  b = true
-}
+inner.a = 42
+inner.b = true
 `)
 	res := resolveWithDir(t, `x { include "sub" }`, dir)
 	obj, _ := res.Root.Get("x")
-	inner, _ := obj.(*resolver.ObjectVal).Get("inner")
+	inner, ok := obj.(*resolver.ObjectVal).Get("inner")
+	if !ok {
+		t.Fatal("inner not found")
+	}
 	o := inner.(*resolver.ObjectVal)
 
 	v1, _ := o.Get("a")
@@ -424,42 +428,24 @@ inner {
 }
 
 func TestResolver_IncludePropertiesArray(t *testing.T) {
-	// Arrays in .properties files should have string elements,
-	// including nested objects and arrays.
+	// Standard .properties files do not support array syntax.
+	// Values that look like arrays are treated as literal strings.
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "sub.properties"), `
-arr = [1, true, 3.14, null]
-nested = [{a = 42}, [false]]
+list = one,two,three
 `)
 
 	res := resolveWithDir(t, `x { include "sub" }`, dir)
 	obj, _ := res.Root.Get("x")
 
-	// Simple array
-	v, _ := obj.(*resolver.ObjectVal).Get("arr")
-	arr := v.(*resolver.ArrayVal)
-	expected := []string{"1", "true", "3.14", "null"}
-	for i, want := range expected {
-		sv := arr.Elements[i].(*resolver.ScalarVal)
-		if s, ok := sv.V.(string); !ok || s != want {
-			t.Errorf("arr[%d]: expected string %q, got %T %v", i, want, sv.V, sv.V)
-		}
+	// Value is a literal string — comma-separated values are the caller's responsibility to split.
+	v, ok := obj.(*resolver.ObjectVal).Get("list")
+	if !ok {
+		t.Fatal("list not found")
 	}
-
-	// Nested array with object and sub-array
-	v2, _ := obj.(*resolver.ObjectVal).Get("nested")
-	nested := v2.(*resolver.ArrayVal)
-	// First element: object {a = 42} → a should be string "42"
-	innerObj := nested.Elements[0].(*resolver.ObjectVal)
-	va, _ := innerObj.Get("a")
-	if sv := va.(*resolver.ScalarVal); sv.V != "42" {
-		t.Errorf("nested[0].a: expected string \"42\", got %T %v", sv.V, sv.V)
-	}
-	// Second element: array [false] → should be string "false"
-	innerArr := nested.Elements[1].(*resolver.ArrayVal)
-	sv := innerArr.Elements[0].(*resolver.ScalarVal)
-	if s, ok := sv.V.(string); !ok || s != "false" {
-		t.Errorf("nested[1][0]: expected string \"false\", got %T %v", sv.V, sv.V)
+	sv := v.(*resolver.ScalarVal)
+	if s, ok := sv.V.(string); !ok || s != "one,two,three" {
+		t.Errorf("list: expected string \"one,two,three\", got %T %v", sv.V, sv.V)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **`\uXXXX` unicode escape** — fully implemented with hex validation and error on invalid
- **Unknown escape sequences** — `\q`, `\a` etc. now error instead of keeping both chars
- **Dedicated `.properties` parser** — replaces HOCON-parse-then-coerce with flat key=value parser, all values strings, dotted keys expand

## Test Plan
- [x] All 5 packages pass (`go test ./...`)
- [x] Unicode: valid `\u0041`→A, invalid `\uZZZZ`/`\u41`/`\u` produce TokenError
- [x] Unknown escapes: `\q`, `\a` produce TokenError
- [x] Properties: 5 unit tests + integration test with dotted keys and comments
- [x] No Lightbend/existing test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)