### PR TITLE
fix: P0 cross-language spec consistency

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -408,8 +408,10 @@ func (l *Lexer) readNumber(line, col int) Token {
 }
 
 // unquotedForbidden are characters that terminate an unquoted string.
-// Parentheses are included so that `include file(...)` can be parsed correctly.
-const unquotedForbidden = `$"{}[]:=,+#\^?!@&()`
+// Per spec: $"{}[]:=,+#\^?!@*& plus all whitespace.
+// Parentheses are not in the spec but are included so that
+// `include file(...)` / `include required(...)` can be parsed correctly.
+const unquotedForbidden = `$"{}[]:=,+#\^?!@*&()`
 
 func isUnquotedForbidden(ch rune) bool {
 	return unicode.IsSpace(ch) || strings.ContainsRune(unquotedForbidden, ch)
@@ -434,6 +436,13 @@ func (l *Lexer) readUnquoted(prefix string, line, col int) Token {
 
 func (l *Lexer) readUnquotedOrKeyword(line, col int) Token {
 	tok := l.readUnquoted("", line, col)
+	if tok.Value == "" {
+		// The character is forbidden in unquoted strings and has no
+		// dedicated token type (e.g. *, !, @, ^, ?).  Consume it and
+		// emit an error so the lexer makes progress.
+		ch := l.advance()
+		return Token{Type: TokenError, Value: fmt.Sprintf("unexpected character: %c", ch), Line: line, Col: col}
+	}
 	switch tok.Value {
 	case "true", "false":
 		return Token{Type: TokenBool, Value: tok.Value, Line: line, Col: col}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/o3co/go.hocon/internal/lexer"
@@ -229,6 +230,35 @@ func TestUnicodeEscapeInvalid(t *testing.T) {
 		}
 		if !hasError {
 			t.Errorf("expected error for %s", input)
+		}
+	}
+}
+
+func TestUnquotedParenthesesProduceSeparateTokens(t *testing.T) {
+	// Parentheses are forbidden in unquoted strings so that
+	// `include file(...)` / `include required(...)` can be parsed.
+	// They should produce dedicated LParen/RParen tokens.
+	tokens := tokenize("key = foo(bar)")
+	hasLParen := false
+	hasRParen := false
+	for _, tok := range tokens {
+		if tok.Type == lexer.TokenLParen {
+			hasLParen = true
+		}
+		if tok.Type == lexer.TokenRParen {
+			hasRParen = true
+		}
+	}
+	if !hasLParen || !hasRParen {
+		t.Errorf("parentheses should produce LParen/RParen tokens, got: %v", tokens)
+	}
+}
+
+func TestUnquotedStarForbidden(t *testing.T) {
+	tokens := tokenize("key = foo*bar")
+	for _, tok := range tokens {
+		if tok.Type == lexer.TokenString && strings.Contains(tok.Value, "*") {
+			t.Errorf("* should be forbidden in unquoted strings, got token: %q", tok.Value)
 		}
 	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -468,21 +468,6 @@ func (r *resolver) concatObjects(vals []Val) Val {
 	return result
 }
 
-func (r *resolver) concatArrays(vals []Val) (Val, error) {
-	result := &ArrayVal{}
-	for _, v := range vals {
-		if v == nil {
-			continue
-		}
-		arr, ok := v.(*ArrayVal)
-		if !ok {
-			return nil, &ResolveError{Message: "cannot concatenate non-array with array"}
-		}
-		result.Elements = append(result.Elements, arr.Elements...)
-	}
-	return result, nil
-}
-
 func (r *resolver) concatArraysPermissive(vals []Val) Val {
 	result := &ArrayVal{}
 	for _, v := range vals {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -435,17 +435,17 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val,
 	switch {
 	case hasObject && !hasArray && !hasScalar:
 		// All meaningful elements are objects → deep merge (left to right, later wins)
-		return r.concatObjects(resolved), nil
+		return concatObjects(resolved), nil
 	case hasArray:
 		// Array concatenation (permissive: non-array elements become single items)
-		return r.concatArraysPermissive(resolved), nil
+		return concatArraysPermissive(resolved), nil
 	default:
 		// String concatenation (fallback)
 		return r.concatStrings(resolved), nil
 	}
 }
 
-func (r *resolver) concatObjects(vals []Val) Val {
+func concatObjects(vals []Val) Val {
 	var result *ObjectVal
 	for _, v := range vals {
 		if v == nil || isSeparator(v) {
@@ -458,7 +458,7 @@ func (r *resolver) concatObjects(vals []Val) Val {
 		if result == nil {
 			result = obj
 		} else {
-			// deepMerge: dst wins for non-objects, so pass later object as dst
+			// obj is the new value; it becomes dst so its keys win over the accumulated result.
 			result = deepMerge(obj, result)
 		}
 	}
@@ -468,7 +468,7 @@ func (r *resolver) concatObjects(vals []Val) Val {
 	return result
 }
 
-func (r *resolver) concatArraysPermissive(vals []Val) Val {
+func concatArraysPermissive(vals []Val) Val {
 	result := &ArrayVal{}
 	for _, v := range vals {
 		if v == nil || isSeparator(v) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -447,6 +447,35 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val,
 	}
 }
 
+// mergeObjectConcat merges two objects for object concatenation.
+// Key order follows left (earlier), new keys from right are appended.
+// For duplicate keys, right (later) values win.
+func mergeObjectConcat(left, right *ObjectVal) *ObjectVal {
+	result := newObjectVal()
+	// seed with left keys in order
+	for _, k := range left.keys {
+		result.set(k, left.values[k])
+	}
+	// merge right keys: override existing values, append new keys
+	for _, k := range right.keys {
+		rv := right.values[k]
+		if lv, ok := result.values[k]; ok {
+			// both object → recursive merge preserving order
+			if lo, lok := lv.(*ObjectVal); lok {
+				if ro, rok := rv.(*ObjectVal); rok {
+					result.values[k] = mergeObjectConcat(lo, ro)
+					continue
+				}
+			}
+			// right wins for value
+			result.values[k] = rv
+		} else {
+			result.set(k, rv)
+		}
+	}
+	return result
+}
+
 func concatObjects(vals []Val) Val {
 	var result *ObjectVal
 	for _, v := range vals {
@@ -460,8 +489,7 @@ func concatObjects(vals []Val) Val {
 		if result == nil {
 			result = obj
 		} else {
-			// obj is the new value; it becomes dst so its keys win over the accumulated result.
-			result = deepMerge(obj, result)
+			result = mergeObjectConcat(result, obj)
 		}
 	}
 	if result == nil {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -394,6 +394,15 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 	return nil, &ResolveError{Message: "unresolved substitution", Path: pathStr, Line: n.Line(), Col: n.Col()}
 }
 
+func isSeparator(v Val) bool {
+	if s, ok := v.(*ScalarVal); ok {
+		if str, ok := s.V.(string); ok && str == " " {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val, error) {
 	// resolve each val
 	var resolved []Val
@@ -404,21 +413,59 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val,
 		}
 		resolved = append(resolved, rv)
 	}
-	// determine mode from first non-nil element
+
+	// Classify non-nil, non-separator elements to determine concatenation mode.
+	hasArray := false
+	hasObject := false
+	hasScalar := false
 	for _, rv := range resolved {
-		if rv == nil {
+		if rv == nil || isSeparator(rv) {
 			continue
 		}
 		switch rv.(type) {
 		case *ArrayVal:
-			return r.concatArrays(resolved)
+			hasArray = true
 		case *ObjectVal:
-			return nil, &ResolveError{Message: "objects cannot appear in concatenation", Path: path}
+			hasObject = true
 		default:
-			return r.concatStrings(resolved), nil
+			hasScalar = true
 		}
 	}
-	return &ScalarVal{V: ""}, nil
+
+	switch {
+	case hasObject && !hasArray && !hasScalar:
+		// All meaningful elements are objects → deep merge (left to right, later wins)
+		return r.concatObjects(resolved), nil
+	case hasArray:
+		// Array concatenation (permissive: non-array elements become single items)
+		return r.concatArraysPermissive(resolved), nil
+	default:
+		// String concatenation (fallback)
+		return r.concatStrings(resolved), nil
+	}
+}
+
+func (r *resolver) concatObjects(vals []Val) Val {
+	var result *ObjectVal
+	for _, v := range vals {
+		if v == nil || isSeparator(v) {
+			continue
+		}
+		obj, ok := v.(*ObjectVal)
+		if !ok {
+			continue
+		}
+		if result == nil {
+			result = obj
+		} else {
+			// deepMerge: dst wins for non-objects, so pass later object as dst
+			result = deepMerge(obj, result)
+		}
+	}
+	if result == nil {
+		return newObjectVal()
+	}
+	return result
 }
 
 func (r *resolver) concatArrays(vals []Val) (Val, error) {
@@ -434,6 +481,21 @@ func (r *resolver) concatArrays(vals []Val) (Val, error) {
 		result.Elements = append(result.Elements, arr.Elements...)
 	}
 	return result, nil
+}
+
+func (r *resolver) concatArraysPermissive(vals []Val) Val {
+	result := &ArrayVal{}
+	for _, v := range vals {
+		if v == nil || isSeparator(v) {
+			continue
+		}
+		if arr, ok := v.(*ArrayVal); ok {
+			result.Elements = append(result.Elements, arr.Elements...)
+		} else {
+			result.Elements = append(result.Elements, v)
+		}
+	}
+	return result
 }
 
 func (r *resolver) concatStrings(vals []Val) Val {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -137,7 +137,8 @@ func Resolve(root *parser.ObjectNode, opts Options) (*Result, error) {
 		}
 		opts.BaseDir = wd
 	}
-	r := &resolver{opts: opts, resolving: make(map[string]bool), resolvedCache: make(map[string]Val), priorValues: make(map[string]Val)}
+	stack := make([]string, 0)
+	r := &resolver{opts: opts, resolving: make(map[string]bool), resolvedCache: make(map[string]Val), priorValues: make(map[string]Val), includeStack: &stack}
 	obj, err := r.resolveObject(root, opts.Fallback)
 	if err != nil {
 		return nil, err
@@ -155,6 +156,7 @@ type resolver struct {
 	resolving     map[string]bool // cycle detection
 	resolvedCache map[string]Val  // previously resolved values for self-reference
 	priorValues   map[string]Val  // previous value before self-referential overwrite (first pass)
+	includeStack  *[]string       // shared across child resolvers for circular include detection
 }
 
 func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal) (*ObjectVal, error) {
@@ -619,6 +621,20 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 // loadIncludeFile reads, parses, and resolves a single include file.
 // When required=false a missing file is silently ignored (returns empty object).
 func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, error) {
+	// Circular include detection: check if this path is already on the include stack.
+	for _, p := range *r.includeStack {
+		if p == path {
+			return nil, &ResolveError{
+				Message:  fmt.Sprintf("circular include: %s", path),
+				FilePath: path,
+			}
+		}
+	}
+	*r.includeStack = append(*r.includeStack, path)
+	defer func() {
+		*r.includeStack = (*r.includeStack)[:len(*r.includeStack)-1]
+	}()
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !required && os.IsNotExist(err) {
@@ -658,6 +674,7 @@ func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, er
 		resolving:     make(map[string]bool),
 		resolvedCache: make(map[string]Val),
 		priorValues:   make(map[string]Val),
+		includeStack:  r.includeStack,
 	}
 	obj, err := childResolver.resolveObject(ast, nil)
 	if err != nil {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -137,7 +137,7 @@ func Resolve(root *parser.ObjectNode, opts Options) (*Result, error) {
 		}
 		opts.BaseDir = wd
 	}
-	stack := make([]string, 0)
+	stack := make([]string, 0, 8)
 	r := &resolver{opts: opts, resolving: make(map[string]bool), resolvedCache: make(map[string]Val), priorValues: make(map[string]Val), includeStack: &stack}
 	obj, err := r.resolveObject(root, opts.Fallback)
 	if err != nil {
@@ -156,7 +156,7 @@ type resolver struct {
 	resolving     map[string]bool // cycle detection
 	resolvedCache map[string]Val  // previously resolved values for self-reference
 	priorValues   map[string]Val  // previous value before self-referential overwrite (first pass)
-	includeStack  *[]string       // shared across child resolvers for circular include detection
+	includeStack  *[]string       // shared stack for circular include detection (normalized paths)
 }
 
 func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal) (*ObjectVal, error) {
@@ -621,16 +621,23 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode) (*ObjectVal, error) {
 // loadIncludeFile reads, parses, and resolves a single include file.
 // When required=false a missing file is silently ignored (returns empty object).
 func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, error) {
-	// Circular include detection: check if this path is already on the include stack.
+	// Normalize path for reliable circular detection.
+	// Clean removes ".." / "." segments; Abs makes relative paths absolute.
+	canonicalPath := filepath.Clean(path)
+	if abs, err := filepath.Abs(canonicalPath); err == nil {
+		canonicalPath = abs
+	}
+
+	// Circular include detection using shared stack.
 	for _, p := range *r.includeStack {
-		if p == path {
+		if p == canonicalPath {
 			return nil, &ResolveError{
 				Message:  fmt.Sprintf("circular include: %s", path),
 				FilePath: path,
 			}
 		}
 	}
-	*r.includeStack = append(*r.includeStack, path)
+	*r.includeStack = append(*r.includeStack, canonicalPath)
 	defer func() {
 		*r.includeStack = (*r.includeStack)[:len(*r.includeStack)-1]
 	}()

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -680,3 +680,17 @@ func TestResolver_CircularIncludeSelfDetected(t *testing.T) {
 		t.Fatal("expected circular include error for self-include, got nil")
 	}
 }
+
+func TestResolver_ObjectConcatenationKeyOrder(t *testing.T) {
+	src := `a = {x: 1} {y: 2}`
+	res := resolve(t, src)
+	aVal, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	aObj := aVal.(*resolver.ObjectVal)
+	keys := aObj.Keys()
+	if len(keys) != 2 || keys[0] != "x" || keys[1] != "y" {
+		t.Errorf("expected keys [x, y], got %v", keys)
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -643,3 +643,40 @@ func TestResolver_CircularIncludeDetection(t *testing.T) {
 		t.Errorf("expected message containing \"circular include\", got %q", re.Message)
 	}
 }
+
+func TestResolver_CircularIncludeDetected(t *testing.T) {
+	// Two files that include each other must produce a circular include error,
+	// not an infinite loop. Use relative paths so Clean+Abs normalization is exercised.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.conf"), `include "b.conf"`)
+	writeFile(t, filepath.Join(dir, "b.conf"), `include "a.conf"`)
+
+	ast, err := parser.Parse(`include "a.conf"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Fatal("expected circular include error, got nil")
+	}
+	if re, ok := err.(*resolver.ResolveError); ok {
+		if re.Message == "" {
+			t.Error("expected non-empty error message")
+		}
+	}
+}
+
+func TestResolver_CircularIncludeSelfDetected(t *testing.T) {
+	// A file that includes itself must be detected as circular.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "self.conf"), `include "self.conf"`)
+
+	ast, err := parser.Parse(`include "self.conf"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if err == nil {
+		t.Fatal("expected circular include error for self-include, got nil")
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -618,5 +619,27 @@ func TestResolver_ObjectConcatenationDeepMerge(t *testing.T) {
 		t.Error("other missing after deep merge")
 	} else if sv, ok := ov.(*resolver.ScalarVal); !ok || sv.V != int64(2) {
 		t.Errorf("expected other=2, got %v", ov)
+	}
+}
+
+func TestResolver_CircularIncludeDetection(t *testing.T) {
+	// circular_a.conf includes circular_b.conf which includes circular_a.conf.
+	// This must produce a ResolveError with "circular include" rather than
+	// hanging forever or stack-overflowing.
+	baseDir := filepath.Join("..", "..", "testdata", "hocon")
+	ast, err := parser.Parse(`include "circular_a.conf"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = resolver.Resolve(ast, resolver.Options{BaseDir: baseDir})
+	if err == nil {
+		t.Fatal("expected circular include error, got nil")
+	}
+	re, ok := err.(*resolver.ResolveError)
+	if !ok {
+		t.Fatalf("expected *ResolveError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Message, "circular include") {
+		t.Errorf("expected message containing \"circular include\", got %q", re.Message)
 	}
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -538,7 +538,7 @@ func TestResolver_IncludeProbingPropagatesParseError(t *testing.T) {
 	}
 }
 
-func TestResolveObjectConcatenation(t *testing.T) {
+func TestResolver_ObjectConcatenation(t *testing.T) {
 	// HOCON spec: `a = {x: 1} {y: 2}` should deep-merge into {x:1, y:2}
 	res := resolve(t, `a = {x: 1} {y: 2}`)
 	v, ok := res.Root.Get("a")
@@ -563,7 +563,34 @@ func TestResolveObjectConcatenation(t *testing.T) {
 	}
 }
 
-func TestResolveObjectConcatenationDeepMerge(t *testing.T) {
+func TestResolver_ArrayConcatenationPermissive(t *testing.T) {
+	// HOCON spec: non-array elements concatenated with arrays are pushed as items.
+	// `a = [1, 2] 3` should produce [1, 2, 3].
+	res := resolve(t, `a = [1, 2] 3`)
+	v, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	arr, ok := v.(*resolver.ArrayVal)
+	if !ok {
+		t.Fatalf("expected ArrayVal, got %T", v)
+	}
+	if len(arr.Elements) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr.Elements))
+	}
+	for i, want := range []int64{1, 2, 3} {
+		sv, ok := arr.Elements[i].(*resolver.ScalarVal)
+		if !ok {
+			t.Errorf("element %d: expected ScalarVal, got %T", i, arr.Elements[i])
+			continue
+		}
+		if sv.V != want {
+			t.Errorf("element %d: expected %d, got %v", i, want, sv.V)
+		}
+	}
+}
+
+func TestResolver_ObjectConcatenationDeepMerge(t *testing.T) {
 	// HOCON spec: nested object concatenation should deep-merge
 	res := resolve(t, `a = {x: {nested: 1}} {x: {other: 2}}`)
 	v, ok := res.Root.Get("a")

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -537,3 +537,59 @@ func TestResolver_IncludeProbingPropagatesParseError(t *testing.T) {
 		t.Error("expected parse error from broken include file to propagate, got nil")
 	}
 }
+
+func TestResolveObjectConcatenation(t *testing.T) {
+	// HOCON spec: `a = {x: 1} {y: 2}` should deep-merge into {x:1, y:2}
+	res := resolve(t, `a = {x: 1} {y: 2}`)
+	v, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	o, ok := v.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("expected ObjectVal, got %T", v)
+	}
+	xv, ok := o.Get("x")
+	if !ok {
+		t.Error("x missing after object concatenation")
+	} else if sv, ok := xv.(*resolver.ScalarVal); !ok || sv.V != int64(1) {
+		t.Errorf("expected x=1, got %v", xv)
+	}
+	yv, ok := o.Get("y")
+	if !ok {
+		t.Error("y missing after object concatenation")
+	} else if sv, ok := yv.(*resolver.ScalarVal); !ok || sv.V != int64(2) {
+		t.Errorf("expected y=2, got %v", yv)
+	}
+}
+
+func TestResolveObjectConcatenationDeepMerge(t *testing.T) {
+	// HOCON spec: nested object concatenation should deep-merge
+	res := resolve(t, `a = {x: {nested: 1}} {x: {other: 2}}`)
+	v, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found")
+	}
+	o, ok := v.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("expected ObjectVal, got %T", v)
+	}
+	xv, ok := o.Get("x")
+	if !ok {
+		t.Fatal("x missing after deep merge")
+	}
+	xo, ok := xv.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("expected x to be ObjectVal, got %T", xv)
+	}
+	if nv, ok := xo.Get("nested"); !ok {
+		t.Error("nested missing after deep merge")
+	} else if sv, ok := nv.(*resolver.ScalarVal); !ok || sv.V != int64(1) {
+		t.Errorf("expected nested=1, got %v", nv)
+	}
+	if ov, ok := xo.Get("other"); !ok {
+		t.Error("other missing after deep merge")
+	} else if sv, ok := ov.(*resolver.ScalarVal); !ok || sv.V != int64(2) {
+		t.Errorf("expected other=2, got %v", ov)
+	}
+}

--- a/testdata/hocon/circular_a.conf
+++ b/testdata/hocon/circular_a.conf
@@ -1,0 +1,2 @@
+include "circular_b.conf"
+a = 1

--- a/testdata/hocon/circular_b.conf
+++ b/testdata/hocon/circular_b.conf
@@ -1,0 +1,2 @@
+include "circular_a.conf"
+b = 2


### PR DESCRIPTION
## Summary

- Allow object concatenation with deep merge (was: error) — aligns with ts.hocon/rs.hocon and Lightbend spec
- Add circular include detection with include stack (was: infinite loop risk)
- Add `*` to unquoted forbidden chars, fix infinite loop for forbidden chars without dedicated token types
- Keep `()` in forbidden set (parser depends on `TokenLParen`/`TokenRParen` for `include required(...)`/`include file(...)`)

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] Object concatenation: `{x:1} {y:2}` → merged `{x:1, y:2}`
- [ ] Deep merge: nested objects merge correctly
- [ ] Permissive array concat: `[1,2] 3` → `[1,2,3]`
- [ ] Circular include: A↔B → `ResolveError`
- [ ] `*` forbidden in unquoted strings
- [ ] `()` still produce separate tokens for include syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)