### PR TITLE
docs: add Known Limitations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,15 @@ if err := conf.Unmarshal(&app); err != nil {
 }
 ```
 
+## Known Limitations
+
+- **`include url(...)` and `include classpath(...)`** are not supported. These are JVM-specific include forms from the Lightbend spec. Only `include "file"`, `include file("file")`, and `include required(...)` are supported.
+- **No watch/reload** — the library parses config at load time. For live-reloading, re-call `ParseString()` or `ParseFile()` on change.
+- **No streaming parser** — the entire input is loaded into memory.
+- **`.properties` include** — supports basic `key=value` syntax. Does not support multiline values (backslash continuation), unicode escapes, or key escaping from the full Java .properties specification.
+
+For full API documentation, see [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon).
+
 ## Security Considerations
 
 When parsing untrusted HOCON input, be aware of:

--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ if err := conf.Unmarshal(&app); err != nil {
 
 ## Known Limitations
 
-- **`include url(...)` and `include classpath(...)`** are not supported. These are JVM-specific include forms from the Lightbend spec. Only `include "file"`, `include file("file")`, and `include required(...)` are supported.
+- **`include url(...)`** is not supported. Fetching remote configuration is outside the scope of this parser. Use your application's HTTP client to fetch the content, then pass it to `ParseString()`.
+- **`include classpath(...)`** is not supported. This is a JVM-specific include form with no equivalent outside Java runtimes.
 - **No watch/reload** — the library parses config at load time. For live-reloading, re-call `ParseString()` or `ParseFile()` on change.
 - **No streaming parser** — the entire input is loaded into memory.
 - **`.properties` include** — supports basic `key=value` syntax. Does not support multiline values (backslash continuation), unicode escapes, or key escaping from the full Java .properties specification.


### PR DESCRIPTION
## Summary
- Add "Known Limitations" section before "Security Considerations" documenting unsupported JVM-specific include forms, lack of watch/reload, no streaming parser, and .properties parsing limitations.
- Add link to pkg.go.dev for full API documentation.

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)