### PR TITLE
fix: populate ParseError Line/Col fields (#24)

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,7 @@ package hocon_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/o3co/go.hocon"
@@ -41,5 +42,27 @@ func TestParseError_IsError(t *testing.T) {
 	var target *hocon.ParseError
 	if !errors.As(err, &target) {
 		t.Fatal("errors.As failed for ParseError")
+	}
+}
+
+func TestParseString_ErrorHasLineCol(t *testing.T) {
+	// Trigger a parse error and verify the public ParseError has Line/Col populated.
+	_, err := hocon.ParseString("{ a = 1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *hocon.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *hocon.ParseError, got %T", err)
+	}
+	if pe.Line == 0 {
+		t.Error("expected Line > 0 in ParseError")
+	}
+	if pe.Col == 0 {
+		t.Error("expected Col > 0 in ParseError")
+	}
+	// Message should contain only the description, not the "parse error at line..." prefix.
+	if strings.Contains(pe.Message, "parse error at") {
+		t.Errorf("Message should not contain 'parse error at' prefix, got: %s", pe.Message)
 	}
 }

--- a/hocon.go
+++ b/hocon.go
@@ -9,6 +9,7 @@
 package hocon
 
 import (
+	"errors"
 	"os"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -32,11 +33,16 @@ func ParseFile(path string) (*Config, error) {
 func parseWith(input, filePath string) (*Config, error) {
 	ast, err := parser.Parse(input)
 	if err != nil {
-		if pe, ok := err.(*ParseError); ok {
-			pe.FilePath = filePath
-			return nil, pe
+		pe := &ParseError{FilePath: filePath}
+		var parserErr *parser.Error
+		if errors.As(err, &parserErr) {
+			pe.Message = parserErr.Msg
+			pe.Line = parserErr.Line
+			pe.Col = parserErr.Col
+		} else {
+			pe.Message = err.Error()
 		}
-		return nil, &ParseError{Message: err.Error(), FilePath: filePath}
+		return nil, pe
 	}
 	baseDir := ""
 	if filePath != "" {

--- a/hocon.go
+++ b/hocon.go
@@ -36,7 +36,7 @@ func parseWith(input, filePath string) (*Config, error) {
 		pe := &ParseError{FilePath: filePath}
 		var parserErr *parser.Error
 		if errors.As(err, &parserErr) {
-			pe.Message = parserErr.Msg
+			pe.Message = parserErr.Message
 			pe.Line = parserErr.Line
 			pe.Col = parserErr.Col
 		} else {

--- a/internal/parser/errors.go
+++ b/internal/parser/errors.go
@@ -13,18 +13,18 @@ import "fmt"
 // Error is a parse error carrying structured line/col position.
 // The root hocon package maps this to the public ParseError type.
 type Error struct {
-	Msg  string
-	Line int
-	Col  int
+	Message string
+	Line    int
+	Col     int
 }
 
 func (e *Error) Error() string {
 	if e.Line > 0 {
-		return fmt.Sprintf("parse error at line %d, col %d: %s", e.Line, e.Col, e.Msg)
+		return fmt.Sprintf("parse error at line %d, col %d: %s", e.Line, e.Col, e.Message)
 	}
-	return fmt.Sprintf("parse error: %s", e.Msg)
+	return fmt.Sprintf("parse error: %s", e.Message)
 }
 
 func newError(line, col int, format string, args ...any) *Error {
-	return &Error{Msg: fmt.Sprintf(format, args...), Line: line, Col: col}
+	return &Error{Message: fmt.Sprintf(format, args...), Line: line, Col: col}
 }

--- a/internal/parser/errors.go
+++ b/internal/parser/errors.go
@@ -1,0 +1,30 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package parser
+
+import "fmt"
+
+// Error is a parse error carrying structured line/col position.
+// The root hocon package maps this to the public ParseError type.
+type Error struct {
+	Msg  string
+	Line int
+	Col  int
+}
+
+func (e *Error) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("parse error at line %d, col %d: %s", e.Line, e.Col, e.Msg)
+	}
+	return fmt.Sprintf("parse error: %s", e.Msg)
+}
+
+func newError(line, col int, format string, args ...any) *Error {
+	return &Error{Msg: fmt.Sprintf(format, args...), Line: line, Col: col}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -244,11 +244,12 @@ func (p *parser) parseField() (*FieldNode, error) {
 }
 
 func (p *parser) parseKey() ([]string, error) {
+	line, col := p.current.Line, p.current.Col
 	if p.current.Type == lexer.TokenError {
-		return nil, newError(p.current.Line, p.current.Col, "%s", p.current.Value)
+		return nil, newError(line, col, "%s", p.current.Value)
 	}
 	if p.current.Type != lexer.TokenString && p.current.Type != lexer.TokenInt {
-		return nil, newError(p.current.Line, p.current.Col, "expected key, got %v", p.current.Type)
+		return nil, newError(line, col, "expected key, got %v", p.current.Type)
 	}
 
 	var parts []string
@@ -288,7 +289,7 @@ func (p *parser) parseKey() ([]string, error) {
 	}
 
 	if len(parts) == 0 {
-		return nil, newError(0, 0, "empty key")
+		return nil, newError(line, col, "empty key")
 	}
 	return parts, nil
 }
@@ -386,7 +387,7 @@ func (p *parser) parseArray() (*ArrayNode, error) {
 			break
 		}
 		if p.current.Type == lexer.TokenEOF {
-			return nil, newError(line, col, "unexpected EOF in array")
+			return nil, newError(p.current.Line, p.current.Col, "unexpected EOF in array")
 		}
 		elem, err := p.parseValue()
 		if err != nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -9,7 +9,6 @@
 package parser
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -100,7 +99,7 @@ func (p *parser) parseObjectFields(braced bool) (*ObjectNode, error) {
 	for {
 		p.skipNewlines()
 		if p.current.Type == lexer.TokenError {
-			return nil, fmt.Errorf("parse error at line %d, col %d: %s", p.current.Line, p.current.Col, p.current.Value)
+			return nil, newError(p.current.Line, p.current.Col, "%s", p.current.Value)
 		}
 		if braced && p.current.Type == lexer.TokenRBrace {
 			p.advance()
@@ -108,7 +107,7 @@ func (p *parser) parseObjectFields(braced bool) (*ObjectNode, error) {
 		}
 		if p.current.Type == lexer.TokenEOF {
 			if braced {
-				return nil, fmt.Errorf("parse error at line %d, col %d: unexpected EOF, expected '}'", p.current.Line, p.current.Col)
+				return nil, newError(p.current.Line, p.current.Col, "unexpected EOF, expected '}'")
 			}
 			break
 		}
@@ -154,7 +153,7 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 	if p.current.Type == lexer.TokenString && !p.current.IsQuoted {
 		switch p.current.Value {
 		case "url", "classpath":
-			return nil, fmt.Errorf("parse error at line %d, col %d: include %s(...) is not supported in v1.0", line, col, p.current.Value)
+			return nil, newError(line, col, "include %s(...) is not supported in v1.0", p.current.Value)
 		}
 	}
 
@@ -164,7 +163,7 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		required = true
 		p.advance() // consume "required"
 		if p.current.Type != lexer.TokenLParen {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected '(' after 'required' in include directive", line, col)
+			return nil, newError(line, col, "expected '(' after 'required' in include directive")
 		}
 		p.advance() // consume '('
 
@@ -173,7 +172,7 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		if p.current.Type == lexer.TokenString && !p.current.IsQuoted {
 			switch p.current.Value {
 			case "url", "classpath":
-				return nil, fmt.Errorf("parse error at line %d, col %d: include required(%s(...)) is not supported in v1.0", line, col, p.current.Value)
+				return nil, newError(line, col, "include required(%s(...)) is not supported in v1.0", p.current.Value)
 			}
 		}
 	}
@@ -184,21 +183,21 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		p.advance() // consume "file"
 		// expect '('
 		if p.current.Type != lexer.TokenLParen {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected '(' after 'file' in include directive", line, col)
+			return nil, newError(line, col, "expected '(' after 'file' in include directive")
 		}
 		p.advance() // consume '('
 		if p.current.Type != lexer.TokenString {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected filename string in include file(...)", line, col)
+			return nil, newError(line, col, "expected filename string in include file(...)")
 		}
 		path = p.current.Value
 		p.advance() // consume path
 		if p.current.Type != lexer.TokenRParen {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected ')' after filename in include file(...)", line, col)
+			return nil, newError(line, col, "expected ')' after filename in include file(...)")
 		}
 		p.advance() // consume ')'
 	} else {
 		if p.current.Type != lexer.TokenString {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected filename after include", line, col)
+			return nil, newError(line, col, "expected filename after include")
 		}
 		path = p.current.Value
 		p.advance()
@@ -207,7 +206,7 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 	// if we consumed 'required(', close the outer paren
 	if required {
 		if p.current.Type != lexer.TokenRParen {
-			return nil, fmt.Errorf("parse error at line %d, col %d: expected ')' to close required(...) in include directive", line, col)
+			return nil, newError(line, col, "expected ')' to close required(...) in include directive")
 		}
 		p.advance() // consume ')'
 	}
@@ -235,7 +234,7 @@ func (p *parser) parseField() (*FieldNode, error) {
 	case lexer.TokenLBrace:
 		// key { ... } shorthand — value is an object
 	default:
-		return nil, fmt.Errorf("parse error at line %d, col %d: expected ':', '=' or '{' after key", p.current.Line, p.current.Col)
+		return nil, newError(p.current.Line, p.current.Col, "expected ':', '=' or '{' after key")
 	}
 	val, err := p.parseValue()
 	if err != nil {
@@ -246,10 +245,10 @@ func (p *parser) parseField() (*FieldNode, error) {
 
 func (p *parser) parseKey() ([]string, error) {
 	if p.current.Type == lexer.TokenError {
-		return nil, fmt.Errorf("parse error at line %d, col %d: %s", p.current.Line, p.current.Col, p.current.Value)
+		return nil, newError(p.current.Line, p.current.Col, "%s", p.current.Value)
 	}
 	if p.current.Type != lexer.TokenString && p.current.Type != lexer.TokenInt {
-		return nil, fmt.Errorf("parse error at line %d, col %d: expected key, got %v", p.current.Line, p.current.Col, p.current.Type)
+		return nil, newError(p.current.Line, p.current.Col, "expected key, got %v", p.current.Type)
 	}
 
 	var parts []string
@@ -289,7 +288,7 @@ func (p *parser) parseKey() ([]string, error) {
 	}
 
 	if len(parts) == 0 {
-		return nil, fmt.Errorf("parse error: empty key")
+		return nil, newError(0, 0, "empty key")
 	}
 	return parts, nil
 }
@@ -328,7 +327,7 @@ func (p *parser) parseValue() (Node, error) {
 
 func (p *parser) parseSingleValue() (Node, error) {
 	if p.current.Type == lexer.TokenError {
-		return nil, fmt.Errorf("parse error at line %d, col %d: %s", p.current.Line, p.current.Col, p.current.Value)
+		return nil, newError(p.current.Line, p.current.Col, "%s", p.current.Value)
 	}
 	line, col := p.current.Line, p.current.Col
 	switch p.current.Type {
@@ -353,7 +352,7 @@ func (p *parser) parseSingleValue() (Node, error) {
 		p.advance()
 		n, err := strconv.ParseInt(raw, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("parse error at line %d: invalid int %q", line, raw)
+			return nil, newError(line, col, "invalid int %q", raw)
 		}
 		return &ScalarNode{pos: pos{line, col}, Value: n}, nil
 	case lexer.TokenFloat:
@@ -361,7 +360,7 @@ func (p *parser) parseSingleValue() (Node, error) {
 		p.advance()
 		f, err := strconv.ParseFloat(raw, 64)
 		if err != nil {
-			return nil, fmt.Errorf("parse error at line %d: invalid float %q", line, raw)
+			return nil, newError(line, col, "invalid float %q", raw)
 		}
 		return &ScalarNode{pos: pos{line, col}, Value: f}, nil
 	case lexer.TokenBool:
@@ -372,7 +371,7 @@ func (p *parser) parseSingleValue() (Node, error) {
 		p.advance()
 		return &ScalarNode{pos: pos{line, col}, Value: nil}, nil
 	default:
-		return nil, fmt.Errorf("parse error at line %d, col %d: unexpected token %v", line, col, p.current.Type)
+		return nil, newError(line, col, "unexpected token %v", p.current.Type)
 	}
 }
 
@@ -387,7 +386,7 @@ func (p *parser) parseArray() (*ArrayNode, error) {
 			break
 		}
 		if p.current.Type == lexer.TokenEOF {
-			return nil, fmt.Errorf("parse error at line %d: unexpected EOF in array", line)
+			return nil, newError(line, col, "unexpected EOF in array")
 		}
 		elem, err := p.parseValue()
 		if err != nil {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -367,6 +368,24 @@ func TestParser_IncludeRequiredQuotedClasspathNotError(t *testing.T) {
 	}
 	if !inc.Required {
 		t.Error("expected Required=true")
+	}
+}
+
+func TestParser_ErrorCarriesLineCol(t *testing.T) {
+	// Unclosed brace on line 1 — parser should return an error with line/col info.
+	_, err := parser.Parse("{ a = 1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *parser.Error
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *parser.Error, got %T: %v", err, err)
+	}
+	if pe.Line == 0 {
+		t.Error("expected Line > 0 in parser.Error")
+	}
+	if pe.Col == 0 {
+		t.Error("expected Col > 0 in parser.Error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Parser now returns structured `*parser.Error` with `Line`/`Col` fields instead of `fmt.Errorf` strings
- `parseWith()` extracts `Line`/`Col` via `errors.As` and maps to public `ParseError`
- All 19 error sites in `internal/parser/parser.go` updated
- `ParseError.Message` now contains only the description (e.g., `"unexpected EOF, expected '}'"`) — position info is in the struct fields

## Test plan
- [x] `TestParser_ErrorCarriesLineCol` — verifies internal `parser.Error` carries Line/Col > 0
- [x] `TestParseString_ErrorHasLineCol` — verifies public `ParseError` has Line/Col populated and Message has no prefix
- [x] Full test suite (5 packages) passes with zero regressions

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)