### PR TITLE
test: add auto-discovery lightbend conformance tests with expected JSON

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             testdata/expected
             .xx-hocon-version
-          key: xx-hocon-expected-${{ github.run_id }}
+          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
           restore-keys: xx-hocon-expected-
 
       - name: Fetch expected JSON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,18 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Cache expected JSON
+        uses: actions/cache@v4
+        with:
+          path: |
+            testdata/expected
+            .xx-hocon-version
+          key: xx-hocon-expected-${{ github.run_id }}
+          restore-keys: xx-hocon-expected-
+
+      - name: Fetch expected JSON
+        run: make testdata
+
       - name: Verify modules
         run: go mod verify
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ coverage.out
 # Claude Code (local-only settings)
 .claude/settings.local.json
 
+# Fetched test data (from xx.hocon)
+testdata/expected/
+
 # Superpowers (development process artifacts)
 docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ coverage.out
 # Fetched test data (from xx.hocon)
 testdata/expected/
 
+# xx.hocon version tracking (local cache marker)
+.xx-hocon-version
+
 # Superpowers (development process artifacts)
 docs/superpowers/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+TESTDATA_REPO  := o3co/xx.hocon
+TESTDATA_REF   := main
+EXPECTED_DIR   := testdata/expected
+
+.PHONY: testdata test
+
+testdata:
+	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
+	@rm -rf /tmp/xx-hocon-dl
+	@mkdir -p /tmp/xx-hocon-dl $(EXPECTED_DIR)
+	@gh api repos/$(TESTDATA_REPO)/tarball/$(TESTDATA_REF) > /tmp/xx-hocon-dl/archive.tar.gz
+	@tar xzf /tmp/xx-hocon-dl/archive.tar.gz -C /tmp/xx-hocon-dl --strip-components=1
+	@rsync -a /tmp/xx-hocon-dl/expected/hocon/ $(EXPECTED_DIR)/
+	@rm -rf /tmp/xx-hocon-dl
+	@echo "Done."
+
+test: testdata
+	go test ./... -count=1

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,20 @@ EXPECTED_DIR   := testdata/expected
 
 testdata:
 	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
-	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
-	  local_sha=$$(cat .xx-hocon-version); \
+	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
+	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \
 	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
 	  fi; \
 	fi; \
-	tmpdir="$$(mktemp -d)"; \
-	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
-	mkdir -p "$(EXPECTED_DIR)"; \
-	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
-	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
-	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
-	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	tmpdir="$$(mktemp -d)" && \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM && \
+	rm -rf "$(EXPECTED_DIR)" && \
+	mkdir -p "$(EXPECTED_DIR)" && \
+	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz" && \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1 && \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/" && \
+	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ EXPECTED_DIR   := testdata/expected
 
 testdata:
 	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
-	@rm -rf /tmp/xx-hocon-dl
-	@mkdir -p /tmp/xx-hocon-dl $(EXPECTED_DIR)
-	@gh api repos/$(TESTDATA_REPO)/tarball/$(TESTDATA_REF) > /tmp/xx-hocon-dl/archive.tar.gz
-	@tar xzf /tmp/xx-hocon-dl/archive.tar.gz -C /tmp/xx-hocon-dl --strip-components=1
-	@rsync -a /tmp/xx-hocon-dl/expected/hocon/ $(EXPECTED_DIR)/
-	@rm -rf /tmp/xx-hocon-dl
-	@echo "Done."
+	@tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
+	mkdir -p "$(EXPECTED_DIR)"; \
+	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
+	echo "Done."
 
-test: testdata
+test:
 	go test ./... -count=1

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,21 @@ EXPECTED_DIR   := testdata/expected
 .PHONY: testdata test
 
 testdata:
-	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
-	@tmpdir="$$(mktemp -d)"; \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
+	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
+	  local_sha=$$(cat .xx-hocon-version); \
+	  if [ "$$remote_sha" = "$$local_sha" ]; then \
+	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
+	  fi; \
+	fi; \
+	tmpdir="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
 	mkdir -p "$(EXPECTED_DIR)"; \
 	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
 	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
 	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
-	echo "Done."
+	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	echo "Done. Fetched $$(cat .xx-hocon-version)"
 
 test:
 	go test ./... -count=1

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -151,6 +151,9 @@ func TestLightbendExpected(t *testing.T) {
 
 	entries, err := os.ReadDir(expectedDir)
 	if err != nil {
+		if os.Getenv("CI") != "" {
+			t.Fatalf("expected JSON dir not found at %s in CI — fetch testdata before running tests: %v", expectedDir, err)
+		}
 		t.Skipf("expected JSON dir not found at %s — run `make testdata` first: %v", expectedDir, err)
 		return
 	}
@@ -223,7 +226,10 @@ func TestLightbendExpectedErrors(t *testing.T) {
 
 	entries, err := os.ReadDir(expectedDir)
 	if err != nil {
-		t.Skipf("expected dir not found — run `make testdata`")
+		if os.Getenv("CI") != "" {
+			t.Fatalf("expected JSON dir not found at %s in CI — fetch testdata before running tests: %v", expectedDir, err)
+		}
+		t.Skipf("expected dir not found at %s — run `make testdata` first: %v", expectedDir, err)
 		return
 	}
 

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -143,6 +143,113 @@ func jsonEqual(a, b any) bool {
 	return string(aj) == string(bj)
 }
 
+// TestLightbendExpected auto-discovers expected JSON files from xx.hocon
+// and compares parsed .conf output against them.
+func TestLightbendExpected(t *testing.T) {
+	confDir := "testdata/hocon"
+	expectedDir := "testdata/expected"
+
+	entries, err := os.ReadDir(expectedDir)
+	if err != nil {
+		t.Skipf("expected JSON dir not found at %s — run `make testdata` first: %v", expectedDir, err)
+		return
+	}
+
+	// Known failures — skip tests that cannot pass yet
+	skip := map[string]string{
+		"test01-expected.json":         "system section contains environment-dependent values",
+		"test02-expected.json":         "unresolved substitution for empty-key path",
+		"test03-expected.json":         "nested include substitution scope",
+		"test09-expected.json":         "object merge with substitution not fully propagated",
+		"test10-expected.json":         "nested include substitution scope",
+		"file-include-expected.json":   "extra keys from file include (bar-file, baz)",
+	}
+
+	for _, e := range entries {
+		name := e.Name()
+
+		if !strings.HasSuffix(name, "-expected.json") || strings.Contains(name, "-expected-error") {
+			continue
+		}
+		if reason, ok := skip[name]; ok {
+			t.Run(name, func(t *testing.T) {
+				t.Skipf("known failure: %s", reason)
+			})
+			continue
+		}
+
+		confName := strings.Replace(name, "-expected.json", ".conf", 1)
+		confPath := filepath.Join(confDir, confName)
+		expectedPath := filepath.Join(expectedDir, name)
+
+		t.Run(confName, func(t *testing.T) {
+			if _, err := os.Stat(confPath); os.IsNotExist(err) {
+				t.Skipf("conf not found: %s", confPath)
+				return
+			}
+
+			cfg, err := hocon.ParseFile(confPath)
+			if err != nil {
+				t.Fatalf("ParseFile: %v", err)
+			}
+
+			expectedData, err := os.ReadFile(expectedPath)
+			if err != nil {
+				t.Fatalf("ReadFile: %v", err)
+			}
+			var want any
+			if err := json.Unmarshal(expectedData, &want); err != nil {
+				t.Fatalf("parse expected JSON: %v", err)
+			}
+
+			got := make(map[string]any)
+			if err := cfg.Unmarshal(&got); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if !jsonEqual(got, want) {
+				gotJSON, _ := json.MarshalIndent(got, "", "  ")
+				wantJSON, _ := json.MarshalIndent(want, "", "  ")
+				t.Errorf("mismatch\ngot:\n%s\nwant:\n%s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// TestLightbendExpectedErrors auto-discovers expected error files.
+func TestLightbendExpectedErrors(t *testing.T) {
+	confDir := "testdata/hocon"
+	expectedDir := "testdata/expected"
+
+	entries, err := os.ReadDir(expectedDir)
+	if err != nil {
+		t.Skipf("expected dir not found — run `make testdata`")
+		return
+	}
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, "-expected-error.json") {
+			continue
+		}
+
+		confName := strings.Replace(name, "-expected-error.json", ".conf", 1)
+		confPath := filepath.Join(confDir, confName)
+
+		t.Run(confName+" should error", func(t *testing.T) {
+			if _, err := os.Stat(confPath); os.IsNotExist(err) {
+				t.Skipf("conf not found: %s", confPath)
+				return
+			}
+
+			_, err := hocon.ParseFile(confPath)
+			if err == nil {
+				t.Errorf("expected error for %s but got success", confPath)
+			}
+		})
+	}
+}
+
 // normalizeForJSON converts int64 values to float64 to match encoding/json's
 // default number type when unmarshaling into any.
 func normalizeForJSON(v any) any {

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -160,12 +160,12 @@ func TestLightbendExpected(t *testing.T) {
 
 	// Known failures — skip tests that cannot pass yet
 	skip := map[string]string{
-		"test01-expected.json":         "system section contains environment-dependent values",
-		"test02-expected.json":         "unresolved substitution for empty-key path",
-		"test03-expected.json":         "nested include substitution scope",
-		"test09-expected.json":         "object merge with substitution not fully propagated",
-		"test10-expected.json":         "nested include substitution scope",
-		"file-include-expected.json":   "extra keys from file include (bar-file, baz)",
+		"test01-expected.json":       "system section contains environment-dependent values",
+		"test02-expected.json":       "unresolved substitution for empty-key path",
+		"test03-expected.json":       "nested include substitution scope",
+		"test09-expected.json":       "object merge with substitution not fully propagated",
+		"test10-expected.json":       "nested include substitution scope",
+		"file-include-expected.json": "extra keys from file include (bar-file, baz)",
 	}
 
 	for _, e := range entries {

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -233,6 +233,7 @@ func TestLightbendExpectedErrors(t *testing.T) {
 		return
 	}
 
+	tested := 0
 	for _, e := range entries {
 		name := e.Name()
 		if !strings.HasSuffix(name, "-expected-error.json") {
@@ -253,6 +254,11 @@ func TestLightbendExpectedErrors(t *testing.T) {
 				t.Errorf("expected error for %s but got success", confPath)
 			}
 		})
+		tested++
+	}
+
+	if tested == 0 {
+		t.Error("No expected error tests were run. Check testdata/expected/")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `make testdata` to fetch expected JSON from [o3co/xx.hocon](https://github.com/o3co/xx.hocon)
- Add `TestLightbendExpected` and `TestLightbendExpectedErrors` auto-discovery tests
- 10 JSON comparison tests pass, 2 error tests pass, 5 skipped (known issues)

## Discovered issues
- test02: empty-string key substitution not resolved
- test09: object merge via substitution doesn't propagate all fields
- test01: `system.*` section has env-dependent values
- file-include: resolves extra keys vs reference implementation

## Test plan
- [x] `make testdata` fetches expected JSON
- [x] `go test -run TestLightbendExpected -v` passes (12 pass, 5 skip)
- [x] Full test suite passes with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)