### PR TITLE
fix: implement delayed merge for objects with prior substitution values (#40)

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -801,3 +801,55 @@ func TestConfig_GetConfigSliceOption_WrongElementType(t *testing.T) {
 		t.Error("expected None when array elements are not objects")
 	}
 }
+
+// --- Delayed merge / self-referential substitution tests ---
+
+func TestConfig_DelayedMergeObjectWithSubstitution(t *testing.T) {
+	// When a key is assigned a substitution (resolving to object) then overridden
+	// with a literal object, the two objects should be deep-merged (prior as base,
+	// current on top).
+	cfg, err := hocon.ParseString("x={q:10}\na=${x}\na={c:3}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.GetInt("a.q"); got != 10 {
+		t.Errorf("expected a.q=10, got %d", got)
+	}
+	if got := cfg.GetInt("a.c"); got != 3 {
+		t.Errorf("expected a.c=3, got %d", got)
+	}
+}
+
+func TestConfig_LastAssignmentWinsForSubstitution(t *testing.T) {
+	// When a key is overridden multiple times with substitutions, the last one wins.
+	// b=${x} then b=${y} → b should be 5 (the value of y), not {q:10}.
+	cfg, err := hocon.ParseString("x={q:10}\ny=5\nb=${x}\nb=${y}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.GetInt("b"); got != 5 {
+		t.Errorf("expected b=5, got %d", got)
+	}
+}
+
+func TestConfig_DelayedMergeNestedSubstitution(t *testing.T) {
+	// Nested delayed merge: c=${x} then c={d:600, e:${a}} where a itself
+	// is a delayed merge. The substitution lookup must also apply delayed merge.
+	cfg, err := hocon.ParseString("x={q:10}\na=${x}\na={c:3}\nc=${x}\nc={d:600,e:${a}}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// c should be deep-merge of {q:10} (from ${x}) and {d:600, e:{c:3,q:10}}
+	if got := cfg.GetInt("c.q"); got != 10 {
+		t.Errorf("expected c.q=10, got %d", got)
+	}
+	if got := cfg.GetInt("c.d"); got != 600 {
+		t.Errorf("expected c.d=600, got %d", got)
+	}
+	if got := cfg.GetInt("c.e.q"); got != 10 {
+		t.Errorf("expected c.e.q=10, got %d", got)
+	}
+	if got := cfg.GetInt("c.e.c"); got != 3 {
+		t.Errorf("expected c.e.c=3, got %d", got)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -295,6 +295,18 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 			return nil, err
 		}
 		if resolved != nil {
+			// Delayed merge (site 1): if both current and prior resolve to objects,
+			// deep-merge them (prior as base, current on top).
+			if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
+				if prior, hasPrior := obj.priorValues[k]; hasPrior {
+					priorResolved, perr := r.resolveVal(prior, root, k)
+					if perr == nil && priorResolved != nil {
+						if priorObj, pOk := priorResolved.(*ObjectVal); pOk {
+							resolved = deepMerge(resolvedObj, priorObj)
+						}
+					}
+				}
+			}
 			result.set(k, resolved)
 			// cache top-level resolved values to support self-referential substitutions
 			if obj == root {
@@ -367,10 +379,25 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 	segments := strings.Split(pathStr, ".")
 	val, ok := r.lookupPath(root, segments)
 	if ok {
-		// If the found value is still a placeholder (self-referential definition),
-		// use the prior value instead.
-		switch val.(type) {
-		case *substPlaceholder, *concatPlaceholder:
+		// If the found value is still a placeholder that references the SAME path
+		// (actual self-reference like b=${b}), use the prior value instead.
+		// A placeholder referencing a DIFFERENT path is not self-referential and
+		// should be resolved normally.
+		isSelfRef := false
+		switch v := val.(type) {
+		case *substPlaceholder:
+			if v.node.Path == pathStr {
+				isSelfRef = true
+			}
+		case *concatPlaceholder:
+			for _, cv := range v.vals {
+				if sp, spOk := cv.(*substPlaceholder); spOk && sp.node.Path == pathStr {
+					isSelfRef = true
+					break
+				}
+			}
+		}
+		if isSelfRef {
 			if prior, ok2 := r.priorValues[pathStr]; ok2 {
 				return r.resolveVal(prior, root, pathStr)
 			}
@@ -384,7 +411,45 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 				}
 			}
 		}
-		return r.resolveVal(val, root, pathStr)
+		resolved, err := r.resolveVal(val, root, pathStr)
+		if err != nil {
+			return nil, err
+		}
+		if resolved == nil {
+			// The looked-up value resolved to nil (e.g. optional substitution with
+			// missing env var). Check the target path's per-object priorValues for a
+			// fallback — this mirrors the fallback logic in resolveSubstitutions but
+			// applies when accessing the value via a substitution lookup.
+			if len(segments) > 0 {
+				var parentObj *ObjectVal
+				if len(segments) == 1 {
+					parentObj = root
+				} else {
+					parentObj, _ = r.lookupPathObj(root, segments[:len(segments)-1])
+				}
+				if parentObj != nil {
+					lastKey := segments[len(segments)-1]
+					if prior, pOk := parentObj.priorValues[lastKey]; pOk {
+						return r.resolveVal(prior, root, pathStr)
+					}
+				}
+			}
+		}
+		// Delayed merge (site 2): after resolving a substitution lookup, if the
+		// result is an object and there is a prior value that also resolves to an
+		// object, deep-merge them (prior as base, current on top).
+		if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
+			prior := r.findPrior(root, segments, pathStr)
+			if prior != nil {
+				priorResolved, perr := r.resolveVal(prior, root, pathStr)
+				if perr == nil && priorResolved != nil {
+					if priorObj, poOk := priorResolved.(*ObjectVal); poOk {
+						resolved = deepMerge(resolvedObj, priorObj)
+					}
+				}
+			}
+		}
+		return resolved, nil
 	}
 	// env var fallback
 	if ev, ok := os.LookupEnv(pathStr); ok {
@@ -394,6 +459,30 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 		return nil, nil // field will be dropped
 	}
 	return nil, &ResolveError{Message: "unresolved substitution", Path: pathStr, Line: n.Line(), Col: n.Col()}
+}
+
+// findPrior looks up the per-object priorValues for a given path in the tree.
+func (r *resolver) findPrior(root *ObjectVal, segments []string, pathStr string) Val {
+	// Check resolver-level priorValues first (top-level keys).
+	if prior, ok := r.priorValues[pathStr]; ok {
+		return prior
+	}
+	// Check the parent object's per-object priorValues for nested paths.
+	if len(segments) > 0 {
+		var parentObj *ObjectVal
+		if len(segments) == 1 {
+			parentObj = root
+		} else {
+			parentObj, _ = r.lookupPathObj(root, segments[:len(segments)-1])
+		}
+		if parentObj != nil {
+			lastKey := segments[len(segments)-1]
+			if prior, ok := parentObj.priorValues[lastKey]; ok {
+				return prior
+			}
+		}
+	}
+	return nil
 }
 
 func isSeparator(v Val) bool {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -300,7 +300,10 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 			if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
 				if prior, hasPrior := obj.priorValues[k]; hasPrior {
 					priorResolved, perr := r.resolveVal(prior, root, k)
-					if perr == nil && priorResolved != nil {
+					if perr != nil {
+						return nil, perr
+					}
+					if priorResolved != nil {
 						if priorObj, pOk := priorResolved.(*ObjectVal); pOk {
 							resolved = deepMerge(resolvedObj, priorObj)
 						}
@@ -438,13 +441,19 @@ func (r *resolver) resolveSubst(n *parser.SubstNode, root *ObjectVal) (Val, erro
 		// Delayed merge (site 2): after resolving a substitution lookup, if the
 		// result is an object and there is a prior value that also resolves to an
 		// object, deep-merge them (prior as base, current on top).
-		if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
-			prior := r.findPrior(root, segments, pathStr)
-			if prior != nil {
-				priorResolved, perr := r.resolveVal(prior, root, pathStr)
-				if perr == nil && priorResolved != nil {
-					if priorObj, poOk := priorResolved.(*ObjectVal); poOk {
-						resolved = deepMerge(resolvedObj, priorObj)
+		// Restricted to single-segment paths to avoid incorrect merges on nested paths.
+		if len(segments) == 1 {
+			if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
+				prior := r.findPrior(root, segments, pathStr)
+				if prior != nil {
+					priorResolved, perr := r.resolveVal(prior, root, pathStr)
+					if perr != nil {
+						return nil, perr
+					}
+					if priorResolved != nil {
+						if priorObj, poOk := priorResolved.(*ObjectVal); poOk {
+							resolved = deepMerge(resolvedObj, priorObj)
+						}
 					}
 				}
 			}

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -163,7 +163,6 @@ func TestLightbendExpected(t *testing.T) {
 		"test01-expected.json":       "system section contains environment-dependent values",
 		"test02-expected.json":       "unresolved substitution for empty-key path",
 		"test03-expected.json":       "nested include substitution scope",
-		"test09-expected.json":       "object merge with substitution not fully propagated",
 		"test10-expected.json":       "nested include substitution scope",
 		"file-include-expected.json": "extra keys from file include (bar-file, baz)",
 	}


### PR DESCRIPTION
## Summary
- Fix self-referential substitution detection: only fall back to priorValues when the substitution path actually matches
- Implement delayed merge in resolveSubstitutions AND resolveSubst: when both current and prior resolve to objects, deep merge them
- test09 conformance now passes against Lightbend reference expected JSON

## Test plan
- [x] 3 new delayed merge tests pass
- [x] Lightbend test09 expected JSON comparison passes
- [x] Full test suite passes with zero regressions

Closes #40

��� Generated with [Claude Code](https://claude.com/claude-code)