### PR TITLE
fix: convert substPlaceholder to use segments array

### DIFF
--- a/internal/resolver/path.go
+++ b/internal/resolver/path.go
@@ -86,7 +86,7 @@ func needsQuoting(s string) bool {
 }
 
 // segmentsToKey produces a canonical string from path segments.
-// Segments containing dots or that are empty strings are quoted.
+// Segments that are empty or contain chars outside letter/digit/hyphen/underscore are quoted.
 func segmentsToKey(segments []string) string {
 	parts := make([]string, len(segments))
 	for i, s := range segments {

--- a/internal/resolver/path.go
+++ b/internal/resolver/path.go
@@ -28,11 +28,17 @@ func parseSubstPath(raw string) []string {
 		case '"':
 			// Quoted segment
 			i++ // skip opening quote
-			start := i
+			var seg strings.Builder
 			for i < len(raw) && raw[i] != '"' {
-				i++
+				if raw[i] == '\\' && i+1 < len(raw) {
+					seg.WriteByte(raw[i+1])
+					i += 2
+				} else {
+					seg.WriteByte(raw[i])
+					i++
+				}
 			}
-			segments = append(segments, raw[start:i])
+			segments = append(segments, seg.String())
 			if i < len(raw) {
 				i++ // skip closing quote
 			}
@@ -67,8 +73,10 @@ func parseSubstPath(raw string) []string {
 func segmentsToKey(segments []string) string {
 	parts := make([]string, len(segments))
 	for i, s := range segments {
-		if s == "" || strings.ContainsAny(s, ".\"") {
-			parts[i] = `"` + s + `"`
+		if s == "" || strings.ContainsAny(s, ".\"\\") {
+			escaped := strings.ReplaceAll(s, `\`, `\\`)
+			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+			parts[i] = `"` + escaped + `"`
 		} else {
 			parts[i] = s
 		}

--- a/internal/resolver/path.go
+++ b/internal/resolver/path.go
@@ -24,7 +24,8 @@ func parseSubstPath(raw string) []string {
 			break
 		}
 
-		if raw[i] == '"' {
+		switch raw[i] {
+		case '"':
 			// Quoted segment
 			i++ // skip opening quote
 			start := i
@@ -42,11 +43,11 @@ func parseSubstPath(raw string) []string {
 			if i < len(raw) && raw[i] == '.' {
 				i++
 			}
-		} else if raw[i] == '.' {
+		case '.':
 			// Dot at start or after dot means empty-string segment
 			segments = append(segments, "")
 			i++
-		} else {
+		default:
 			// Unquoted segment - read until dot or end
 			start := i
 			for i < len(raw) && raw[i] != '.' {

--- a/internal/resolver/path.go
+++ b/internal/resolver/path.go
@@ -8,7 +8,10 @@
 
 package resolver
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // parseSubstPath parses a substitution path string into segments,
 // handling quoted identifiers that may contain dots.
@@ -30,7 +33,7 @@ func parseSubstPath(raw string) []string {
 			i++ // skip opening quote
 			var seg strings.Builder
 			for i < len(raw) && raw[i] != '"' {
-				if raw[i] == '\\' && i+1 < len(raw) {
+				if raw[i] == '\\' && i+1 < len(raw) && (raw[i+1] == '"' || raw[i+1] == '\\') {
 					seg.WriteByte(raw[i+1])
 					i += 2
 				} else {
@@ -68,12 +71,26 @@ func parseSubstPath(raw string) []string {
 	return segments
 }
 
+// needsQuoting returns true if a segment must be quoted in a key string.
+// Matches Lightbend's hasFunkyChars: any char that is not letter/digit/hyphen/underscore.
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for _, c := range s {
+		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '-' && c != '_' {
+			return true
+		}
+	}
+	return false
+}
+
 // segmentsToKey produces a canonical string from path segments.
 // Segments containing dots or that are empty strings are quoted.
 func segmentsToKey(segments []string) string {
 	parts := make([]string, len(segments))
 	for i, s := range segments {
-		if s == "" || strings.ContainsAny(s, ".\"\\") {
+		if needsQuoting(s) {
 			escaped := strings.ReplaceAll(s, `\`, `\\`)
 			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 			parts[i] = `"` + escaped + `"`

--- a/internal/resolver/path.go
+++ b/internal/resolver/path.go
@@ -1,0 +1,76 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+import "strings"
+
+// parseSubstPath parses a substitution path string into segments,
+// handling quoted identifiers that may contain dots.
+func parseSubstPath(raw string) []string {
+	var segments []string
+	i := 0
+	for i < len(raw) {
+		// Skip whitespace
+		for i < len(raw) && (raw[i] == ' ' || raw[i] == '\t') {
+			i++
+		}
+		if i >= len(raw) {
+			break
+		}
+
+		if raw[i] == '"' {
+			// Quoted segment
+			i++ // skip opening quote
+			start := i
+			for i < len(raw) && raw[i] != '"' {
+				i++
+			}
+			segments = append(segments, raw[start:i])
+			if i < len(raw) {
+				i++ // skip closing quote
+			}
+			// Skip whitespace and dot separator
+			for i < len(raw) && (raw[i] == ' ' || raw[i] == '\t') {
+				i++
+			}
+			if i < len(raw) && raw[i] == '.' {
+				i++
+			}
+		} else if raw[i] == '.' {
+			// Dot at start or after dot means empty-string segment
+			segments = append(segments, "")
+			i++
+		} else {
+			// Unquoted segment - read until dot or end
+			start := i
+			for i < len(raw) && raw[i] != '.' {
+				i++
+			}
+			segments = append(segments, strings.TrimSpace(raw[start:i]))
+			if i < len(raw) && raw[i] == '.' {
+				i++
+			}
+		}
+	}
+	return segments
+}
+
+// segmentsToKey produces a canonical string from path segments.
+// Segments containing dots or that are empty strings are quoted.
+func segmentsToKey(segments []string) string {
+	parts := make([]string, len(segments))
+	for i, s := range segments {
+		if s == "" || strings.ContainsAny(s, ".\"") {
+			parts[i] = `"` + s + `"`
+		} else {
+			parts[i] = s
+		}
+	}
+	return strings.Join(parts, ".")
+}

--- a/internal/resolver/path_test.go
+++ b/internal/resolver/path_test.go
@@ -56,6 +56,8 @@ func TestRoundtrip(t *testing.T) {
 		{"a.b", "c"},
 		{"", "x", ""},
 		{"a.b.c", "d.e"},
+		{`a"b`, "c"},
+		{`a\b`, "c"},
 	}
 	for _, segs := range cases {
 		key := segmentsToKey(segs)
@@ -68,5 +70,46 @@ func TestRoundtrip(t *testing.T) {
 				t.Fatalf("roundtrip %v → %q → %v", segs, key, got)
 			}
 		}
+	}
+}
+
+func TestParseSubstPath_EscapedQuotes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{`"a\"b".c`, []string{`a"b`, "c"}},
+		{`"a\\b".c`, []string{`a\b`, "c"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseSubstPath(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("parseSubstPath(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Fatalf("parseSubstPath(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSegmentsToKey_EscapedQuotes(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected string
+	}{
+		{[]string{`a"b`, "c"}, `"a\"b".c`},
+		{[]string{`a\b`, "c"}, `"a\\b".c`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := segmentsToKey(tt.input)
+			if got != tt.expected {
+				t.Fatalf("segmentsToKey(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/resolver/path_test.go
+++ b/internal/resolver/path_test.go
@@ -1,0 +1,72 @@
+package resolver
+
+import (
+	"testing"
+)
+
+func TestParseSubstPath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"a.b.c", []string{"a", "b", "c"}},
+		{`"a.b".c`, []string{"a.b", "c"}},
+		{`"".foo`, []string{"", "foo"}},
+		{"x", []string{"x"}},
+		{`"a.b"."c.d"`, []string{"a.b", "c.d"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseSubstPath(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("parseSubstPath(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Fatalf("parseSubstPath(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSegmentsToKey(t *testing.T) {
+	tests := []struct {
+		input    []string
+		expected string
+	}{
+		{[]string{"a", "b", "c"}, "a.b.c"},
+		{[]string{"a.b", "c"}, `"a.b".c`},
+		{[]string{"", "foo"}, `"".foo`},
+		{[]string{"x"}, "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := segmentsToKey(tt.input)
+			if got != tt.expected {
+				t.Fatalf("segmentsToKey(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	cases := [][]string{
+		{"a", "b"},
+		{"a.b", "c"},
+		{"", "x", ""},
+		{"a.b.c", "d.e"},
+	}
+	for _, segs := range cases {
+		key := segmentsToKey(segs)
+		got := parseSubstPath(key)
+		if len(got) != len(segs) {
+			t.Fatalf("roundtrip %v → %q → %v", segs, key, got)
+		}
+		for i := range got {
+			if got[i] != segs[i] {
+				t.Fatalf("roundtrip %v → %q → %v", segs, key, got)
+			}
+		}
+	}
+}

--- a/internal/resolver/path_test.go
+++ b/internal/resolver/path_test.go
@@ -96,6 +96,28 @@ func TestParseSubstPath_EscapedQuotes(t *testing.T) {
 	}
 }
 
+func TestParseSubstPath_PreservesUnknownEscapes(t *testing.T) {
+	// \n inside quotes should be preserved as literal \n
+	got := parseSubstPath(`"a\nb"`)
+	expected := []string{"a\\nb"}
+	if len(got) != 1 || got[0] != expected[0] {
+		t.Fatalf("parseSubstPath preserves unknown escapes: got %v, want %v", got, expected)
+	}
+}
+
+func TestSegmentsToKey_QuotesWhitespace(t *testing.T) {
+	got := segmentsToKey([]string{" a ", "b"})
+	expected := `" a ".b`
+	if got != expected {
+		t.Fatalf("segmentsToKey whitespace: got %q, want %q", got, expected)
+	}
+	// roundtrip
+	parsed := parseSubstPath(got)
+	if len(parsed) != 2 || parsed[0] != " a " || parsed[1] != "b" {
+		t.Fatalf("roundtrip whitespace: got %v", parsed)
+	}
+}
+
 func TestSegmentsToKey_EscapedQuotes(t *testing.T) {
 	tests := []struct {
 		input    []string

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -239,7 +239,7 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					}
 				} else {
 					// non-object overwrite: save prior value for self-referential substitution support
-					r.priorValues[key] = existing
+					r.priorValues[segmentsToKey([]string{key})] = existing
 					obj.priorValues[key] = existing // per-object scope for optional-substitution fallback
 				}
 				// non-object: last value wins (fall through to obj.set below)
@@ -504,13 +504,6 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 	// env var fallback
 	if ev, ok := os.LookupEnv(segmentsToKey(s.segments)); ok {
 		return &ScalarVal{V: ev}, nil
-	}
-	// For relativized paths, also try env var with original path
-	if s.prefixLen > 0 && len(segments) > s.prefixLen {
-		originalKey := segmentsToKey(segments[s.prefixLen:])
-		if ev, ok := os.LookupEnv(originalKey); ok {
-			return &ScalarVal{V: ev}, nil
-		}
 	}
 	if n.Optional {
 		return nil, nil // field will be dropped
@@ -821,17 +814,15 @@ func relativizeVals(obj *ObjectVal, prefixSegments []string) {
 func relativizeVal(v Val, prefixSegments []string) Val {
 	switch vv := v.(type) {
 	case *substPlaceholder:
-		if vv.prefixLen == 0 {
-			// Create a new SubstNode with the relativized path.
-			newNode := &parser.SubstNode{}
-			*newNode = *vv.node
-			newSegments := make([]string, 0, len(prefixSegments)+len(vv.segments))
-			newSegments = append(newSegments, prefixSegments...)
-			newSegments = append(newSegments, vv.segments...)
-			newNode.Path = segmentsToKey(newSegments)
-			return &substPlaceholder{node: newNode, segments: newSegments, prefixLen: len(prefixSegments)}
-		}
-		return v
+		// Create a new SubstNode with the relativized path.
+		// Accumulate prefixLen so multi-layer includes compose correctly.
+		newNode := &parser.SubstNode{}
+		*newNode = *vv.node
+		newSegments := make([]string, 0, len(prefixSegments)+len(vv.segments))
+		newSegments = append(newSegments, prefixSegments...)
+		newSegments = append(newSegments, vv.segments...)
+		newNode.Path = segmentsToKey(newSegments)
+		return &substPlaceholder{node: newNode, segments: newSegments, prefixLen: vv.prefixLen + len(prefixSegments)}
 	case *concatPlaceholder:
 		newVals := make([]Val, len(vv.vals))
 		for i, cv := range vv.vals {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -495,14 +495,14 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 			}
 			return resolved, nil
 		}
-		// Also try env var with original path
-		if ev, ok := os.LookupEnv(originalKey); ok {
+		// Also try env var with original path (raw dot-join, no quoting)
+		if ev, ok := os.LookupEnv(strings.Join(originalSegments, ".")); ok {
 			return &ScalarVal{V: ev}, nil
 		}
 	}
 
-	// env var fallback
-	if ev, ok := os.LookupEnv(segmentsToKey(s.segments)); ok {
+	// env var fallback — use raw dot-join (no quoting) to match Lightbend behavior
+	if ev, ok := os.LookupEnv(strings.Join(s.segments, ".")); ok {
 		return &ScalarVal{V: ev}, nil
 	}
 	if n.Optional {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -269,7 +270,7 @@ func (r *resolver) resolveNode(node parser.Node, ctx *ObjectVal, pathPrefix []st
 		return arr, nil
 	case *parser.SubstNode:
 		// leave substitution nodes for second pass
-		return &substPlaceholder{node: n}, nil
+		return &substPlaceholder{node: n, segments: parseSubstPath(n.Path)}, nil
 	case *parser.ConcatNode:
 		return r.resolveConcatPartial(n, ctx, pathPrefix)
 	case *parser.IncludeNode:
@@ -282,7 +283,8 @@ func (r *resolver) resolveNode(node parser.Node, ctx *ObjectVal, pathPrefix []st
 // substPlaceholder is a temporary stand-in for unresolved substitutions.
 type substPlaceholder struct {
 	node      *parser.SubstNode
-	prefixLen int // 0 for normal, >0 for relativized (number of prefix segments)
+	segments  []string // path segments — source of truth
+	prefixLen int      // 0 for normal, >0 for relativized (number of prefix segments)
 }
 
 func (s *substPlaceholder) val() {}
@@ -378,27 +380,28 @@ func (r *resolver) resolveVal(v Val, root *ObjectVal, path string) (Val, error) 
 
 func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, error) {
 	n := s.node
-	pathStr := n.Path
-	if r.resolving[pathStr] {
+	key := segmentsToKey(s.segments)
+	segments := s.segments
+
+	if r.resolving[key] {
 		// Check if a previously resolved value exists (self-referential substitution).
 		// e.g. path=${path}["/extra"] — the ${path} should resolve to the prior value.
-		if cached, ok := r.resolvedCache[pathStr]; ok {
+		if cached, ok := r.resolvedCache[key]; ok {
 			return cached, nil
 		}
 		// Check for prior (pre-overwrite) value saved during first pass.
-		if prior, ok := r.priorValues[pathStr]; ok {
+		if prior, ok := r.priorValues[key]; ok {
 			// Resolve the prior value (it may itself contain placeholders).
-			return r.resolveVal(prior, root, pathStr)
+			return r.resolveVal(prior, root, key)
 		}
 		if !n.Optional {
-			return nil, &ResolveError{Message: "circular reference detected", Path: pathStr, Line: n.Line(), Col: n.Col()}
+			return nil, &ResolveError{Message: "circular reference detected", Path: key, Line: n.Line(), Col: n.Col()}
 		}
 		return nil, nil
 	}
-	r.resolving[pathStr] = true
-	defer delete(r.resolving, pathStr)
+	r.resolving[key] = true
+	defer delete(r.resolving, key)
 
-	segments := strings.Split(pathStr, ".")
 	val, ok := r.lookupPath(root, segments)
 	if ok {
 		// If the found value is still a placeholder that references the SAME path
@@ -408,32 +411,32 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		isSelfRef := false
 		switch v := val.(type) {
 		case *substPlaceholder:
-			if v.node.Path == pathStr {
+			if slices.Equal(v.segments, s.segments) {
 				isSelfRef = true
 			}
 		case *concatPlaceholder:
 			for _, cv := range v.vals {
-				if sp, spOk := cv.(*substPlaceholder); spOk && sp.node.Path == pathStr {
+				if sp, spOk := cv.(*substPlaceholder); spOk && slices.Equal(sp.segments, s.segments) {
 					isSelfRef = true
 					break
 				}
 			}
 		}
 		if isSelfRef {
-			if prior, ok2 := r.priorValues[pathStr]; ok2 {
-				return r.resolveVal(prior, root, pathStr)
+			if prior, ok2 := r.priorValues[key]; ok2 {
+				return r.resolveVal(prior, root, key)
 			}
 			// For nested paths, check the parent object's per-object priorValues.
 			if len(segments) > 1 {
 				if parent, pok := r.lookupPathObj(root, segments[:len(segments)-1]); pok {
 					lastKey := segments[len(segments)-1]
 					if prior2, ok3 := parent.priorValues[lastKey]; ok3 {
-						return r.resolveVal(prior2, root, pathStr)
+						return r.resolveVal(prior2, root, key)
 					}
 				}
 			}
 		}
-		resolved, err := r.resolveVal(val, root, pathStr)
+		resolved, err := r.resolveVal(val, root, key)
 		if err != nil {
 			return nil, err
 		}
@@ -452,7 +455,7 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 				if parentObj != nil {
 					lastKey := segments[len(segments)-1]
 					if prior, pOk := parentObj.priorValues[lastKey]; pOk {
-						return r.resolveVal(prior, root, pathStr)
+						return r.resolveVal(prior, root, key)
 					}
 				}
 			}
@@ -463,9 +466,9 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		// Restricted to single-segment paths to avoid incorrect merges on nested paths.
 		if len(segments) == 1 {
 			if resolvedObj, rOk := resolved.(*ObjectVal); rOk {
-				prior := r.findPrior(root, segments, pathStr)
+				prior := r.findPrior(root, segments, key)
 				if prior != nil {
-					priorResolved, perr := r.resolveVal(prior, root, pathStr)
+					priorResolved, perr := r.resolveVal(prior, root, key)
 					if perr != nil {
 						return nil, perr
 					}
@@ -482,30 +485,30 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 
 	// Relativized path not found — fall back to original (non-relativized) path.
 	if s.prefixLen > 0 && len(segments) > s.prefixLen {
-		originalPath := strings.Join(segments[s.prefixLen:], ".")
 		originalSegments := segments[s.prefixLen:]
+		originalKey := segmentsToKey(originalSegments)
 		origVal, origOk := r.lookupPath(root, originalSegments)
 		if origOk {
-			resolved, err := r.resolveVal(origVal, root, originalPath)
+			resolved, err := r.resolveVal(origVal, root, originalKey)
 			if err != nil {
 				return nil, err
 			}
 			return resolved, nil
 		}
 		// Also try env var with original path
-		if ev, ok := os.LookupEnv(originalPath); ok {
+		if ev, ok := os.LookupEnv(originalKey); ok {
 			return &ScalarVal{V: ev}, nil
 		}
 	}
 
 	// env var fallback
-	if ev, ok := os.LookupEnv(pathStr); ok {
+	if ev, ok := os.LookupEnv(segmentsToKey(s.segments)); ok {
 		return &ScalarVal{V: ev}, nil
 	}
 	// For relativized paths, also try env var with original path
 	if s.prefixLen > 0 && len(segments) > s.prefixLen {
-		originalPath := strings.Join(segments[s.prefixLen:], ".")
-		if ev, ok := os.LookupEnv(originalPath); ok {
+		originalKey := segmentsToKey(segments[s.prefixLen:])
+		if ev, ok := os.LookupEnv(originalKey); ok {
 			return &ScalarVal{V: ev}, nil
 		}
 	}
@@ -517,7 +520,7 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		// substitutions as placeholders for the parent resolver to handle.
 		return s, nil
 	}
-	return nil, &ResolveError{Message: "unresolved substitution", Path: pathStr, Line: n.Line(), Col: n.Col()}
+	return nil, &ResolveError{Message: "unresolved substitution", Path: key, Line: n.Line(), Col: n.Col()}
 }
 
 // findPrior looks up the per-object priorValues for a given path in the tree.
@@ -797,48 +800,50 @@ func (r *resolver) resolveInclude(inc *parser.IncludeNode, pathPrefix []string) 
 	// Relativize substitution placeholders in the included object so that
 	// paths like ${x} become ${prefix.x} when included under a nested scope.
 	if len(pathPrefix) > 0 {
-		prefix := strings.Join(pathPrefix, ".")
-		relativizeVals(included, prefix, len(pathPrefix))
+		relativizeVals(included, pathPrefix)
 	}
 
 	return included, nil
 }
 
-// relativizeVals recursively walks all values in obj and prepends prefix to
+// relativizeVals recursively walks all values in obj and prepends prefix segments to
 // any substPlaceholder paths, recording prefixLen so the resolver can fall
 // back to the original (non-relativized) path if the relativized one is not found.
-func relativizeVals(obj *ObjectVal, prefix string, prefixLen int) {
+func relativizeVals(obj *ObjectVal, prefixSegments []string) {
 	for _, k := range obj.keys {
-		obj.values[k] = relativizeVal(obj.values[k], prefix, prefixLen)
+		obj.values[k] = relativizeVal(obj.values[k], prefixSegments)
 	}
 	for k, v := range obj.priorValues {
-		obj.priorValues[k] = relativizeVal(v, prefix, prefixLen)
+		obj.priorValues[k] = relativizeVal(v, prefixSegments)
 	}
 }
 
-func relativizeVal(v Val, prefix string, prefixLen int) Val {
+func relativizeVal(v Val, prefixSegments []string) Val {
 	switch vv := v.(type) {
 	case *substPlaceholder:
 		if vv.prefixLen == 0 {
 			// Create a new SubstNode with the relativized path.
 			newNode := &parser.SubstNode{}
 			*newNode = *vv.node
-			newNode.Path = prefix + "." + vv.node.Path
-			return &substPlaceholder{node: newNode, prefixLen: prefixLen}
+			newSegments := make([]string, 0, len(prefixSegments)+len(vv.segments))
+			newSegments = append(newSegments, prefixSegments...)
+			newSegments = append(newSegments, vv.segments...)
+			newNode.Path = segmentsToKey(newSegments)
+			return &substPlaceholder{node: newNode, segments: newSegments, prefixLen: len(prefixSegments)}
 		}
 		return v
 	case *concatPlaceholder:
 		newVals := make([]Val, len(vv.vals))
 		for i, cv := range vv.vals {
-			newVals[i] = relativizeVal(cv, prefix, prefixLen)
+			newVals[i] = relativizeVal(cv, prefixSegments)
 		}
 		return &concatPlaceholder{vals: newVals}
 	case *ObjectVal:
-		relativizeVals(vv, prefix, prefixLen)
+		relativizeVals(vv, prefixSegments)
 		return vv
 	case *ArrayVal:
 		for i, elem := range vv.Elements {
-			vv.Elements[i] = relativizeVal(elem, prefix, prefixLen)
+			vv.Elements[i] = relativizeVal(elem, prefixSegments)
 		}
 		return vv
 	default:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -333,7 +333,7 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 			result.set(k, resolved)
 			// cache top-level resolved values to support self-referential substitutions
 			if obj == root {
-				r.resolvedCache[k] = resolved
+				r.resolvedCache[segmentsToKey([]string{k})] = resolved
 			}
 		} else if prior, ok := obj.priorValues[k]; ok {
 			// optional substitution resolved to nothing — fall back to prior value (per-object scope)
@@ -344,7 +344,7 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 			if fallback != nil {
 				result.set(k, fallback)
 				if obj == root {
-					r.resolvedCache[k] = fallback
+					r.resolvedCache[segmentsToKey([]string{k})] = fallback
 				}
 			}
 		}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -218,7 +218,7 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 			}
 			existArr, ok := existing.(*ArrayVal)
 			if !ok {
-				return nil, &ResolveError{Message: "'+=' on non-array value", Path: strings.Join(field.Key, ".")}
+				return nil, &ResolveError{Message: "'+=' on non-array value", Path: segmentsToKey(field.Key)}
 			}
 			newArr, ok2 := val.(*ArrayVal)
 			if !ok2 {
@@ -725,7 +725,7 @@ func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val) {
 				}
 			} else {
 				// non-object overwrite: save prior value for self-referential substitution support
-				r.priorValues[strings.Join(segments, ".")] = existing
+				r.priorValues[segmentsToKey(segments)] = existing
 			}
 		}
 		obj.set(key, val)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -823,3 +823,79 @@ wrapper { include "child.conf" }
 		t.Errorf("expected a='from-root', got %v", sv.V)
 	}
 }
+
+// lookupObj navigates into a nested ObjectVal using a dot-separated key.
+// Each segment is looked up as a direct key first (for quoted keys like "a.b"),
+// falling back to nested traversal.
+func lookupObj(t *testing.T, res *resolver.Result, key string) *resolver.ObjectVal {
+	t.Helper()
+	// Try direct key first (handles quoted keys like "a.b")
+	v, ok := res.Root.Get(key)
+	if ok {
+		obj, isObj := v.(*resolver.ObjectVal)
+		if isObj {
+			return obj
+		}
+	}
+	// Fall back to dot-separated traversal
+	parts := strings.Split(key, ".")
+	cur := res.Root
+	for _, p := range parts {
+		val, found := cur.Get(p)
+		if !found {
+			t.Fatalf("key %q not found while looking up %q", p, key)
+		}
+		obj, isObj := val.(*resolver.ObjectVal)
+		if !isObj {
+			t.Fatalf("value at %q is %T, not ObjectVal", p, val)
+		}
+		cur = obj
+	}
+	return cur
+}
+
+func assertScalar(t *testing.T, obj *resolver.ObjectVal, key string, expected any) {
+	t.Helper()
+	v, ok := obj.Get(key)
+	if !ok {
+		t.Fatalf("key %q not found", key)
+	}
+	sv, ok := v.(*resolver.ScalarVal)
+	if !ok {
+		t.Fatalf("key %q: expected ScalarVal, got %T", key, v)
+	}
+	if sv.V != expected {
+		t.Errorf("key %q: expected %v (%T), got %v (%T)", key, expected, expected, sv.V, sv.V)
+	}
+}
+
+func TestResolver_IncludeRelativizeQuotedKeyWithDots(t *testing.T) {
+	// When a file is included under a quoted key containing dots (like "a.b"),
+	// substitutions referencing external values must be correctly relativized.
+	// The path prefix ["a.b"] must NOT be joined with "." naively — that would
+	// produce "a.b.ext" which splits into ["a","b","ext"] instead of ["a.b","ext"].
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "child.conf"), `val = ${ext}`)
+
+	res := resolveWithDir(t, `
+"a.b" {
+  ext = "hello"
+  include "child.conf"
+}
+`, dir)
+	ab := lookupObj(t, res, "a.b")
+	assertScalar(t, ab, "ext", "hello")
+	assertScalar(t, ab, "val", "hello")
+}
+
+func TestResolver_EnvFallbackQuotedKeyPrefix(t *testing.T) {
+	// Env var fallback for substitutions under a quoted-dot key prefix.
+	// ${MY_VAR} included under "a.b" is relativized to "a.b".MY_VAR.
+	// The env lookup must try the original key MY_VAR (not "a.b".MY_VAR).
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "child.conf"), `val = ${MY_VAR}`)
+	t.Setenv("MY_VAR", "ok")
+	res := resolveWithDir(t, `"a.b" { include "child.conf" }`, dir)
+	ab := lookupObj(t, res, "a.b")
+	assertScalar(t, ab, "val", "ok")
+}


### PR DESCRIPTION
## Summary

- Add `parseSubstPath` (quote-aware path parser) and `segmentsToKey` helpers in new `path.go`
- Convert `substPlaceholder` to store `segments []string` as source of truth
- Replace all `strings.Split(pathStr, ".")` with segment-based access in resolver
- Relativization uses segment array concat instead of string join — fixes quoted-key dot ambiguity
- Add `\"` / `\\` escape support (matches Lightbend reference implementation)
- Fix `priorValues` key and error path to use `segmentsToKey`

## Test plan

- [x] New tests for `parseSubstPath` and `segmentsToKey` (parsing, serialization, escaping, roundtrip)
- [x] New tests for quoted-key include relativization (`"a.b" { include "child.conf" }`)
- [x] New tests for env var fallback with quoted-key prefix
- [x] All existing tests pass with `-race`
- [x] golangci-lint: 0 issues

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>