### PR TITLE
refactor: store scalars as raw string + type discriminant

### DIFF
--- a/config.go
+++ b/config.go
@@ -219,8 +219,8 @@ func (c *Config) GetFloat32Option(path string) Option[float32] {
 
 func (c *Config) GetBool(path string) bool {
 	sv := c.getScalar(path)
-	parsed, err := strconv.ParseBool(sv.Raw)
-	if err != nil {
+	parsed, ok := parseBool(sv.Raw)
+	if !ok {
 		panicConfig(path, fmt.Sprintf("expected bool, got %q", sv.Raw))
 	}
 	return parsed
@@ -235,10 +235,26 @@ func (c *Config) GetBoolOption(path string) Option[bool] {
 	if !ok2 || sv.Type == resolver.ScalarNull {
 		return None[bool]()
 	}
-	if parsed, err := strconv.ParseBool(sv.Raw); err == nil {
+	if parsed, ok3 := parseBool(sv.Raw); ok3 {
 		return Some(parsed)
 	}
 	return None[bool]()
+}
+
+// parseBool parses a boolean string per the HOCON spec.
+// Accepted values (case-insensitive): true, yes, on → true; false, no, off → false.
+// Falls back to strconv.ParseBool for 1/0/t/f/T/F compatibility.
+func parseBool(s string) (bool, bool) {
+	switch strings.ToLower(s) {
+	case "true", "yes", "on":
+		return true, true
+	case "false", "no", "off":
+		return false, true
+	}
+	if v, err := strconv.ParseBool(s); err == nil {
+		return v, true
+	}
+	return false, false
 }
 
 // ── duration ──────────────────────────────────────────────────────

--- a/config.go
+++ b/config.go
@@ -117,7 +117,7 @@ func (c *Config) Keys() []string {
 
 // ── scalar getters ────────────────────────────────────────────────
 
-func (c *Config) getScalar(path string) any {
+func (c *Config) getScalar(path string) *resolver.ScalarVal {
 	v, ok := c.lookup(path)
 	if !ok {
 		panicConfig(path, "key not found")
@@ -126,19 +126,15 @@ func (c *Config) getScalar(path string) any {
 	if !ok {
 		panicConfig(path, fmt.Sprintf("expected scalar, got %T", v))
 	}
-	if sv.V == nil {
+	if sv.Type == resolver.ScalarNull {
 		panicConfig(path, "value is null")
 	}
-	return sv.V
+	return sv
 }
 
 func (c *Config) GetString(path string) string {
-	v := c.getScalar(path)
-	s, ok := v.(string)
-	if !ok {
-		panicConfig(path, fmt.Sprintf("expected string, got %T", v))
-	}
-	return s
+	sv := c.getScalar(path)
+	return sv.Raw
 }
 
 func (c *Config) GetStringOption(path string) Option[string] {
@@ -147,31 +143,19 @@ func (c *Config) GetStringOption(path string) Option[string] {
 		return None[string]()
 	}
 	sv, ok := v.(*resolver.ScalarVal)
-	if !ok || sv.V == nil {
+	if !ok || sv.Type == resolver.ScalarNull {
 		return None[string]()
 	}
-	s, ok := sv.V.(string)
-	if !ok {
-		return None[string]()
-	}
-	return Some(s)
+	return Some(sv.Raw)
 }
 
 func (c *Config) GetInt64(path string) int64 {
-	v := c.getScalar(path)
-	switch n := v.(type) {
-	case int64:
-		return n
-	case string:
-		parsed, err := strconv.ParseInt(n, 10, 64)
-		if err != nil {
-			panicConfig(path, fmt.Sprintf("expected int64, got string %q", n))
-		}
-		return parsed
-	default:
-		panicConfig(path, fmt.Sprintf("expected int64, got %T", v))
+	sv := c.getScalar(path)
+	parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+	if err != nil {
+		panicConfig(path, fmt.Sprintf("expected int64, got %q", sv.Raw))
 	}
-	panic("unreachable")
+	return parsed
 }
 
 func (c *Config) GetInt64Option(path string) Option[int64] {
@@ -180,16 +164,11 @@ func (c *Config) GetInt64Option(path string) Option[int64] {
 		return None[int64]()
 	}
 	sv, ok2 := v.(*resolver.ScalarVal)
-	if !ok2 || sv.V == nil {
+	if !ok2 || sv.Type == resolver.ScalarNull {
 		return None[int64]()
 	}
-	switch n := sv.V.(type) {
-	case int64:
-		return Some(n)
-	case string:
-		if parsed, err := strconv.ParseInt(n, 10, 64); err == nil {
-			return Some(parsed)
-		}
+	if parsed, err := strconv.ParseInt(sv.Raw, 10, 64); err == nil {
+		return Some(parsed)
 	}
 	return None[int64]()
 }
@@ -205,21 +184,12 @@ func (c *Config) GetIntOption(path string) Option[int] {
 }
 
 func (c *Config) GetFloat64(path string) float64 {
-	v := c.getScalar(path)
-	switch f := v.(type) {
-	case float64:
-		return f
-	case int64:
-		return float64(f)
-	case string:
-		parsed, err := strconv.ParseFloat(f, 64)
-		if err != nil {
-			panicConfig(path, fmt.Sprintf("expected float64, got string %q", f))
-		}
-		return parsed
+	sv := c.getScalar(path)
+	parsed, err := strconv.ParseFloat(sv.Raw, 64)
+	if err != nil {
+		panicConfig(path, fmt.Sprintf("expected float64, got %q", sv.Raw))
 	}
-	panicConfig(path, fmt.Sprintf("expected float64, got %T", v))
-	return 0
+	return parsed
 }
 
 func (c *Config) GetFloat64Option(path string) Option[float64] {
@@ -228,18 +198,11 @@ func (c *Config) GetFloat64Option(path string) Option[float64] {
 		return None[float64]()
 	}
 	sv, ok2 := v.(*resolver.ScalarVal)
-	if !ok2 || sv.V == nil {
+	if !ok2 || sv.Type == resolver.ScalarNull {
 		return None[float64]()
 	}
-	switch f := sv.V.(type) {
-	case float64:
-		return Some(f)
-	case int64:
-		return Some(float64(f))
-	case string:
-		if parsed, err := strconv.ParseFloat(f, 64); err == nil {
-			return Some(parsed)
-		}
+	if parsed, err := strconv.ParseFloat(sv.Raw, 64); err == nil {
+		return Some(parsed)
 	}
 	return None[float64]()
 }
@@ -255,19 +218,12 @@ func (c *Config) GetFloat32Option(path string) Option[float32] {
 }
 
 func (c *Config) GetBool(path string) bool {
-	v := c.getScalar(path)
-	switch b := v.(type) {
-	case bool:
-		return b
-	case string:
-		parsed, err := strconv.ParseBool(b)
-		if err != nil {
-			panicConfig(path, fmt.Sprintf("expected bool, got string %q", b))
-		}
-		return parsed
+	sv := c.getScalar(path)
+	parsed, err := strconv.ParseBool(sv.Raw)
+	if err != nil {
+		panicConfig(path, fmt.Sprintf("expected bool, got %q", sv.Raw))
 	}
-	panicConfig(path, fmt.Sprintf("expected bool, got %T", v))
-	return false
+	return parsed
 }
 
 func (c *Config) GetBoolOption(path string) Option[bool] {
@@ -276,16 +232,11 @@ func (c *Config) GetBoolOption(path string) Option[bool] {
 		return None[bool]()
 	}
 	sv, ok2 := v.(*resolver.ScalarVal)
-	if !ok2 || sv.V == nil {
+	if !ok2 || sv.Type == resolver.ScalarNull {
 		return None[bool]()
 	}
-	switch b := sv.V.(type) {
-	case bool:
-		return Some(b)
-	case string:
-		if parsed, err := strconv.ParseBool(b); err == nil {
-			return Some(parsed)
-		}
+	if parsed, err := strconv.ParseBool(sv.Raw); err == nil {
+		return Some(parsed)
 	}
 	return None[bool]()
 }
@@ -424,14 +375,10 @@ func (c *Config) GetStringSlice(path string) []string {
 	result := make([]string, len(arr.Elements))
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
-		if !ok || sv.V == nil {
+		if !ok || sv.Type == resolver.ScalarNull {
 			panicConfig(path, fmt.Sprintf("element %d is not a string", i))
 		}
-		s, ok := sv.V.(string)
-		if !ok {
-			panicConfig(path, fmt.Sprintf("element %d: expected string, got %T", i, sv.V))
-		}
-		result[i] = s
+		result[i] = sv.Raw
 	}
 	return result
 }
@@ -448,14 +395,10 @@ func (c *Config) GetStringSliceOption(path string) Option[[]string] {
 	result := make([]string, len(arr.Elements))
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
-		if !ok || sv.V == nil {
+		if !ok || sv.Type == resolver.ScalarNull {
 			return None[[]string]()
 		}
-		s, ok := sv.V.(string)
-		if !ok {
-			return None[[]string]()
-		}
-		result[i] = s
+		result[i] = sv.Raw
 	}
 	return Some(result)
 }
@@ -465,21 +408,14 @@ func (c *Config) GetInt64Slice(path string) []int64 {
 	result := make([]int64, len(arr.Elements))
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
-		if !ok || sv.V == nil {
+		if !ok || sv.Type == resolver.ScalarNull {
 			panicConfig(path, fmt.Sprintf("element %d is not an int", i))
 		}
-		switch n := sv.V.(type) {
-		case int64:
-			result[i] = n
-		case string:
-			parsed, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				panicConfig(path, fmt.Sprintf("element %d: expected int64, got string %q", i, n))
-			}
-			result[i] = parsed
-		default:
-			panicConfig(path, fmt.Sprintf("element %d: expected int64, got %T", i, sv.V))
+		parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+		if err != nil {
+			panicConfig(path, fmt.Sprintf("element %d: expected int64, got %q", i, sv.Raw))
 		}
+		result[i] = parsed
 	}
 	return result
 }
@@ -496,21 +432,14 @@ func (c *Config) GetInt64SliceOption(path string) Option[[]int64] {
 	result := make([]int64, len(arr.Elements))
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
-		if !ok || sv.V == nil {
+		if !ok || sv.Type == resolver.ScalarNull {
 			return None[[]int64]()
 		}
-		switch n := sv.V.(type) {
-		case int64:
-			result[i] = n
-		case string:
-			parsed, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				return None[[]int64]()
-			}
-			result[i] = parsed
-		default:
+		parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+		if err != nil {
 			return None[[]int64]()
 		}
+		result[i] = parsed
 	}
 	return Some(result)
 }
@@ -536,21 +465,14 @@ func (c *Config) GetIntSliceOption(path string) Option[[]int] {
 	result := make([]int, len(arr.Elements))
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
-		if !ok || sv.V == nil {
+		if !ok || sv.Type == resolver.ScalarNull {
 			return None[[]int]()
 		}
-		switch n := sv.V.(type) {
-		case int64:
-			result[i] = int(n)
-		case string:
-			parsed, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				return None[[]int]()
-			}
-			result[i] = int(parsed)
-		default:
+		parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+		if err != nil {
 			return None[[]int]()
 		}
+		result[i] = int(parsed)
 	}
 	return Some(result)
 }
@@ -575,7 +497,7 @@ func (c *Config) GetConfigOption(path string) Option[*Config] {
 		return None[*Config]()
 	}
 	sv, isSc := v.(*resolver.ScalarVal)
-	if isSc && sv.V == nil {
+	if isSc && sv.Type == resolver.ScalarNull {
 		return None[*Config]()
 	}
 	obj, ok2 := v.(*resolver.ObjectVal)

--- a/config.go
+++ b/config.go
@@ -392,7 +392,7 @@ func (c *Config) GetStringSlice(path string) []string {
 	for i, elem := range arr.Elements {
 		sv, ok := elem.(*resolver.ScalarVal)
 		if !ok || sv.Type == resolver.ScalarNull {
-			panicConfig(path, fmt.Sprintf("element %d is not a string", i))
+			panicConfig(path, fmt.Sprintf("element %d is not a non-null scalar", i))
 		}
 		result[i] = sv.Raw
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -770,11 +770,17 @@ func TestIncludePropertiesFile(t *testing.T) {
 	}
 }
 
-func TestConfig_GetStringSliceOption_WrongElementType(t *testing.T) {
+func TestConfig_GetStringSliceOption_NumberElements(t *testing.T) {
+	// After the raw-string refactor, GetStringSlice works on any scalar type
+	// (returns the raw string representation). [1, 2, 3] → ["1", "2", "3"].
 	cfg := mustParseCfg(t, `key = [1, 2, 3]`)
 	opt := cfg.GetStringSliceOption("key")
-	if opt.IsSome() {
-		t.Error("expected None when array elements are not strings")
+	if opt.IsNone() {
+		t.Error("expected Some for number elements (raw strings)")
+	}
+	v, _ := opt.Get()
+	if len(v) != 3 || v[0] != "1" || v[1] != "2" || v[2] != "3" {
+		t.Errorf("expected [1 2 3], got %v", v)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -840,18 +840,12 @@ func TestConfig_DotPrefixedFloat_ToObject(t *testing.T) {
 	if err := cfg.Unmarshal(&m); err != nil {
 		t.Fatal(err)
 	}
-	// .33 is a valid float, so it becomes float64 in map[string]any
-	switch v := m["val"].(type) {
-	case float64:
-		if v != 0.33 {
-			t.Errorf("got %v, want 0.33", v)
-		}
-	case string:
-		if v != ".33" {
-			t.Errorf("got %q, want %q", v, ".33")
-		}
-	default:
-		t.Errorf("unexpected type %T for val", m["val"])
+	v, ok := m["val"].(string)
+	if !ok {
+		t.Fatalf("unexpected type %T for val, want string", m["val"])
+	}
+	if v != ".33" {
+		t.Errorf("got %q, want %q", v, ".33")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -808,6 +808,118 @@ func TestConfig_GetConfigSliceOption_WrongElementType(t *testing.T) {
 	}
 }
 
+// --- Scalar raw-string preservation tests ---
+
+func TestConfig_GetString_ReturnsRawTextForNumber(t *testing.T) {
+	cfg := mustParseCfg(t, `port = 8080`)
+	if got := cfg.GetString("port"); got != "8080" {
+		t.Errorf("got %q, want %q", got, "8080")
+	}
+}
+
+func TestConfig_GetString_ReturnsRawTextForBool(t *testing.T) {
+	cfg := mustParseCfg(t, `enabled = true`)
+	if got := cfg.GetString("enabled"); got != "true" {
+		t.Errorf("got %q, want %q", got, "true")
+	}
+}
+
+func TestConfig_GetString_DotPrefixedFloat(t *testing.T) {
+	// ".33" must be preserved as the raw string, not normalized to "0.33".
+	cfg := mustParseCfg(t, `val = .33`)
+	if got := cfg.GetString("val"); got != ".33" {
+		t.Errorf("got %q, want %q", got, ".33")
+	}
+}
+
+func TestConfig_DotPrefixedFloat_ToObject(t *testing.T) {
+	// When unmarshalled into map[string]any, ".33" should stay as a string
+	// because it cannot be parsed as int and preserves the raw representation.
+	cfg := mustParseCfg(t, `val = .33`)
+	var m map[string]any
+	if err := cfg.Unmarshal(&m); err != nil {
+		t.Fatal(err)
+	}
+	// .33 is a valid float, so it becomes float64 in map[string]any
+	switch v := m["val"].(type) {
+	case float64:
+		if v != 0.33 {
+			t.Errorf("got %v, want 0.33", v)
+		}
+	case string:
+		if v != ".33" {
+			t.Errorf("got %q, want %q", v, ".33")
+		}
+	default:
+		t.Errorf("unexpected type %T for val", m["val"])
+	}
+}
+
+func TestConfig_GetString_OctalLikePreserved(t *testing.T) {
+	// "0100" must be preserved as the raw string, not interpreted as octal.
+	cfg := mustParseCfg(t, `val = 0100`)
+	if got := cfg.GetString("val"); got != "0100" {
+		t.Errorf("got %q, want %q", got, "0100")
+	}
+}
+
+// --- GetBool yes/no/on/off tests ---
+
+func TestConfig_GetBool_YesNoOnOff(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{`b = yes`, true},
+		{`b = Yes`, true},
+		{`b = YES`, true},
+		{`b = no`, false},
+		{`b = No`, false},
+		{`b = NO`, false},
+		{`b = on`, true},
+		{`b = On`, true},
+		{`b = ON`, true},
+		{`b = off`, false},
+		{`b = Off`, false},
+		{`b = OFF`, false},
+		{`b = true`, true},
+		{`b = false`, false},
+	}
+	for _, tc := range tests {
+		cfg := mustParseCfg(t, tc.input)
+		got := cfg.GetBool("b")
+		if got != tc.want {
+			t.Errorf("input=%q: got %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestConfig_GetBoolOption_YesNoOnOff(t *testing.T) {
+	cfg := mustParseCfg(t, `a = yes
+b = no
+c = on
+d = off`)
+	for _, tc := range []struct {
+		key  string
+		want bool
+	}{
+		{"a", true},
+		{"b", false},
+		{"c", true},
+		{"d", false},
+	} {
+		opt := cfg.GetBoolOption(tc.key)
+		if opt.IsNone() {
+			t.Errorf("key=%q: expected Some, got None", tc.key)
+			continue
+		}
+		v, _ := opt.Get()
+		if v != tc.want {
+			t.Errorf("key=%q: got %v, want %v", tc.key, v, tc.want)
+		}
+	}
+}
+
 // --- Delayed merge / self-referential substitution tests ---
 
 func TestConfig_DelayedMergeObjectWithSubstitution(t *testing.T) {

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -44,11 +44,12 @@ type ArrayNode struct {
 
 func (n *ArrayNode) node() {}
 
-// ScalarNode holds a primitive value.
-// Value is one of: string, int64, float64, bool, nil (null).
+// ScalarNode holds a primitive value as its raw string plus a type tag.
+// ValueType is one of: "string", "number", "boolean", "null".
 type ScalarNode struct {
 	pos
-	Value any
+	Raw       string
+	ValueType string
 }
 
 func (n *ScalarNode) node() {}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -316,7 +316,7 @@ func (p *parser) parseValue() (Node, error) {
 			break
 		}
 		if hadSpace {
-			nodes = append(nodes, &ScalarNode{Value: " "})
+			nodes = append(nodes, &ScalarNode{Raw: " ", ValueType: "string"})
 		}
 		nodes = append(nodes, next)
 	}
@@ -347,30 +347,28 @@ func (p *parser) parseSingleValue() (Node, error) {
 	case lexer.TokenString:
 		val := p.current.Value
 		p.advance()
-		return &ScalarNode{pos: pos{line, col}, Value: val}, nil
+		return &ScalarNode{pos: pos{line, col}, Raw: val, ValueType: "string"}, nil
 	case lexer.TokenInt:
 		raw := p.current.Value
 		p.advance()
-		n, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil {
+		if _, err := strconv.ParseInt(raw, 10, 64); err != nil {
 			return nil, newError(line, col, "invalid int %q", raw)
 		}
-		return &ScalarNode{pos: pos{line, col}, Value: n}, nil
+		return &ScalarNode{pos: pos{line, col}, Raw: raw, ValueType: "number"}, nil
 	case lexer.TokenFloat:
 		raw := p.current.Value
 		p.advance()
-		f, err := strconv.ParseFloat(raw, 64)
-		if err != nil {
+		if _, err := strconv.ParseFloat(raw, 64); err != nil {
 			return nil, newError(line, col, "invalid float %q", raw)
 		}
-		return &ScalarNode{pos: pos{line, col}, Value: f}, nil
+		return &ScalarNode{pos: pos{line, col}, Raw: raw, ValueType: "number"}, nil
 	case lexer.TokenBool:
-		val := p.current.Value == "true"
+		raw := p.current.Value
 		p.advance()
-		return &ScalarNode{pos: pos{line, col}, Value: val}, nil
+		return &ScalarNode{pos: pos{line, col}, Raw: raw, ValueType: "boolean"}, nil
 	case lexer.TokenNull:
 		p.advance()
-		return &ScalarNode{pos: pos{line, col}, Value: nil}, nil
+		return &ScalarNode{pos: pos{line, col}, Raw: "null", ValueType: "null"}, nil
 	default:
 		return nil, newError(line, col, "unexpected token %v", p.current.Type)
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -30,8 +30,8 @@ func TestParser_SimpleKV(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected ScalarNode, got %T", f.Value)
 	}
-	if sc.Value != "value" {
-		t.Errorf("unexpected value: %v", sc.Value)
+	if sc.Raw != "value" || sc.ValueType != "string" {
+		t.Errorf("unexpected value: Raw=%v, ValueType=%v", sc.Raw, sc.ValueType)
 	}
 }
 
@@ -114,13 +114,14 @@ func TestParser_PlusEquals(t *testing.T) {
 func TestParser_NullBoolNumbers(t *testing.T) {
 	obj := mustParse(t, "a=null\nb=true\nc=42\nd=3.14")
 	checks := []struct {
-		idx  int
-		want any
+		idx       int
+		wantRaw   string
+		wantType  string
 	}{
-		{0, nil},
-		{1, true},
-		{2, int64(42)},
-		{3, float64(3.14)},
+		{0, "null", "null"},
+		{1, "true", "boolean"},
+		{2, "42", "number"},
+		{3, "3.14", "number"},
 	}
 	for _, tc := range checks {
 		sc, ok := obj.Fields[tc.idx].Value.(*parser.ScalarNode)
@@ -128,8 +129,8 @@ func TestParser_NullBoolNumbers(t *testing.T) {
 			t.Errorf("[%d] expected ScalarNode, got %T", tc.idx, obj.Fields[tc.idx].Value)
 			continue
 		}
-		if sc.Value != tc.want {
-			t.Errorf("[%d] got %v (%T), want %v", tc.idx, sc.Value, sc.Value, tc.want)
+		if sc.Raw != tc.wantRaw || sc.ValueType != tc.wantType {
+			t.Errorf("[%d] got Raw=%q ValueType=%q, want Raw=%q ValueType=%q", tc.idx, sc.Raw, sc.ValueType, tc.wantRaw, tc.wantType)
 		}
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -114,9 +114,9 @@ func TestParser_PlusEquals(t *testing.T) {
 func TestParser_NullBoolNumbers(t *testing.T) {
 	obj := mustParse(t, "a=null\nb=true\nc=42\nd=3.14")
 	checks := []struct {
-		idx       int
-		wantRaw   string
-		wantType  string
+		idx      int
+		wantRaw  string
+		wantType string
 	}{
 		{0, "null", "null"},
 		{1, "true", "boolean"},

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -104,8 +104,23 @@ type ArrayVal struct{ Elements []Val }
 
 func (a *ArrayVal) val() {}
 
-// ScalarVal holds a resolved primitive.
-type ScalarVal struct{ V any }
+// ScalarType discriminates the kind of scalar value.
+type ScalarType int
+
+const (
+	ScalarString  ScalarType = iota
+	ScalarNumber
+	ScalarBoolean
+	ScalarNull
+)
+
+// ScalarVal holds a resolved primitive as its raw string representation
+// plus a type discriminant. The raw string is what appeared in the source
+// (or was produced by concatenation / env var lookup).
+type ScalarVal struct {
+	Raw  string
+	Type ScalarType
+}
 
 func (s *ScalarVal) val() {}
 
@@ -255,7 +270,16 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 func (r *resolver) resolveNode(node parser.Node, ctx *ObjectVal, pathPrefix []string) (Val, error) {
 	switch n := node.(type) {
 	case *parser.ScalarNode:
-		return &ScalarVal{V: n.Value}, nil
+		st := ScalarString
+		switch n.ValueType {
+		case "number":
+			st = ScalarNumber
+		case "boolean":
+			st = ScalarBoolean
+		case "null":
+			st = ScalarNull
+		}
+		return &ScalarVal{Raw: n.Raw, Type: st}, nil
 	case *parser.ObjectNode:
 		return r.resolveObject(n, nil, pathPrefix)
 	case *parser.ArrayNode:
@@ -497,13 +521,13 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		}
 		// Also try env var with original path (raw dot-join, no quoting)
 		if ev, ok := os.LookupEnv(strings.Join(originalSegments, ".")); ok {
-			return &ScalarVal{V: ev}, nil
+			return &ScalarVal{Raw: ev, Type: ScalarString}, nil
 		}
 	}
 
 	// env var fallback — use raw dot-join (no quoting) to match Lightbend behavior
 	if ev, ok := os.LookupEnv(strings.Join(s.segments, ".")); ok {
-		return &ScalarVal{V: ev}, nil
+		return &ScalarVal{Raw: ev, Type: ScalarString}, nil
 	}
 	if n.Optional {
 		return nil, nil // field will be dropped
@@ -542,7 +566,7 @@ func (r *resolver) findPrior(root *ObjectVal, segments []string, pathStr string)
 
 func isSeparator(v Val) bool {
 	if s, ok := v.(*ScalarVal); ok {
-		if str, ok := s.V.(string); ok && str == " " {
+		if s.Type == ScalarString && s.Raw == " " {
 			return true
 		}
 	}
@@ -665,16 +689,13 @@ func (r *resolver) concatStrings(vals []Val) Val {
 		}
 		sb.WriteString(valToString(v))
 	}
-	return &ScalarVal{V: sb.String()}
+	return &ScalarVal{Raw: sb.String(), Type: ScalarString}
 }
 
 func valToString(v Val) string {
 	switch vv := v.(type) {
 	case *ScalarVal:
-		if vv.V == nil {
-			return "null"
-		}
-		return fmt.Sprintf("%v", vv.V)
+		return vv.Raw
 	default:
 		return fmt.Sprintf("%v", v)
 	}
@@ -936,7 +957,7 @@ func propsToObjectVal(props map[string]string) *ObjectVal {
 		cur := root
 		for i, part := range parts {
 			if i == len(parts)-1 {
-				cur.set(part, &ScalarVal{V: value})
+				cur.set(part, &ScalarVal{Raw: value, Type: ScalarString})
 			} else {
 				existing, ok := cur.values[part]
 				if !ok {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -118,6 +118,9 @@ const (
 // plus a type discriminant. The raw string is what appeared in the source
 // (or was produced by concatenation / env var lookup).
 type ScalarVal struct {
+	// Raw is the scalar's string representation. For unquoted tokens this is
+	// the literal source text. For quoted strings the lexer has already
+	// decoded escape sequences, so Raw contains the decoded value.
 	Raw  string
 	Type ScalarType
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -108,7 +108,7 @@ func (a *ArrayVal) val() {}
 type ScalarType int
 
 const (
-	ScalarString  ScalarType = iota
+	ScalarString ScalarType = iota
 	ScalarNumber
 	ScalarBoolean
 	ScalarNull

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -29,7 +29,7 @@ func TestResolver_SimpleKV(t *testing.T) {
 	if !ok {
 		t.Fatal("key not found")
 	}
-	if sv, ok := v.(*resolver.ScalarVal); !ok || sv.V != "hello" {
+	if sv, ok := v.(*resolver.ScalarVal); !ok || sv.Raw != "hello" {
 		t.Errorf("unexpected value: %v", v)
 	}
 }
@@ -52,7 +52,7 @@ func TestResolver_DuplicateKeyMerge(t *testing.T) {
 func TestResolver_Substitution(t *testing.T) {
 	res := resolve(t, "x=1\ny=${x}")
 	v, _ := res.Root.Get("y")
-	if sv, ok := v.(*resolver.ScalarVal); !ok || sv.V != int64(1) {
+	if sv, ok := v.(*resolver.ScalarVal); !ok || sv.Raw != "1" {
 		t.Errorf("substitution failed: %v", v)
 	}
 }
@@ -74,7 +74,7 @@ func TestResolver_OptionalSubstitutionFallback(t *testing.T) {
 		t.Fatal("prior value should be preserved when optional substitution is unset")
 	}
 	sv, ok := v.(*resolver.ScalarVal)
-	if !ok || sv.V != "0.0.0.0" {
+	if !ok || sv.Raw != "0.0.0.0" {
 		t.Errorf("expected prior value \"0.0.0.0\", got %v", v)
 	}
 }
@@ -113,7 +113,7 @@ func TestResolver_NullValue(t *testing.T) {
 		t.Fatal("key missing")
 	}
 	sv, ok := v.(*resolver.ScalarVal)
-	if !ok || sv.V != nil {
+	if !ok || sv.Type != resolver.ScalarNull {
 		t.Errorf("expected null ScalarVal, got %v", v)
 	}
 }
@@ -126,7 +126,7 @@ func TestResolver_DuplicateScalarLastWins(t *testing.T) {
 		t.Fatal("a not found")
 	}
 	sv, ok := v.(*resolver.ScalarVal)
-	if !ok || sv.V != int64(2) {
+	if !ok || sv.Raw != "2" {
 		t.Errorf("expected last value 2, got %v", v)
 	}
 }
@@ -190,7 +190,7 @@ func TestResolver_ObjectEqualsReplacesWithScalar(t *testing.T) {
 		t.Fatal("a not found")
 	}
 	sv, ok := v.(*resolver.ScalarVal)
-	if !ok || sv.V != int64(42) {
+	if !ok || sv.Raw != "42" {
 		t.Errorf("expected scalar 42, got %v", v)
 	}
 }
@@ -241,8 +241,8 @@ func TestResolver_IncludeProbeConf(t *testing.T) {
 	if !ok {
 		t.Fatal("x not found")
 	}
-	if sv := v.(*resolver.ScalarVal); sv.V != "from-conf" {
-		t.Errorf("expected from-conf, got %v", sv.V)
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "from-conf" {
+		t.Errorf("expected from-conf, got %v", sv.Raw)
 	}
 }
 
@@ -259,8 +259,8 @@ func TestResolver_IncludeProbeJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("y not found")
 	}
-	if sv := v.(*resolver.ScalarVal); sv.V != "from-json" {
-		t.Errorf("expected from-json, got %v", sv.V)
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "from-json" {
+		t.Errorf("expected from-json, got %v", sv.Raw)
 	}
 }
 
@@ -278,8 +278,8 @@ func TestResolver_IncludeProbeProperties(t *testing.T) {
 	if !ok {
 		t.Fatal("z not found")
 	}
-	if sv := v.(*resolver.ScalarVal); sv.V != "from-props" {
-		t.Errorf("expected from-props, got %v", sv.V)
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "from-props" {
+		t.Errorf("expected from-props, got %v", sv.Raw)
 	}
 }
 
@@ -297,16 +297,16 @@ y = "only-conf"`)
 
 	// x exists in both: .conf wins (parsed last per spec).
 	v, _ := o.Get("x")
-	if sv := v.(*resolver.ScalarVal); sv.V != "conf" {
-		t.Errorf("expected conf (later override), got %v", sv.V)
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "conf" {
+		t.Errorf("expected conf (later override), got %v", sv.Raw)
 	}
 	// y exists only in .conf: should be present.
 	v2, ok := o.Get("y")
 	if !ok {
 		t.Fatal("y not found — merge missed .conf-only key")
 	}
-	if sv := v2.(*resolver.ScalarVal); sv.V != "only-conf" {
-		t.Errorf("expected only-conf, got %v", sv.V)
+	if sv := v2.(*resolver.ScalarVal); sv.Raw != "only-conf" {
+		t.Errorf("expected only-conf, got %v", sv.Raw)
 	}
 }
 
@@ -325,16 +325,16 @@ func TestResolver_IncludeMergeAllWithProperties(t *testing.T) {
 	if !ok1 {
 		t.Fatal("p not found")
 	}
-	if sv := v1.(*resolver.ScalarVal); sv.V != "from-props" {
-		t.Errorf("expected from-props, got %v", sv.V)
+	if sv := v1.(*resolver.ScalarVal); sv.Raw != "from-props" {
+		t.Errorf("expected from-props, got %v", sv.Raw)
 	}
 
 	v2, ok2 := o.Get("c")
 	if !ok2 {
 		t.Fatal("c not found")
 	}
-	if sv := v2.(*resolver.ScalarVal); sv.V != "from-conf" {
-		t.Errorf("expected from-conf, got %v", sv.V)
+	if sv := v2.(*resolver.ScalarVal); sv.Raw != "from-conf" {
+		t.Errorf("expected from-conf, got %v", sv.Raw)
 	}
 }
 
@@ -346,8 +346,8 @@ func TestResolver_IncludeWithExtensionNoProbe(t *testing.T) {
 	res := resolveWithDir(t, `a { include "sub.conf" }`, dir)
 	obj, _ := res.Root.Get("a")
 	v, _ := obj.(*resolver.ObjectVal).Get("x")
-	if sv := v.(*resolver.ScalarVal); sv.V != "direct" {
-		t.Errorf("expected direct, got %v", sv.V)
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "direct" {
+		t.Errorf("expected direct, got %v", sv.Raw)
 	}
 }
 
@@ -377,9 +377,9 @@ d = null
 			continue
 		}
 		sv := v.(*resolver.ScalarVal)
-		s, ok := sv.V.(string)
-		if !ok {
-			t.Errorf("key %q: expected string type, got %T (%v)", tc.key, sv.V, sv.V)
+		s := sv.Raw
+		if sv.Type != resolver.ScalarString {
+			t.Errorf("key %q: expected ScalarString type, got %v (%v)", tc.key, sv.Type, sv.Raw)
 			continue
 		}
 		if s != tc.want {
@@ -397,8 +397,8 @@ func TestResolver_IncludePropertiesExplicitExtension(t *testing.T) {
 	obj, _ := res.Root.Get("x")
 	v, _ := obj.(*resolver.ObjectVal).Get("val")
 	sv := v.(*resolver.ScalarVal)
-	if _, ok := sv.V.(string); !ok {
-		t.Errorf("expected string, got %T (%v)", sv.V, sv.V)
+	if sv.Type != resolver.ScalarString {
+		t.Errorf("expected ScalarString type, got %v (%v)", sv.Type, sv.Raw)
 	}
 }
 
@@ -419,12 +419,12 @@ inner.b = true
 	o := inner.(*resolver.ObjectVal)
 
 	v1, _ := o.Get("a")
-	if sv := v1.(*resolver.ScalarVal); sv.V != "42" {
-		t.Errorf("nested a: expected string \"42\", got %T %v", sv.V, sv.V)
+	if sv := v1.(*resolver.ScalarVal); sv.Raw != "42" {
+		t.Errorf("nested a: expected string \"42\", got %T %v", sv.Raw, sv.Raw)
 	}
 	v2, _ := o.Get("b")
-	if sv := v2.(*resolver.ScalarVal); sv.V != "true" {
-		t.Errorf("nested b: expected string \"true\", got %T %v", sv.V, sv.V)
+	if sv := v2.(*resolver.ScalarVal); sv.Raw != "true" {
+		t.Errorf("nested b: expected string \"true\", got %T %v", sv.Raw, sv.Raw)
 	}
 }
 
@@ -445,8 +445,8 @@ list = one,two,three
 		t.Fatal("list not found")
 	}
 	sv := v.(*resolver.ScalarVal)
-	if s, ok := sv.V.(string); !ok || s != "one,two,three" {
-		t.Errorf("list: expected string \"one,two,three\", got %T %v", sv.V, sv.V)
+	if sv.Raw != "one,two,three" || sv.Type != resolver.ScalarString {
+		t.Errorf("list: expected string \"one,two,three\", got %v (type %v)", sv.Raw, sv.Type)
 	}
 }
 
@@ -553,13 +553,13 @@ func TestResolver_ObjectConcatenation(t *testing.T) {
 	xv, ok := o.Get("x")
 	if !ok {
 		t.Error("x missing after object concatenation")
-	} else if sv, ok := xv.(*resolver.ScalarVal); !ok || sv.V != int64(1) {
+	} else if sv, ok := xv.(*resolver.ScalarVal); !ok || sv.Raw != "1" {
 		t.Errorf("expected x=1, got %v", xv)
 	}
 	yv, ok := o.Get("y")
 	if !ok {
 		t.Error("y missing after object concatenation")
-	} else if sv, ok := yv.(*resolver.ScalarVal); !ok || sv.V != int64(2) {
+	} else if sv, ok := yv.(*resolver.ScalarVal); !ok || sv.Raw != "2" {
 		t.Errorf("expected y=2, got %v", yv)
 	}
 }
@@ -579,14 +579,14 @@ func TestResolver_ArrayConcatenationPermissive(t *testing.T) {
 	if len(arr.Elements) != 3 {
 		t.Fatalf("expected 3 elements, got %d", len(arr.Elements))
 	}
-	for i, want := range []int64{1, 2, 3} {
+	for i, want := range []string{"1", "2", "3"} {
 		sv, ok := arr.Elements[i].(*resolver.ScalarVal)
 		if !ok {
 			t.Errorf("element %d: expected ScalarVal, got %T", i, arr.Elements[i])
 			continue
 		}
-		if sv.V != want {
-			t.Errorf("element %d: expected %d, got %v", i, want, sv.V)
+		if sv.Raw != want {
+			t.Errorf("element %d: expected %s, got %v", i, want, sv.Raw)
 		}
 	}
 }
@@ -612,12 +612,12 @@ func TestResolver_ObjectConcatenationDeepMerge(t *testing.T) {
 	}
 	if nv, ok := xo.Get("nested"); !ok {
 		t.Error("nested missing after deep merge")
-	} else if sv, ok := nv.(*resolver.ScalarVal); !ok || sv.V != int64(1) {
+	} else if sv, ok := nv.(*resolver.ScalarVal); !ok || sv.Raw != "1" {
 		t.Errorf("expected nested=1, got %v", nv)
 	}
 	if ov, ok := xo.Get("other"); !ok {
 		t.Error("other missing after deep merge")
-	} else if sv, ok := ov.(*resolver.ScalarVal); !ok || sv.V != int64(2) {
+	} else if sv, ok := ov.(*resolver.ScalarVal); !ok || sv.Raw != "2" {
 		t.Errorf("expected other=2, got %v", ov)
 	}
 }
@@ -718,16 +718,16 @@ y = ${x}
 	if !ok {
 		t.Fatal("x not found in wrapper")
 	}
-	if sv := xv.(*resolver.ScalarVal); sv.V != int64(10) {
-		t.Errorf("expected x=10, got %v", sv.V)
+	if sv := xv.(*resolver.ScalarVal); sv.Raw != "10" {
+		t.Errorf("expected x=10, got %v", sv.Raw)
 	}
 
 	yv, ok := wo.Get("y")
 	if !ok {
 		t.Fatal("y not found in wrapper")
 	}
-	if sv := yv.(*resolver.ScalarVal); sv.V != int64(10) {
-		t.Errorf("expected y=10 (resolved from ${x}), got %v", sv.V)
+	if sv := yv.(*resolver.ScalarVal); sv.Raw != "10" {
+		t.Errorf("expected y=10 (resolved from ${x}), got %v", sv.Raw)
 	}
 }
 
@@ -755,8 +755,8 @@ y = ${x}
 	if !ok {
 		t.Fatal("y not found in bar.nested")
 	}
-	if sv := yv.(*resolver.ScalarVal); sv.V != int64(10) {
-		t.Errorf("expected y=10, got %v", sv.V)
+	if sv := yv.(*resolver.ScalarVal); sv.Raw != "10" {
+		t.Errorf("expected y=10, got %v", sv.Raw)
 	}
 }
 
@@ -792,8 +792,8 @@ a.b {
 	if !ok {
 		t.Fatal("val not found in a.b")
 	}
-	if sv := vv.(*resolver.ScalarVal); sv.V != "hello" {
-		t.Errorf("expected val='hello' (resolved from ${ext}), got %v", sv.V)
+	if sv := vv.(*resolver.ScalarVal); sv.Raw != "hello" {
+		t.Errorf("expected val='hello' (resolved from ${ext}), got %v", sv.Raw)
 	}
 }
 
@@ -819,8 +819,8 @@ wrapper { include "child.conf" }
 	if !ok {
 		t.Fatal("a not found in wrapper")
 	}
-	if sv := av.(*resolver.ScalarVal); sv.V != "from-root" {
-		t.Errorf("expected a='from-root', got %v", sv.V)
+	if sv := av.(*resolver.ScalarVal); sv.Raw != "from-root" {
+		t.Errorf("expected a='from-root', got %v", sv.Raw)
 	}
 }
 
@@ -854,7 +854,7 @@ func lookupObj(t *testing.T, res *resolver.Result, key string) *resolver.ObjectV
 	return cur
 }
 
-func assertScalar(t *testing.T, obj *resolver.ObjectVal, key string, expected any) {
+func assertScalar(t *testing.T, obj *resolver.ObjectVal, key string, expected string) {
 	t.Helper()
 	v, ok := obj.Get(key)
 	if !ok {
@@ -864,8 +864,8 @@ func assertScalar(t *testing.T, obj *resolver.ObjectVal, key string, expected an
 	if !ok {
 		t.Fatalf("key %q: expected ScalarVal, got %T", key, v)
 	}
-	if sv.V != expected {
-		t.Errorf("key %q: expected %v (%T), got %v (%T)", key, expected, expected, sv.V, sv.V)
+	if sv.Raw != expected {
+		t.Errorf("key %q: expected %q, got %q", key, expected, sv.Raw)
 	}
 }
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -251,8 +251,8 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 		}
 		target.SetFloat(parsed)
 	case reflect.Bool:
-		parsed, err := strconv.ParseBool(sv.Raw)
-		if err != nil {
+		parsed, ok := parseBool(sv.Raw)
+		if !ok {
 			return fmt.Errorf("hocon: expected bool, got %q", sv.Raw)
 		}
 		target.SetBool(parsed)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -34,7 +34,7 @@ func unmarshalVal(val resolver.Val, target reflect.Value) error {
 		if val == nil {
 			return nil
 		}
-		if sv, ok := val.(*resolver.ScalarVal); ok && sv.V == nil {
+		if sv, ok := val.(*resolver.ScalarVal); ok && sv.Type == resolver.ScalarNull {
 			return nil
 		}
 		if target.IsNil() {
@@ -66,11 +66,7 @@ func unmarshalStruct(val resolver.Val, target reflect.Value) error {
 		if !ok2 {
 			return fmt.Errorf("hocon: expected string for duration")
 		}
-		s, ok3 := sv.V.(string)
-		if !ok3 {
-			return fmt.Errorf("hocon: expected string for duration, got %T", sv.V)
-		}
-		d, err := parseDuration(s)
+		d, err := parseDuration(sv.Raw)
 		if err != nil {
 			return err
 		}
@@ -102,7 +98,7 @@ func unmarshalStruct(val resolver.Val, target reflect.Value) error {
 			return fmt.Errorf("hocon: missing required field %q", key)
 		}
 		// null + omitempty: preserve
-		if sv, isSc := v.(*resolver.ScalarVal); isSc && sv.V == nil && omitempty {
+		if sv, isSc := v.(*resolver.ScalarVal); isSc && sv.Type == resolver.ScalarNull && omitempty {
 			continue
 		}
 		if err := unmarshalVal(v, fval); err != nil {
@@ -160,7 +156,25 @@ func unmarshalMap(val resolver.Val, target reflect.Value) error {
 func valToAny(v resolver.Val) any {
 	switch vv := v.(type) {
 	case *resolver.ScalarVal:
-		return vv.V
+		switch vv.Type {
+		case resolver.ScalarNull:
+			return nil
+		case resolver.ScalarBoolean:
+			return vv.Raw == "true"
+		case resolver.ScalarNumber:
+			// Try int first (no dot/exponent), then float
+			if !strings.ContainsAny(vv.Raw, ".eE") {
+				if n, err := strconv.ParseInt(vv.Raw, 10, 64); err == nil {
+					return n
+				}
+			}
+			if f, err := strconv.ParseFloat(vv.Raw, 64); err == nil {
+				return f
+			}
+			return vv.Raw
+		default:
+			return vv.Raw
+		}
 	case *resolver.ArrayVal:
 		r := make([]any, len(vv.Elements))
 		for i, e := range vv.Elements {
@@ -202,17 +216,13 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 	if !ok {
 		return fmt.Errorf("hocon: expected scalar for %v, got %T", target.Type(), val)
 	}
-	if sv.V == nil {
+	if sv.Type == resolver.ScalarNull {
 		return nil // null → zero value
 	}
 
 	// time.Duration special case (underlying kind is int64)
 	if target.Type() == reflect.TypeOf(time.Duration(0)) {
-		s, ok2 := sv.V.(string)
-		if !ok2 {
-			return fmt.Errorf("hocon: expected string for duration")
-		}
-		d, err := parseDuration(s)
+		d, err := parseDuration(sv.Raw)
 		if err != nil {
 			return err
 		}
@@ -222,54 +232,30 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 
 	switch target.Kind() {
 	case reflect.String:
-		s, ok2 := sv.V.(string)
-		if !ok2 {
-			return fmt.Errorf("hocon: expected string, got %T", sv.V)
-		}
-		target.SetString(s)
+		target.SetString(sv.Raw)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		switch n := sv.V.(type) {
-		case int64:
-			target.SetInt(n)
-		case float64:
-			target.SetInt(int64(n))
-		case string:
-			parsed, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				return fmt.Errorf("hocon: expected int, got string %q", n)
+		parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+		if err != nil {
+			// Try parsing as float and truncating (e.g. "3.0" → 3)
+			if f, ferr := strconv.ParseFloat(sv.Raw, 64); ferr == nil {
+				target.SetInt(int64(f))
+				return nil
 			}
-			target.SetInt(parsed)
-		default:
-			return fmt.Errorf("hocon: expected int, got %T", sv.V)
+			return fmt.Errorf("hocon: expected int, got %q", sv.Raw)
 		}
+		target.SetInt(parsed)
 	case reflect.Float32, reflect.Float64:
-		switch f := sv.V.(type) {
-		case float64:
-			target.SetFloat(f)
-		case int64:
-			target.SetFloat(float64(f))
-		case string:
-			parsed, err := strconv.ParseFloat(f, 64)
-			if err != nil {
-				return fmt.Errorf("hocon: expected float, got string %q", f)
-			}
-			target.SetFloat(parsed)
-		default:
-			return fmt.Errorf("hocon: expected float, got %T", sv.V)
+		parsed, err := strconv.ParseFloat(sv.Raw, 64)
+		if err != nil {
+			return fmt.Errorf("hocon: expected float, got %q", sv.Raw)
 		}
+		target.SetFloat(parsed)
 	case reflect.Bool:
-		switch b := sv.V.(type) {
-		case bool:
-			target.SetBool(b)
-		case string:
-			parsed, err := strconv.ParseBool(b)
-			if err != nil {
-				return fmt.Errorf("hocon: expected bool, got string %q", b)
-			}
-			target.SetBool(parsed)
-		default:
-			return fmt.Errorf("hocon: expected bool, got %T", sv.V)
+		parsed, err := strconv.ParseBool(sv.Raw)
+		if err != nil {
+			return fmt.Errorf("hocon: expected bool, got %q", sv.Raw)
 		}
+		target.SetBool(parsed)
 	default:
 		return fmt.Errorf("hocon: unsupported target type %v", target.Type())
 	}


### PR DESCRIPTION
## Summary

- Replace `ScalarVal{V any}` with `ScalarVal{Raw string, Type ScalarType}`
- Parser validates number/boolean literals but stores raw string, not converted values
- `GetString()` returns `Raw` for ALL scalar types (Lightbend compatible)
- `GetInt64()`/`GetFloat64()` parse from `Raw` on demand
- `GetBool()` supports `yes/no/on/off` (case-insensitive) per HOCON spec
- `valToAny`/`unmarshalScalar` convert based on `ScalarType` discriminant
- Number detection already Lightbend-aligned (first char `0-9` or `-`)

## Test plan

- [x] All existing tests pass (`go test ./...` — 5 packages OK)
- [x] New tests: getString on number/boolean, `.33` as string, `0100` raw preservation
- [x] New tests: GetBool yes/no/on/off (14 sub-cases)
- [x] GetStringSlice now works on number arrays (intentional behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)