### PR TITLE
fix: resolve include file() paths relative to CWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `include file("path")` now resolves relative to the process working directory (CWD) instead of the including file's directory, matching the HOCON spec. Bare `include "path"` continues to resolve relative to the including file. This fixes the Lightbend `file-include` conformance test.
 - `GetBool()` now supports `yes`/`no`/`on`/`off` (case-insensitive) per HOCON spec. Previously only `true`/`false` were accepted.
 - Quoted-key include relativization: `${"a.b".c}` inside included files now resolves correctly.
 - Nested include prefix composition: multi-layer includes accumulate prefixes correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `include file("path")` now resolves relative to the process working directory (CWD) instead of the including file's directory, matching the HOCON spec. Bare `include "path"` continues to resolve relative to the including file. This fixes the Lightbend `file-include` conformance test.
+- `include file("path")` now resolves relative to the process working directory (CWD) instead of the including file's directory, matching the HOCON spec. Bare `include "path"` continues to resolve relative to the including file's directory. This fixes the Lightbend `file-include` conformance test.
 - `GetBool()` now supports `yes`/`no`/`on`/`off` (case-insensitive) per HOCON spec. Previously only `true`/`false` were accepted.
 - Quoted-key include relativization: `${"a.b".c}` inside included files now resolves correctly.
 - Nested include prefix composition: multi-layer includes accumulate prefixes correctly.

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -86,6 +86,7 @@ type IncludeNode struct {
 	pos
 	Path     string
 	Required bool
+	IsFile   bool
 }
 
 func (n *IncludeNode) node() {}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -179,7 +179,9 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 
 	// support: include "file.conf" and include file("file.conf")
 	var path string
+	isFile := false
 	if p.current.Type == lexer.TokenString && !p.current.IsQuoted && p.current.Value == "file" {
+		isFile = true
 		p.advance() // consume "file"
 		// expect '('
 		if p.current.Type != lexer.TokenLParen {
@@ -211,7 +213,7 @@ func (p *parser) parseInclude() (*IncludeNode, error) {
 		p.advance() // consume ')'
 	}
 
-	return &IncludeNode{pos: pos{line, col}, Path: path, Required: required}, nil
+	return &IncludeNode{pos: pos{line, col}, Path: path, Required: required, IsFile: isFile}, nil
 }
 
 func (p *parser) parseField() (*FieldNode, error) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -102,6 +102,40 @@ func TestParser_Include(t *testing.T) {
 	if inc.Path != "other.conf" {
 		t.Errorf("unexpected path: %s", inc.Path)
 	}
+	if inc.IsFile {
+		t.Error("expected IsFile=false for bare include")
+	}
+}
+
+func TestParser_IncludeFileIsFile(t *testing.T) {
+	obj := mustParse(t, `include file("other.conf")`)
+	if len(obj.Fields) != 1 {
+		t.Fatalf("expected 1 field (include), got %d", len(obj.Fields))
+	}
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if inc.Path != "other.conf" {
+		t.Errorf("unexpected path: %s", inc.Path)
+	}
+	if !inc.IsFile {
+		t.Error("expected IsFile=true for include file(...)")
+	}
+}
+
+func TestParser_IncludeRequiredFileIsFile(t *testing.T) {
+	obj := mustParse(t, `include required(file("base.conf"))`)
+	inc, ok := obj.Fields[0].Value.(*parser.IncludeNode)
+	if !ok {
+		t.Fatalf("expected IncludeNode, got %T", obj.Fields[0].Value)
+	}
+	if !inc.IsFile {
+		t.Error("expected IsFile=true for include required(file(...))")
+	}
+	if !inc.Required {
+		t.Error("expected Required=true")
+	}
 }
 
 func TestParser_PlusEquals(t *testing.T) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -767,7 +767,17 @@ var includeExtensions = []string{".properties", ".json", ".conf"}
 func (r *resolver) resolveInclude(inc *parser.IncludeNode, pathPrefix []string) (*ObjectVal, error) {
 	path := inc.Path
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(r.opts.BaseDir, path)
+		if inc.IsFile {
+			// file() includes resolve relative to the process working directory,
+			// NOT relative to the including file's directory (BaseDir).
+			wd, err := os.Getwd()
+			if err != nil {
+				return nil, &ResolveError{Message: "cannot determine working directory: " + err.Error()}
+			}
+			path = filepath.Join(wd, path)
+		} else {
+			path = filepath.Join(r.opts.BaseDir, path)
+		}
 	}
 
 	var included *ObjectVal

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -899,3 +899,89 @@ func TestResolver_EnvFallbackQuotedKeyPrefix(t *testing.T) {
 	ab := lookupObj(t, res, "a.b")
 	assertScalar(t, ab, "val", "ok")
 }
+
+func TestResolver_FileIncludeResolvesFromCWD(t *testing.T) {
+	// include file("path") must resolve relative to the process working
+	// directory, NOT relative to the including file's directory (BaseDir).
+	// Bare include "path" continues to resolve relative to BaseDir.
+
+	// Set up two directories: baseDir (where the .conf file lives) and cwdDir (process CWD).
+	baseDir := t.TempDir()
+	cwdDir := t.TempDir()
+
+	// Put a file in cwdDir that should be found by file() include.
+	writeFile(t, filepath.Join(cwdDir, "cwd-only.conf"), `cwd_val = "from-cwd"`)
+
+	// Put a file in baseDir that should be found by bare include.
+	writeFile(t, filepath.Join(baseDir, "base-only.conf"), `base_val = "from-base"`)
+
+	// Put a file in baseDir that has the same name as one in cwdDir but different content.
+	// This tests that file() does NOT pick up the baseDir version.
+	writeFile(t, filepath.Join(baseDir, "cwd-only.conf"), `cwd_val = "WRONG-from-base"`)
+
+	// Change CWD to cwdDir for this test.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(cwdDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	src := `
+include "base-only.conf"
+include file("cwd-only.conf")
+`
+	ast, parseErr := parser.Parse(src)
+	if parseErr != nil {
+		t.Fatalf("parse: %v", parseErr)
+	}
+	res, resolveErr := resolver.Resolve(ast, resolver.Options{BaseDir: baseDir})
+	if resolveErr != nil {
+		t.Fatalf("resolve: %v", resolveErr)
+	}
+
+	// Bare include should resolve from baseDir.
+	v, ok := res.Root.Get("base_val")
+	if !ok {
+		t.Fatal("base_val not found — bare include failed")
+	}
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "from-base" {
+		t.Errorf("base_val: expected from-base, got %s", sv.Raw)
+	}
+
+	// file() include should resolve from CWD, not baseDir.
+	v2, ok2 := res.Root.Get("cwd_val")
+	if !ok2 {
+		t.Fatal("cwd_val not found — file() include failed")
+	}
+	if sv := v2.(*resolver.ScalarVal); sv.Raw != "from-cwd" {
+		t.Errorf("cwd_val: expected from-cwd, got %s", sv.Raw)
+	}
+}
+
+func TestResolver_FileIncludeMissingSilentlySkipped(t *testing.T) {
+	// include file("nonexistent.conf") with Required=false should be silently skipped.
+	dir := t.TempDir()
+
+	src := `
+base = 1
+include file("nonexistent.conf")
+`
+	ast, parseErr := parser.Parse(src)
+	if parseErr != nil {
+		t.Fatalf("parse: %v", parseErr)
+	}
+	res, resolveErr := resolver.Resolve(ast, resolver.Options{BaseDir: dir})
+	if resolveErr != nil {
+		t.Fatalf("resolve: %v — file() include of missing file should be silently skipped", resolveErr)
+	}
+	v, ok := res.Root.Get("base")
+	if !ok {
+		t.Fatal("base not found")
+	}
+	if sv := v.(*resolver.ScalarVal); sv.Raw != "1" {
+		t.Errorf("expected 1, got %s", sv.Raw)
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -963,7 +963,19 @@ include file("cwd-only.conf")
 
 func TestResolver_FileIncludeMissingSilentlySkipped(t *testing.T) {
 	// include file("nonexistent.conf") with Required=false should be silently skipped.
+	// Use a temp directory as CWD so the test doesn't depend on the real CWD's contents.
 	dir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	writeFile(t, filepath.Join(dir, "main.conf"), "base = 1\ninclude file(\"nonexistent.conf\")\n")
 
 	src := `
 base = 1

--- a/lightbend_test.go
+++ b/lightbend_test.go
@@ -160,9 +160,8 @@ func TestLightbendExpected(t *testing.T) {
 
 	// Known failures — skip tests that cannot pass yet
 	skip := map[string]string{
-		"test01-expected.json":       "system section contains environment-dependent values",
-		"test02-expected.json":       "unresolved substitution for empty-key path",
-		"file-include-expected.json": "extra keys from file include (bar-file, baz)",
+		"test01-expected.json": "system section contains environment-dependent values",
+		"test02-expected.json": "unresolved substitution for empty-key path",
 	}
 
 	for _, e := range entries {


### PR DESCRIPTION
## Summary

- `include file("path")` now resolves relative to the process working directory (CWD) instead of the including file's directory, matching the HOCON spec
- Bare `include "path"` continues to resolve relative to the including file's directory (unchanged)
- Adds `IsFile` field to `IncludeNode` AST and sets it when parsing `file(...)` syntax
- Removes `file-include-expected.json` from the Lightbend conformance skip list (test now passes)

## Test plan

- [x] `TestParser_IncludeFileIsFile` — verifies `IsFile=true` for `include file(...)`
- [x] `TestParser_IncludeRequiredFileIsFile` — verifies `IsFile=true` for `include required(file(...))`
- [x] `TestParser_Include` — verifies `IsFile=false` for bare `include "..."`
- [x] `TestResolver_FileIncludeResolvesFromCWD` — verifies file() resolves from CWD while bare resolves from BaseDir
- [x] `TestResolver_FileIncludeMissingSilentlySkipped` — verifies missing file() include is silently skipped
- [x] `TestLightbendExpected/file-include.conf` — Lightbend conformance test passes
- [x] `go test ./...` all pass
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)