### PR TITLE
docs: add library stance and cross-language conformance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A full [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md)
 
 [日本語](README.ja.md)
 
+**Library stance** -- go.hocon is a HOCON config loader, not a low-level parser API. Its purpose is reading `.hocon` files and providing typed access via the Config API (`GetString`, `GetInt`, `GetFloat64`, `GetBool`, `GetDuration`, `GetBytes`, `Unmarshal`). Internal types such as `ScalarVal` may change between minor versions.
+
+**Cross-language conformance** -- This implementation is tested against shared expected-JSON fixtures from [o3co/xx.hocon](https://github.com/o3co/xx.hocon) alongside [ts.hocon](https://github.com/o3co/ts.hocon) and [rs.hocon](https://github.com/o3co/rs.hocon) to ensure all three implementations meet the same Lightbend HOCON specification.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add a **Library stance** note near the top of the README clarifying that go.hocon is a config loader API, not a low-level parser — internal types like `ScalarVal` may change between minor versions.
- Add a **Cross-language conformance** note explaining that go.hocon, ts.hocon, and rs.hocon share expected-JSON fixtures from xx.hocon to verify spec compliance.

## Test plan
- [ ] Verify README renders correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)