### PR TITLE
fix: support hocon:"-" to skip fields in Unmarshal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `Unmarshal`: `hocon:"-"` now skips the field, matching the Go ecosystem convention (`encoding/json`, `encoding/xml`, `yaml.v3`, `toml`). Previously it attempted to look up a literal key `"-"`.
+
 ## [1.1.0] - 2026-04-05
 
 ### Changed

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -85,7 +85,10 @@ func unmarshalStruct(val resolver.Val, target reflect.Value) error {
 		if !fval.CanSet() {
 			continue
 		}
-		key, omitempty := parseTag(field)
+		key, omitempty, skip := parseTag(field)
+		if skip {
+			continue
+		}
 		v, ok2 := obj.Get(key)
 		if !ok2 {
 			if omitempty {
@@ -108,10 +111,13 @@ func unmarshalStruct(val resolver.Val, target reflect.Value) error {
 	return nil
 }
 
-func parseTag(f reflect.StructField) (key string, omitempty bool) {
+func parseTag(f reflect.StructField) (key string, omitempty bool, skip bool) {
 	tag := f.Tag.Get("hocon")
 	if tag == "" {
-		return strings.ToLower(f.Name), false
+		return strings.ToLower(f.Name), false, false
+	}
+	if tag == "-" {
+		return "", false, true
 	}
 	parts := strings.SplitN(tag, ",", 2)
 	key = parts[0]

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -168,6 +168,24 @@ func TestUnmarshal_MapStringBool(t *testing.T) {
 	}
 }
 
+func TestUnmarshal_SkipTag(t *testing.T) {
+	type Cfg struct {
+		Name     string `hocon:"name"`
+		Computed string `hocon:"-"`
+	}
+	cfg := mustParseCfg(t, `name = "alice"`)
+	c := Cfg{Computed: "should stay"}
+	if err := cfg.Unmarshal(&c); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if c.Name != "alice" {
+		t.Errorf("Name=%q, want alice", c.Name)
+	}
+	if c.Computed != "should stay" {
+		t.Errorf("Computed=%q, want 'should stay' (skip should preserve value)", c.Computed)
+	}
+}
+
 func TestUnmarshal_MapStringFloat64(t *testing.T) {
 	cfg := mustParseCfg(t, "rates { usd = 1.0, eur = 0.85 }")
 	var result struct{ Rates map[string]float64 }


### PR DESCRIPTION
## Summary
- `hocon:"-"` now skips fields during `Unmarshal`, matching the Go ecosystem convention (`encoding/json`, `encoding/xml`, `yaml.v3`, `toml`)
- Previously, `hocon:"-"` attempted to look up a literal key `"-"` in the config, causing `missing required field "-"` errors

Fixes #52

## Test plan
- [x] `TestUnmarshal_SkipTag` — verifies skipped field preserves its pre-populated value
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)