### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.1] - 2026-04-10
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Update CHANGELOG `[Unreleased]` → `[1.1.1] - 2026-04-10`

Tag `v1.1.1` already pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)