### PR TITLE
docs: align README spec-compliance claims with docs/spec-compliance.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -202,7 +202,7 @@ max-size  = "512MiB"
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-12 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標 | 状況 |
 | --- | --- |
@@ -210,8 +210,6 @@ max-size  = "512MiB"
 | In-scope のみ | **58.2%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
-
-ts/rs/go 横断のロールアップ: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md)。
 
 ## 関連プロジェクト
 
@@ -221,7 +219,7 @@ ts/rs/go 横断のロールアップ: [`xx.hocon/docs/compliance-matrix.md`](htt
 | [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | Rust 向け HOCON パーサー |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties 変換 CLI |
 
-3 実装はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+3 つのパーサー実装（[ts.hocon](https://github.com/o3co/ts.hocon)、[rs.hocon](https://github.com/o3co/rs.hocon)、[go.hocon](https://github.com/o3co/go.hocon)）はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 ## ベストプラクティス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/o3co/go.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-[Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 仕様に完全準拠した Go ライブラリ。
+[Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 仕様の Go パーサー。現在の準拠率は [仕様準拠](#仕様準拠) を参照。
 
 > **[Claude](https://claude.ai/)（Anthropic）による実装** — 設計・実装のすべてを Claude Code が担当。
 > [GitHub Copilot](https://github.com/features/copilot) および [OpenAI Codex](https://openai.com/index/openai-codex/) によるレビュー。
@@ -202,9 +202,16 @@ max-size  = "512MiB"
 
 ## 仕様準拠
 
-[Lightbend 公式テストスイート](https://github.com/lightbend/config/tree/main/config/src/test/resources) で検証済み：**13/13 グループ PASS**（equiv01-equiv05 + test01-test13）。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。
 
-[hocon2](https://github.com/o3co/hocon2) の準拠テスト（JSON, YAML, TOML, Properties 出力で 77/77 PASS）でも検証済み。
+| 指標 | 状況 |
+| --- | --- |
+| 仕様全体（out-of-scope を含む） | **52.6%** |
+| In-scope のみ | **58.2%** |
+| Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
+| [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
+
+ts/rs/go 横断のロールアップ: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md)。
 
 ## 関連プロジェクト
 
@@ -214,7 +221,7 @@ max-size  = "512MiB"
 | [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | Rust 向け HOCON パーサー |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties 変換 CLI |
 
-すべての実装が Lightbend HOCON 仕様に完全準拠しています。
+3 実装はすべて同じ Lightbend HOCON 仕様で追跡されています — 実装ごとの準拠率は [横断ロールアップ](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 ## ベストプラクティス
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md).
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-12; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
 
 | Metric | Status |
 | --- | --- |
@@ -272,8 +272,6 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 | In-scope only | **58.2%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
-
-Cross-impl roll-up across ts/rs/go: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
 
 ## Related Projects
 
@@ -283,7 +281,7 @@ Cross-impl roll-up across ts/rs/go: [`xx.hocon/docs/compliance-matrix.md`](https
 | [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | HOCON parser for Rust |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
-All three implementations are tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
+The three parser implementations ([ts.hocon](https://github.com/o3co/ts.hocon), [rs.hocon](https://github.com/o3co/rs.hocon), [go.hocon](https://github.com/o3co/go.hocon)) are all tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
 
 ## Best Practices
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/o3co/go.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-A full [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) spec-compliant Go library.
+A [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) parser for Go. See [Spec Compliance](#spec-compliance) for the current conformance rate.
 
 > **Implemented by [Claude](https://claude.ai/) (Anthropic)** — designed and built end-to-end with Claude Code.
 > Reviewed by [GitHub Copilot](https://github.com/features/copilot) and [OpenAI Codex](https://openai.com/index/openai-codex/).
@@ -264,9 +264,16 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-Tested against the [Lightbend official test suite](https://github.com/lightbend/config/tree/main/config/src/test/resources): **13/13 test groups pass** (equiv01–equiv05 + test01–test13).
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md).
 
-Also verified via [hocon2](https://github.com/o3co/hocon2) conformance tests (77/77 pass across JSON, YAML, TOML, and Properties output).
+| Metric | Status |
+| --- | --- |
+| Spec total (incl. out-of-scope) | **52.6%** |
+| In-scope only | **58.2%** |
+| Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
+| [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
+
+Cross-impl roll-up across ts/rs/go: [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
 
 ## Related Projects
 
@@ -276,7 +283,7 @@ Also verified via [hocon2](https://github.com/o3co/hocon2) conformance tests (77
 | [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | HOCON parser for Rust |
 | [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
-All implementations are full Lightbend HOCON spec compliant.
+All three implementations are tracked against the same Lightbend HOCON spec — see the [cross-impl roll-up](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for per-impl conformance rates.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

- Replace "A full Lightbend HOCON spec-compliant Go library" tagline and "All implementations are full Lightbend HOCON spec compliant" footer with the actual conformance rates tracked in [docs/spec-compliance.md](docs/spec-compliance.md): **52.6% spec-total / 58.2% in-scope**.
- The Lightbend 13/13 test groups (equiv01–equiv05 + test01–test13) and hocon2 77/77 conformance pass-rates remain, now framed as rows in the Spec Compliance table.
- Link to cross-impl roll-up at [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md).
- Same edits applied to README.ja.md.

## Why

`docs/spec-compliance.md` (merged in #56) tracks conformance at 209-item granularity and reports honest rates. The README's "full compliant" wording contradicts that. Resolving by softening the README, not by inflating the spec-compliance numbers.

## Companion PRs

- [o3co/ts.hocon#71](https://github.com/o3co/ts.hocon/pull/71)
- [o3co/rs.hocon#61](https://github.com/o3co/rs.hocon/pull/61)

## Test plan

- [x] No code changes
- [x] Internal anchor `#spec-compliance` / `#仕様準拠` resolves
- [x] Cross-repo absolute URL to xx.hocon matrix is accurate
- [x] Markdown lint clean (table style follows existing compact convention in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)