### PR TITLE
test: spec compliance Phase 1 — lexer & comma rules (12 items)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -206,8 +206,8 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **52.6%** |
-| In-scope のみ | **58.2%** |
+| 仕様全体（out-of-scope を含む） | **55.7%** |
+| In-scope のみ | **61.6%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -206,8 +206,8 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **55.7%** |
-| In-scope のみ | **61.6%** |
+| 仕様全体（out-of-scope を含む） | **56.7%** |
+| In-scope のみ | **62.7%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **52.6%** |
-| In-scope only | **58.2%** |
+| Spec total (incl. out-of-scope) | **55.7%** |
+| In-scope only | **61.6%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **55.7%** |
-| In-scope only | **61.6%** |
+| Spec total (incl. out-of-scope) | **56.7%** |
+| In-scope only | **62.7%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -120,11 +120,11 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: internal/lexer/lexer_test.go:439 (TestSpecS6_1_UnicodeCategoryZsIsWhitespace); internal/lexer/lexer_test.go:459 (TestSpecS6_1_UnicodeCategoryZlIsWhitespace)
-  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — lexer rejects Zs/Zl chars with "unexpected character" instead of treating them as whitespace separators
+  tests: internal/lexer/lexer_test.go:439 (TestSpecS6_1_UnicodeCategoryZsIsWhitespace); internal/lexer/lexer_test.go:459 (TestSpecS6_1_UnicodeCategoryZlIsWhitespace); internal/lexer/lexer_test.go:478 (TestSpecS6_1_UnicodeCategoryZpIsWhitespace)
+  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — lexer rejects Zs/Zl/Zp chars with "unexpected character" instead of treating them as whitespace separators
 
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: internal/lexer/lexer_test.go:477 (TestSpecS6_2_NBSPIsWhitespace); internal/lexer/lexer_test.go:494 (TestSpecS6_2_FigureSpaceIsWhitespace); internal/lexer/lexer_test.go:511 (TestSpecS6_2_NarrowNBSPIsWhitespace)
+  tests: internal/lexer/lexer_test.go:496 (TestSpecS6_2_NBSPIsWhitespace); internal/lexer/lexer_test.go:513 (TestSpecS6_2_FigureSpaceIsWhitespace); internal/lexer/lexer_test.go:530 (TestSpecS6_2_NarrowNBSPIsWhitespace)
   status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — NBSP / figure space / narrow NBSP are rejected with "unexpected character" instead of acting as whitespace
 
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
@@ -132,7 +132,7 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: internal/lexer/lexer_test.go:528 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:544 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:561 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:579 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:597 (TestSpecS6_4_SeparatorsAreWhitespace)
+  tests: internal/lexer/lexer_test.go:547 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:563 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:580 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:598 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:616 (TestSpecS6_4_SeparatorsAreWhitespace)
   status: ⚠️ ([#59](https://github.com/o3co/go.hocon/issues/59)) — 2 of 8 sub-rules pass: tab (0x09) and CR (0x0D) are recognized; vtab (0x0B) and FF (0x0C) emit "unexpected character"; FS–US (0x1C–0x1F) are absorbed into unquoted string runs
 
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
@@ -188,15 +188,15 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S8.6** Unquoted string cannot begin with `0-9` or `-` — §Unquoted strings (L270)
-  tests: internal/lexer/lexer_test.go:619 (TestSpecS8_6_DigitStartUnquotedRejected); internal/lexer/lexer_test.go:633 (TestSpecS8_6_HyphenStartUnquotedRejected)
+  tests: internal/lexer/lexer_test.go:638 (TestSpecS8_6_DigitStartUnquotedRejected); internal/lexer/lexer_test.go:652 (TestSpecS8_6_HyphenStartUnquotedRejected)
   status: ❌ ([#60](https://github.com/o3co/go.hocon/issues/60)) — lexer dispatches digit/hyphen to readNumber then emits TokenInt for the prefix; non-numeric suffix "123abc" → TokenInt("123") + TokenString("abc") instead of error
 
 - **S8.7** No escape sequences in unquoted strings — §Unquoted strings (L253)
-  tests: internal/lexer/lexer_test.go:646 (TestSpecS8_7_BackslashRejectedInUnquoted)
+  tests: internal/lexer/lexer_test.go:665 (TestSpecS8_7_BackslashRejectedInUnquoted)
   status: ✅
 
 - **S8.8** Unquoted strings allow control characters except forbidden set — §Unquoted strings (L280)
-  tests: internal/lexer/lexer_test.go:658 (TestSpecS8_8_ControlCharsAllowedInUnquoted)
+  tests: internal/lexer/lexer_test.go:677 (TestSpecS8_8_ControlCharsAllowedInUnquoted)
   status: ✅
 
 ## S9. Multi-line strings

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -60,8 +60,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S2.3** Comment markers inside quoted strings are literal — §Comments (L126)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:408 (TestSpecS2_3_CommentMarkersInQuotedString)
+  status: ✅
 
 ## S3. Omit root braces
 
@@ -98,42 +98,42 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S5.2** Single trailing comma is allowed and ignored — §Commas (L155)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:453 (TestSpecS5_2_SingleTrailingCommaInArrayAllowed); internal/parser/parser_test.go:473 (TestSpecS5_2_SingleTrailingCommaInObjectAllowed)
+  status: ✅
 
 - **S5.3** Two trailing commas (`[1,2,3,,]`) is invalid — §Commas (L160)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:485 (TestSpecS5_3_TwoTrailingCommasInArrayInvalid)
+  status: ✅
 
 - **S5.4** Leading comma (`[,1,2,3]`) is invalid — §Commas (L161)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:493 (TestSpecS5_4_LeadingCommaInArrayInvalid)
+  status: ✅
 
 - **S5.5** Two consecutive commas (`[1,,2,3]`) is invalid — §Commas (L162)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:501 (TestSpecS5_5_ConsecutiveCommasInArrayInvalid)
+  status: ✅
 
 - **S5.6** Same comma rules apply to object fields — §Commas (L163)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:510 (TestSpecS5_6_CommaRulesApplyToObjects)
+  status: ✅
 
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:439 (TestSpecS6_1_UnicodeCategoryZsIsWhitespace); internal/lexer/lexer_test.go:459 (TestSpecS6_1_UnicodeCategoryZlIsWhitespace)
+  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — lexer rejects Zs/Zl chars with "unexpected character" instead of treating them as whitespace separators
 
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:477 (TestSpecS6_2_NBSPIsWhitespace); internal/lexer/lexer_test.go:494 (TestSpecS6_2_FigureSpaceIsWhitespace); internal/lexer/lexer_test.go:511 (TestSpecS6_2_NarrowNBSPIsWhitespace)
+  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — NBSP / figure space / narrow NBSP are rejected with "unexpected character" instead of acting as whitespace
 
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
   tests: config_test.go:408 (TestConfig_BOM_ParseFile); config_test.go:422 (TestConfig_BOM_ParseString); testdata/hocon/bom.conf (fixture)
   status: ✅
 
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:528 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:544 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:561 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:579 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:597 (TestSpecS6_4_SeparatorsAreWhitespace)
+  status: ⚠️ ([#59](https://github.com/o3co/go.hocon/issues/59)) — 2 of 8 sub-rules pass: tab (0x09) and CR (0x0D) are recognized; vtab (0x0B) and FF (0x0C) emit "unexpected character"; FS–US (0x1C–0x1F) are absorbed into unquoted string runs
 
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: —
@@ -188,16 +188,16 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S8.6** Unquoted string cannot begin with `0-9` or `-` — §Unquoted strings (L270)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:619 (TestSpecS8_6_DigitStartUnquotedRejected); internal/lexer/lexer_test.go:633 (TestSpecS8_6_HyphenStartUnquotedRejected)
+  status: ❌ ([#60](https://github.com/o3co/go.hocon/issues/60)) — lexer dispatches digit/hyphen to readNumber then emits TokenInt for the prefix; non-numeric suffix "123abc" → TokenInt("123") + TokenString("abc") instead of error
 
 - **S8.7** No escape sequences in unquoted strings — §Unquoted strings (L253)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:646 (TestSpecS8_7_BackslashRejectedInUnquoted)
+  status: ✅
 
 - **S8.8** Unquoted strings allow control characters except forbidden set — §Unquoted strings (L280)
-  tests: —
-  status: 🤷
+  tests: internal/lexer/lexer_test.go:658 (TestSpecS8_8_ControlCharsAllowedInUnquoted)
+  status: ✅
 
 ## S9. Multi-line strings
 

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -440,7 +440,7 @@ func TestSpecS6_1_UnicodeCategoryZsIsWhitespace(t *testing.T) {
 	t.Skipf("spec violation, see #59")
 	// Em space (U+2003, Zs) between two unquoted tokens should act as a
 	// separator, producing two separate TokenString tokens.
-	src := "a b"
+	src := "a\u2003b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
@@ -459,7 +459,26 @@ func TestSpecS6_1_UnicodeCategoryZsIsWhitespace(t *testing.T) {
 func TestSpecS6_1_UnicodeCategoryZlIsWhitespace(t *testing.T) {
 	t.Skipf("spec violation, see #59")
 	// Line separator (U+2028, Zl) should separate two unquoted tokens.
-	src := "a b"
+	src := "a\u2028b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("src=%q: got string tokens %v, want [a b]", src, strings_)
+	}
+}
+
+// TestSpecS6_1_UnicodeCategoryZpIsWhitespace verifies that paragraph separator
+// (U+2029, Zp) is treated as whitespace. Spec L170 covers Zs/Zl/Zp; this is the
+// Zp half. Status: ❌ spec violation — see issue #59.
+func TestSpecS6_1_UnicodeCategoryZpIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	// Paragraph separator (U+2029, Zp) should separate two unquoted tokens.
+	src := "a\u2029b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
@@ -476,7 +495,7 @@ func TestSpecS6_1_UnicodeCategoryZlIsWhitespace(t *testing.T) {
 // Spec L171. Status: ❌ spec violation — see issue #59.
 func TestSpecS6_2_NBSPIsWhitespace(t *testing.T) {
 	t.Skipf("spec violation, see #59")
-	src := "a b"
+	src := "a\u00a0b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
@@ -493,7 +512,7 @@ func TestSpecS6_2_NBSPIsWhitespace(t *testing.T) {
 // Spec L171. Status: ❌ spec violation — see issue #59.
 func TestSpecS6_2_FigureSpaceIsWhitespace(t *testing.T) {
 	t.Skipf("spec violation, see #59")
-	src := "a b"
+	src := "a\u2007b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
@@ -510,7 +529,7 @@ func TestSpecS6_2_FigureSpaceIsWhitespace(t *testing.T) {
 // Spec L171. Status: ❌ spec violation — see issue #59.
 func TestSpecS6_2_NarrowNBSPIsWhitespace(t *testing.T) {
 	t.Skipf("spec violation, see #59")
-	src := "a b"
+	src := "a\u202fb"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -387,3 +387,294 @@ func TestUnknownEscapeError(t *testing.T) {
 		}
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Spec compliance Phase 1 (issue #57): lexer-level rules.
+//
+// Each test is annotated with its xx.hocon spec checklist ID (S<n>.<m>).
+// Where the current implementation diverges from spec, the test body calls
+//
+//	t.Skipf("spec violation, see #NN")
+//
+// as its first statement. This wires the spec-correct assertion while keeping
+// CI green (skipped tests are reported but not failed). When the underlying
+// bug is fixed, remove the t.Skipf call and promote the
+// docs/spec-compliance.md status row from ❌ / ⚠️ to ✅ or ⚠️ (partial).
+// -----------------------------------------------------------------------------
+
+// TestSpecS2_3_CommentMarkersInQuotedString verifies that // and # inside a
+// quoted string are treated as literal characters, not comment starts.
+// Spec L126.
+func TestSpecS2_3_CommentMarkersInQuotedString(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{`"http://example.com"`, "http://example.com"},
+		{`"# not a comment"`, "# not a comment"},
+	}
+	for _, tc := range cases {
+		toks := tokenize(tc.src)
+		if len(toks) == 0 {
+			t.Fatalf("src=%q: no tokens", tc.src)
+		}
+		tok := toks[0]
+		if tok.Type != lexer.TokenString {
+			t.Errorf("src=%q: got type %v, want TokenString", tc.src, tok.Type)
+		}
+		if !tok.IsQuoted {
+			t.Errorf("src=%q: IsQuoted=false, want true", tc.src)
+		}
+		if tok.Value != tc.want {
+			t.Errorf("src=%q: value=%q, want %q", tc.src, tok.Value, tc.want)
+		}
+	}
+}
+
+// TestSpecS6_1_UnicodeCategoryZsIsWhitespace verifies that Unicode Zs-category
+// characters (e.g. em space U+2003) are treated as token separators.
+// Spec L170.
+// Status: ❌ spec violation — lexer rejects Zs chars with "unexpected character"
+// instead of treating them as whitespace. See issue #59.
+func TestSpecS6_1_UnicodeCategoryZsIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	// Em space (U+2003, Zs) between two unquoted tokens should act as a
+	// separator, producing two separate TokenString tokens.
+	src := "a b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("src=%q: got string tokens %v, want [a b]", src, strings_)
+	}
+}
+
+// TestSpecS6_1_UnicodeCategoryZlIsWhitespace verifies that line separator
+// (U+2028, Zl) is treated as whitespace. Spec L170.
+// Status: ❌ spec violation — see issue #59.
+func TestSpecS6_1_UnicodeCategoryZlIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	// Line separator (U+2028, Zl) should separate two unquoted tokens.
+	src := "a b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("src=%q: got string tokens %v, want [a b]", src, strings_)
+	}
+}
+
+// TestSpecS6_2_NBSPIsWhitespace verifies that NBSP (U+00A0) is whitespace.
+// Spec L171. Status: ❌ spec violation — see issue #59.
+func TestSpecS6_2_NBSPIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	src := "a b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("NBSP: got string tokens %v, want [a b]", strings_)
+	}
+}
+
+// TestSpecS6_2_FigureSpaceIsWhitespace verifies figure space (U+2007).
+// Spec L171. Status: ❌ spec violation — see issue #59.
+func TestSpecS6_2_FigureSpaceIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	src := "a b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("figure space: got string tokens %v, want [a b]", strings_)
+	}
+}
+
+// TestSpecS6_2_NarrowNBSPIsWhitespace verifies narrow no-break space (U+202F).
+// Spec L171. Status: ❌ spec violation — see issue #59.
+func TestSpecS6_2_NarrowNBSPIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	src := "a b"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("narrow NBSP: got string tokens %v, want [a b]", strings_)
+	}
+}
+
+// TestSpecS6_4_TabIsWhitespace verifies tab (0x09) is a whitespace separator.
+// Spec L174. Status: ✅
+func TestSpecS6_4_TabIsWhitespace(t *testing.T) {
+	src := "a\tb"
+	toks := tokenize(src)
+	var strToks []lexer.Token
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strToks = append(strToks, tok)
+		}
+	}
+	if len(strToks) != 2 || strToks[0].Value != "a" || strToks[1].Value != "b" {
+		t.Errorf("tab: got string tokens %v, want [a b]", strToks)
+	}
+}
+
+// TestSpecS6_4_CRIsWhitespace verifies carriage return (0x0D) is whitespace.
+// Spec L174. Status: ✅
+func TestSpecS6_4_CRIsWhitespace(t *testing.T) {
+	src := "a\rb"
+	toks := tokenize(src)
+	var strToks []lexer.Token
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strToks = append(strToks, tok)
+		}
+	}
+	if len(strToks) != 2 || strToks[0].Value != "a" || strToks[1].Value != "b" {
+		t.Errorf("CR: got string tokens %v, want [a b]", strToks)
+	}
+}
+
+// TestSpecS6_4_VtabIsWhitespace verifies vertical tab (0x0B) is whitespace.
+// Spec L174. Status: ❌ spec violation — lexer rejects with "unexpected character".
+// See issue #59.
+func TestSpecS6_4_VtabIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	src := "a\x0bb"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("vtab: got string tokens %v, want [a b]", strings_)
+	}
+}
+
+// TestSpecS6_4_FFIsWhitespace verifies form feed (0x0C) is whitespace.
+// Spec L174. Status: ❌ spec violation — lexer rejects with "unexpected character".
+// See issue #59.
+func TestSpecS6_4_FFIsWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	src := "a\x0cb"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("FF: got string tokens %v, want [a b]", strings_)
+	}
+}
+
+// TestSpecS6_4_SeparatorsAreWhitespace verifies FS/GS/RS/US (0x1C-0x1F) are
+// whitespace. Spec L174. Status: ❌ spec violation — these chars are absorbed
+// into unquoted string runs instead of acting as separators. See issue #59.
+func TestSpecS6_4_SeparatorsAreWhitespace(t *testing.T) {
+	t.Skipf("spec violation, see #59")
+	// FS=0x1C, GS=0x1D, RS=0x1E, US=0x1F — all must act as whitespace
+	for _, ch := range []rune{'\x1c', '\x1d', '\x1e', '\x1f'} {
+		src := "a" + string(ch) + "b"
+		toks := tokenize(src)
+		var strings_ []string
+		for _, tok := range toks {
+			if tok.Type == lexer.TokenString {
+				strings_ = append(strings_, tok.Value)
+			}
+		}
+		if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+			t.Errorf("U+%04X: got string tokens %v, want [a b]", ch, strings_)
+		}
+	}
+}
+
+// TestSpecS8_6_DigitStartUnquotedRejected verifies that an unquoted string
+// starting with a digit (e.g. "123abc") is rejected. Spec L270.
+// Status: ❌ spec violation — lexer tokenizes "123abc" as TokenInt("123") +
+// TokenString("abc") instead of rejecting. See issue #60.
+func TestSpecS8_6_DigitStartUnquotedRejected(t *testing.T) {
+	t.Skipf("spec violation, see #60")
+	// "x = 123abc": the value "123abc" starts with a digit and is not a valid
+	// JSON number, so it should be rejected (parse error).
+	_, err := lexer.Tokenize("123abc")
+	if err == nil {
+		t.Error("expected error for digit-starting unquoted string '123abc', got nil")
+	}
+}
+
+// TestSpecS8_6_HyphenStartUnquotedRejected verifies that "-foo" (not a valid
+// JSON number) is rejected. Spec L270.
+// Status: ❌ spec violation — lexer tokenizes "-foo" as TokenInt("-") +
+// TokenString("foo"). See issue #60.
+func TestSpecS8_6_HyphenStartUnquotedRejected(t *testing.T) {
+	t.Skipf("spec violation, see #60")
+	// "-foo" starts with '-' and is not a valid JSON number, so it should
+	// be rejected. "-123" is a valid number and is not tested here.
+	_, err := lexer.Tokenize("-foo")
+	if err == nil {
+		t.Error("expected error for hyphen-starting non-number '-foo', got nil")
+	}
+}
+
+// TestSpecS8_7_BackslashRejectedInUnquoted verifies that a backslash in an
+// unquoted string position is rejected (no escape decoding in unquoted strings).
+// Spec L253. Status: ✅
+func TestSpecS8_7_BackslashRejectedInUnquoted(t *testing.T) {
+	// tokenize("a\n") — the backslash terminates the unquoted run via
+	// isUnquotedForbidden, then the lexer hits the bare '\' and emits an error.
+	_, err := lexer.Tokenize(`a\n`)
+	if err == nil {
+		t.Error("expected error for backslash in unquoted string, got nil")
+	}
+}
+
+// TestSpecS8_8_ControlCharsAllowedInUnquoted verifies that control characters
+// not in the forbidden set (e.g. SOH 0x01, BEL 0x07) are allowed inside
+// unquoted strings. Spec L280. Status: ✅
+func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"SOH (0x01)", "foo\x01bar", "foo\x01bar"},
+		{"BEL (0x07)", "foo\x07bar", "foo\x07bar"},
+	}
+	for _, tc := range cases {
+		toks := tokenize(tc.src)
+		if len(toks) == 0 {
+			t.Fatalf("%s: no tokens", tc.name)
+		}
+		tok := toks[0]
+		if tok.Type != lexer.TokenString {
+			t.Errorf("%s: type=%v, want TokenString", tc.name, tok.Type)
+		}
+		if tok.Value != tc.want {
+			t.Errorf("%s: value=%q, want %q", tc.name, tok.Value, tc.want)
+		}
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -438,3 +438,86 @@ func TestBracedRootTrailingGarbage(t *testing.T) {
 		})
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Spec compliance Phase 1 (issue #57): parser-level comma rules (S5.2–S5.6).
+//
+// Convention: tests assert spec-correct behavior. Where the impl currently
+// violates spec, use t.Skipf("spec violation, see #NN") at the top of the
+// test. See lexer/lexer_test.go for the full Phase 1 convention comment.
+// -----------------------------------------------------------------------------
+
+// TestSpecS5_2_SingleTrailingCommaInArrayAllowed verifies that a single
+// trailing comma in an array is silently ignored. Spec L155.
+// Status: ✅
+func TestSpecS5_2_SingleTrailingCommaInArrayAllowed(t *testing.T) {
+	obj, err := parser.Parse("list = [1, 2, 3,]")
+	if err != nil {
+		t.Fatalf("expected no error for trailing comma in array, got: %v", err)
+	}
+	if len(obj.Fields) == 0 {
+		t.Fatal("expected at least one field")
+	}
+	arr, ok := obj.Fields[0].Value.(*parser.ArrayNode)
+	if !ok {
+		t.Fatalf("expected ArrayNode, got %T", obj.Fields[0].Value)
+	}
+	if len(arr.Elements) != 3 {
+		t.Errorf("expected 3 elements (trailing comma ignored), got %d", len(arr.Elements))
+	}
+}
+
+// TestSpecS5_2_SingleTrailingCommaInObjectAllowed verifies that a single
+// trailing comma in an object is silently ignored. Spec L155.
+// Status: ✅
+func TestSpecS5_2_SingleTrailingCommaInObjectAllowed(t *testing.T) {
+	obj, err := parser.Parse("{ a = 1, b = 2, }")
+	if err != nil {
+		t.Fatalf("expected no error for trailing comma in object, got: %v", err)
+	}
+	if len(obj.Fields) != 2 {
+		t.Errorf("expected 2 fields (trailing comma ignored), got %d", len(obj.Fields))
+	}
+}
+
+// TestSpecS5_3_TwoTrailingCommasInArrayInvalid verifies that [1,2,3,,] is
+// rejected. Spec L160. Status: ✅
+func TestSpecS5_3_TwoTrailingCommasInArrayInvalid(t *testing.T) {
+	if _, err := parser.Parse("list = [1,2,3,,]"); err == nil {
+		t.Error("expected error for double trailing comma [1,2,3,,], got nil")
+	}
+}
+
+// TestSpecS5_4_LeadingCommaInArrayInvalid verifies that [,1,2,3] is rejected.
+// Spec L161. Status: ✅
+func TestSpecS5_4_LeadingCommaInArrayInvalid(t *testing.T) {
+	if _, err := parser.Parse("list = [,1,2,3]"); err == nil {
+		t.Error("expected error for leading comma [,1,2,3], got nil")
+	}
+}
+
+// TestSpecS5_5_ConsecutiveCommasInArrayInvalid verifies that [1,,2,3] is
+// rejected. Spec L162. Status: ✅
+func TestSpecS5_5_ConsecutiveCommasInArrayInvalid(t *testing.T) {
+	if _, err := parser.Parse("list = [1,,2,3]"); err == nil {
+		t.Error("expected error for consecutive commas [1,,2,3], got nil")
+	}
+}
+
+// TestSpecS5_6_CommaRulesApplyToObjects verifies that the same leading/double
+// comma rules that apply to arrays also apply to object fields. Spec L163.
+// Status: ✅
+func TestSpecS5_6_CommaRulesApplyToObjects(t *testing.T) {
+	invalid := []struct {
+		name string
+		src  string
+	}{
+		{"leading comma in object", "{ ,a = 1, b = 2 }"},
+		{"double comma in object", "{ a = 1,, b = 2 }"},
+	}
+	for _, tc := range invalid {
+		if _, err := parser.Parse(tc.src); err == nil {
+			t.Errorf("%s: expected error for %q, got nil", tc.name, tc.src)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Go counterpart to ts.hocon PR #74. Adds spec-assertion tests for the 12 Phase 1 spec items (S2.3, S5.2–S5.6, S6.1, S6.2, S6.4, S8.6, S8.7, S8.8) and promotes all 12 rows in `docs/spec-compliance.md` from 🤷 to a confirmed status.

Refs #57.

### Convention (mirrors ts.hocon PR #74)

Passing specs use plain `TestXxx(t *testing.T)` functions. Known violations call `t.Skipf("spec violation, see #NN")` as their first statement — the assertion is wired, CI stays green (skip is reported not failed), and removing the `t.Skipf` when the bug is fixed makes the assertion live and flips CI red until fixed correctly.

### Per-item results

| Item | Status | Notes |
|------|--------|-------|
| S2.3 | ✅ | `//` and `#` inside quoted strings are literal |
| S5.2 | ✅ | Single trailing comma in array + object allowed |
| S5.3 | ✅ | Double trailing comma rejected |
| S5.4 | ✅ | Leading comma rejected |
| S5.5 | ✅ | Consecutive commas rejected |
| S5.6 | ✅ | Same comma rules apply to objects |
| S6.1 | ❌ | Zs/Zl chars rejected as errors instead of treated as whitespace ([#59](https://github.com/o3co/go.hocon/issues/59)) |
| S6.2 | ❌ | NBSP / figure space / narrow NBSP rejected as errors ([#59](https://github.com/o3co/go.hocon/issues/59)) |
| S6.4 | ⚠️ | 2 of 8 sub-rules pass: tab + CR only; vtab/FF error; FS–US absorbed into unquoted runs ([#59](https://github.com/o3co/go.hocon/issues/59)) |
| S8.6 | ❌ | Digit/hyphen prefix tokenised as partial number + unquoted suffix, not rejected ([#60](https://github.com/o3co/go.hocon/issues/60)) |
| S8.7 | ✅ | Backslash in unquoted string position is rejected |
| S8.8 | ✅ | SOH/BEL and similar control chars allowed in unquoted strings |

### Compliance rate change

| Metric | Before | After |
|--------|--------|-------|
| Spec total (incl. out-of-scope) | 52.6% | **55.7%** |
| In-scope only | 58.2% | **61.6%** |

### Bug issues filed

- [#59](https://github.com/o3co/go.hocon/issues/59): lexer ignores spec-mandated whitespace categories (S6.1, S6.2, S6.4)
- [#60](https://github.com/o3co/go.hocon/issues/60): lexer accepts digits and hyphen as unquoted-string starts (S8.6)

## Test plan

- [x] `go test -race ./...` — all pass (skipped tests are not failures)
- [x] `golangci-lint run` — 0 issues
- [x] All 12 spec items covered with at least one named test function
- [x] Skipped tests document which issue tracks the fix
- [x] `docs/spec-compliance.md` rows promoted with test file:line references
- [x] README.md and README.ja.md compliance rates updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)