### PR TITLE
test: Phase 3 — substitution & include spec tests (10 items)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -206,7 +206,7 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **63.1%** |
+| 仕様全体（out-of-scope を含む） | **63.4%** |
 | In-scope のみ | **70.1%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -206,8 +206,8 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **59.6%** |
-| In-scope のみ | **65.9%** |
+| 仕様全体（out-of-scope を含む） | **63.1%** |
+| In-scope のみ | **70.1%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **59.6%** |
-| In-scope only | **65.9%** |
+| Spec total (incl. out-of-scope) | **63.1%** |
+| In-scope only | **70.1%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **63.1%** |
+| Spec total (incl. out-of-scope) | **63.4%** |
 | In-scope only | **70.1%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -374,16 +374,16 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S13.3** `${?` is exactly 3 chars (no whitespace before `?`) — §Substitutions (L584)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:709 (TestSpecS13_3_OptionalSubstNoWhitespaceBeforeQ)
+  status: ✅
 
 - **S13.4** Resolver MAY consult external sources (env vars, system properties) for unresolved substitutions — §Substitutions (L588) (concrete env behavior → S26)
   tests: config_test.go:204 (TestConfig_EnvVarInt); config_test.go:212 (TestConfig_EnvVarFloat); config_test.go:220 (TestConfig_EnvVarBool)
   status: ✅
 
 - **S13.5** Substitutions are NOT parsed inside quoted strings — §Substitutions (L593)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:729 (TestSpecS13_5_NoSubstInQuotedString)
+  status: ✅
 
 - **S13.6** Substitution paths are absolute (rooted at config root) — §Substitutions (L603)
   tests: internal/resolver/resolver_test.go:52 (TestResolver_Substitution)
@@ -414,8 +414,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: 🤷
 
 - **S13.13** Optional undefined in string concat → empty string — §Substitutions (L636)
-  tests: —
-  status: 🤷
+  tests: internal/resolver/resolver_test.go:1119 (TestSpecS13_13_OptionalUndefinedInStringConcatBecomesEmpty)
+  status: ✅
 
 - **S13.14** Optional undefined in obj/array concat → empty obj/array — §Substitutions (L637)
   tests: testdata/hocon/equiv04/missing-substitutions.conf (fixture)
@@ -426,8 +426,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: 🤷
 
 - **S13.16** Substitutions only in field values / array elements — §Substitutions (L644)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:746 (TestSpecS13_16_SubstOnlyInFieldValuesNotKeys)
+  status: ✅
 
 - **S13.17** Single-substitution value preserves type — §Substitutions (L648)
   tests: internal/resolver/resolver_test.go:52 (TestResolver_Substitution)
@@ -480,8 +480,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: 🤷
 
 - **S13a.10** Substitution memoized by instance, not by path — §Self-Referential (L885)
-  tests: —
-  status: 🤷
+  tests: internal/resolver/resolver_test.go:1139 (TestSpecS13a_10_SubstMemoizedByInstance — skipped; not externally observable)
+  status: 🤷 — internal invariant; no public-API observable test possible
 
 - **S13a.11** Object can refer to its own descendant (`bar : { foo : 42, baz : ${bar.foo} }`) — §Self-Referential (L806)
   tests: config_test.go:947 (TestConfig_DelayedMergeNestedSubstitution)
@@ -492,8 +492,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: 🤷
 
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
-  tests: —
-  status: 🤷
+  tests: internal/resolver/resolver_test.go:1147 (TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty — skipped, spec violation)
+  status: ❌ (see [#68](https://github.com/o3co/go.hocon/issues/68))
 
 - **S13a.14** Mutually-referring object fields (`bar.a = ${foo.d}; foo.c = ${bar.b}`) resolve lazily without false cycle — §Self-Referential (L825-834)
   tests: —
@@ -562,20 +562,20 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S14a.6** Unquoted `include` at non-start-of-key is literal — §Include syntax (L962)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:756 (TestSpecS14a_6_UnquotedIncludeNonStartOfKeyIsLiteral)
+  status: ✅
 
 - **S14a.7** Whitespace allowed between `include` and resource name (incl. newlines) — §Include syntax (L952)
   tests: testdata/hocon/test03.conf (fixture)
   status: ✅
 
 - **S14a.8** No value concatenation on include argument — §Include syntax (L957)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:774 (TestSpecS14a_8_NoValueConcatOnIncludeArg)
+  status: ✅
 
 - **S14a.9** No substitutions in include argument — §Include syntax (L959)
-  tests: —
-  status: 🤷
+  tests: internal/parser/parser_test.go:783 (TestSpecS14a_9_NoSubstInIncludeArg)
+  status: ✅
 
 - **S14a.10** Include argument must be quoted string — §Include syntax (L958)
   tests: —
@@ -588,8 +588,8 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ### S14b. Include semantics: merging
 
 - **S14b.1** Included root must be an object (array → error) — §Include semantics: merging (L993)
-  tests: —
-  status: 🤷
+  tests: internal/resolver/resolver_test.go:1166 (TestSpecS14b_1_ArrayRootIncludeIsError)
+  status: ✅
 
 - **S14b.2** Included keys merge per duplicate-key rules — §Include semantics: merging (L997)
   tests: internal/resolver/resolver_test.go:286 (TestResolver_IncludeMergeAll); testdata/hocon/test03.conf (fixture)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -492,7 +492,7 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: 🤷
 
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
-  tests: internal/resolver/resolver_test.go:1147 (TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty — skipped, spec violation)
+  tests: internal/resolver/resolver_test.go:1147 (TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty)
   status: ❌ (see [#68](https://github.com/o3co/go.hocon/issues/68))
 
 - **S13a.14** Mutually-referring object fields (`bar.a = ${foo.d}; foo.c = ${bar.b}`) resolve lazily without false cycle — §Self-Referential (L825-834)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -698,3 +698,90 @@ func TestSpecS12_5_IncludeDotFooRejected(t *testing.T) {
 		t.Error("expected parse error: 'include.foo' begins with reserved 'include', must be rejected")
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Spec compliance Phase 3: substitutions & includes (S13, S13a, S14a, S14b).
+// -----------------------------------------------------------------------------
+
+// TestSpecS13_3_OptionalSubstNoWhitespaceBeforeQ verifies that `${?` is exactly
+// 3 chars with no whitespace before `?`; `${ ?foo}` must NOT behave like
+// `${?foo}`. Spec HOCON.md L584. Status: ✅
+func TestSpecS13_3_OptionalSubstNoWhitespaceBeforeQ(t *testing.T) {
+	// ${?foo} must parse successfully as an optional substitution.
+	if _, err := parser.Parse(`x = ${?foo}`); err != nil {
+		t.Fatalf("expected ${?foo} to parse OK, got: %v", err)
+	}
+	// ${ ?foo} must NOT parse as an optional substitution; the parser may
+	// return an error or treat it differently, but it must NOT be equivalent.
+	_, err2 := parser.Parse(`x = ${ ?foo}`)
+	// The parser must either reject it or treat the ? as part of the path
+	// (not as the optional marker). Either way err2 != nil is acceptable, but
+	// the key requirement is that the two inputs are NOT semantically identical.
+	// We verify by checking that ${ ?foo} actually errors (current impl behaviour).
+	if err2 == nil {
+		t.Error("expected parse error for ${ ?foo} (whitespace before ?), got nil")
+	}
+}
+
+// TestSpecS13_5_NoSubstInQuotedString verifies that substitutions are NOT
+// parsed inside quoted strings; `x = "${foo}"` has a string value of `${foo}`.
+// Spec HOCON.md L593. Status: ✅
+func TestSpecS13_5_NoSubstInQuotedString(t *testing.T) {
+	ast, err := parser.Parse(`x = "${foo}"`)
+	if err != nil {
+		t.Fatalf("expected no parse error for x = \"${foo}\", got: %v", err)
+	}
+	if len(ast.Fields) == 0 {
+		t.Fatal("expected 1 field")
+	}
+	// The field value must be a plain string literal, not a substitution node.
+	if _, isSubst := ast.Fields[0].Value.(*parser.SubstNode); isSubst {
+		t.Error("expected StringNode, got SubstNode: substitutions inside quoted strings must not be parsed")
+	}
+}
+
+// TestSpecS13_16_SubstOnlyInFieldValuesNotKeys verifies that a substitution
+// cannot appear in key position; `${foo} = 1` must be a parse error.
+// Spec HOCON.md L644. Status: ✅
+func TestSpecS13_16_SubstOnlyInFieldValuesNotKeys(t *testing.T) {
+	if _, err := parser.Parse(`${foo} = 1`); err == nil {
+		t.Error("expected parse error for substitution in key position, got nil")
+	}
+}
+
+// TestSpecS14a_6_UnquotedIncludeNonStartOfKeyIsLiteral verifies that when
+// `include` appears after a dot (i.e. it is NOT the start of a key path), it
+// is treated as a normal identifier, not a directive keyword.
+// Spec HOCON.md L962. Status: ✅
+func TestSpecS14a_6_UnquotedIncludeNonStartOfKeyIsLiteral(t *testing.T) {
+	ast, err := parser.Parse(`x.include = 1`)
+	if err != nil {
+		t.Fatalf("expected no parse error for x.include = 1, got: %v", err)
+	}
+	if len(ast.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(ast.Fields))
+	}
+	// Key must be ["x", "include"] — two path segments.
+	key := ast.Fields[0].Key
+	if len(key) != 2 || key[0] != "x" || key[1] != "include" {
+		t.Errorf("expected key [x include], got %v", key)
+	}
+}
+
+// TestSpecS14a_8_NoValueConcatOnIncludeArg verifies that value concatenation is
+// not allowed on an include argument; `include "a.conf" "b.conf"` must be a
+// parse error. Spec HOCON.md L957. Status: ✅
+func TestSpecS14a_8_NoValueConcatOnIncludeArg(t *testing.T) {
+	if _, err := parser.Parse(`include "a.conf" "b.conf"`); err == nil {
+		t.Error("expected parse error for include with multiple filenames, got nil")
+	}
+}
+
+// TestSpecS14a_9_NoSubstInIncludeArg verifies that substitutions are not
+// allowed as the include argument; `include ${path}` must be a parse error.
+// Spec HOCON.md L959. Status: ✅
+func TestSpecS14a_9_NoSubstInIncludeArg(t *testing.T) {
+	if _, err := parser.Parse(`include ${path}`); err == nil {
+		t.Error("expected parse error for include with substitution argument, got nil")
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -734,9 +734,19 @@ func TestSpecS13_5_NoSubstInQuotedString(t *testing.T) {
 	if len(ast.Fields) == 0 {
 		t.Fatal("expected 1 field")
 	}
-	// The field value must be a plain string literal, not a substitution node.
-	if _, isSubst := ast.Fields[0].Value.(*parser.SubstNode); isSubst {
-		t.Error("expected StringNode, got SubstNode: substitutions inside quoted strings must not be parsed")
+	// The field value must be a string-typed scalar carrying the literal `${foo}`
+	// — assert shape AND contents to rule out wrapped/concat encodings (e.g.
+	// ConcatNode{[ScalarNode("${foo}")]}, or ScalarNode with the wrong type tag)
+	// that would also pass a bare "not SubstNode" check.
+	sc, ok := ast.Fields[0].Value.(*parser.ScalarNode)
+	if !ok {
+		t.Fatalf("expected *parser.ScalarNode, got %T", ast.Fields[0].Value)
+	}
+	if sc.Raw != "${foo}" {
+		t.Errorf("expected scalar raw = %q, got %q", "${foo}", sc.Raw)
+	}
+	if sc.ValueType != "string" {
+		t.Errorf("expected scalar value type = %q, got %q", "string", sc.ValueType)
 	}
 }
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1107,3 +1107,83 @@ func resolveErr(src string) (*resolver.Result, error) {
 	}
 	return resolver.Resolve(ast, resolver.Options{})
 }
+
+// -----------------------------------------------------------------------------
+// Spec compliance Phase 3: substitutions & includes (S13, S13a, S14a, S14b).
+// -----------------------------------------------------------------------------
+
+// TestSpecS13_13_OptionalUndefinedInStringConcatBecomesEmpty verifies that an
+// optional substitution that is undefined contributes an empty string when used
+// inside a string concatenation. Spec HOCON.md L636.
+// e.g. `x = "pre"${?missing}"post"` → x == "prepost". Status: ✅
+func TestSpecS13_13_OptionalUndefinedInStringConcatBecomesEmpty(t *testing.T) {
+	res := resolve(t, `x = "pre"${?missing}"post"`)
+	v, ok := res.Root.Get("x")
+	if !ok {
+		t.Fatal("x not found in resolved config")
+	}
+	sv, ok := v.(*resolver.ScalarVal)
+	if !ok {
+		t.Fatalf("expected ScalarVal for x, got %T", v)
+	}
+	if sv.Raw != "prepost" {
+		t.Errorf("expected x == %q, got %q", "prepost", sv.Raw)
+	}
+}
+
+// TestSpecS13a_10_SubstMemoizedByInstance notes that memoization by instance
+// (not by path) is an internal resolver property that cannot be observed from
+// the public API without implementation-specific hooks. This test is left as a
+// documentation placeholder; the behavior cannot be black-box verified.
+// Spec HOCON.md L885. Status: 🤷 — not externally observable.
+func TestSpecS13a_10_SubstMemoizedByInstance(t *testing.T) {
+	t.Skip("S13a.10: memoization-by-instance is an internal invariant not observable via the public API")
+}
+
+// TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty verifies that
+// `a = ${?a}foo` resolves to "foo" when `a` has no prior value; the
+// look-back substitution ${?a} is undefined and contributes nothing.
+// Spec HOCON.md L841. Status: ❌ — impl resolves to "foofoo" (see #68).
+func TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty(t *testing.T) {
+	t.Skipf("spec violation, see #%d", specIssueS13a13)
+	res := resolve(t, `a = ${?a}foo`)
+	v, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatal("a not found in resolved config")
+	}
+	sv, ok := v.(*resolver.ScalarVal)
+	if !ok {
+		t.Fatalf("expected ScalarVal for a, got %T", v)
+	}
+	if sv.Raw != "foo" {
+		t.Errorf("expected a == %q, got %q", "foo", sv.Raw)
+	}
+}
+
+// TestSpecS14b_1_ArrayRootIncludeIsError verifies that when an included file's
+// root is an array (not an object), it is rejected as a resolve error.
+// Spec HOCON.md L993. Status: ✅
+func TestSpecS14b_1_ArrayRootIncludeIsError(t *testing.T) {
+	f, err := os.CreateTemp("", "array-root-*.conf")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	_, _ = f.WriteString("[1, 2, 3]")
+	name := f.Name()
+	_ = f.Close()
+	defer os.Remove(name)
+
+	src := `include "` + name + `"`
+	ast, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, resolveErr := resolver.Resolve(ast, resolver.Options{BaseDir: os.TempDir()})
+	if resolveErr == nil {
+		t.Error("expected error when included file has array root, got nil")
+	}
+}
+
+// specIssueS13a13 is the GitHub issue number for the S13a.13 spec violation.
+// Filed as: resolver incorrectly evaluates `a = ${?a}foo` to "foofoo" instead of "foo".
+const specIssueS13a13 = 68

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1164,21 +1164,20 @@ func TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty(t *testing.T) {
 // root is an array (not an object), it is rejected as a resolve error.
 // Spec HOCON.md L993. Status: ✅
 func TestSpecS14b_1_ArrayRootIncludeIsError(t *testing.T) {
-	f, err := os.CreateTemp("", "array-root-*.conf")
-	if err != nil {
-		t.Fatalf("create temp file: %v", err)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "array-root.conf")
+	if err := os.WriteFile(path, []byte("[1, 2, 3]"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
 	}
-	_, _ = f.WriteString("[1, 2, 3]")
-	name := f.Name()
-	_ = f.Close()
-	defer os.Remove(name)
 
-	src := `include "` + name + `"`
+	// HOCON strings use '/' as a path separator across platforms; convert
+	// Windows backslashes so the include argument parses correctly.
+	src := `include "` + filepath.ToSlash(path) + `"`
 	ast, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	_, resolveErr := resolver.Resolve(ast, resolver.Options{BaseDir: os.TempDir()})
+	_, resolveErr := resolver.Resolve(ast, resolver.Options{BaseDir: dir})
 	if resolveErr == nil {
 		t.Error("expected error when included file has array root, got nil")
 	}


### PR DESCRIPTION
## Summary

Phase 3 of spec-compliance test coverage, targeting 10 items previously marked 🤷 in `docs/spec-compliance.md` (§Substitutions, §Self-Referential, §Include syntax, §Include semantics).

| Item | Result | Notes |
|------|--------|-------|
| S13.3 — `${?` no whitespace before `?` | 🤷 → ✅ | `${ ?foo}` correctly errors |
| S13.5 — no substitution inside quoted string | 🤷 → ✅ | parser does not produce SubstNode |
| S13.13 — optional undefined in string concat → empty | 🤷 → ✅ | `"pre"${?missing}"post"` → `"prepost"` |
| S13.16 — substitution only in values, not keys | 🤷 → ✅ | `${foo} = 1` correctly errors |
| S13a.10 — memoization by instance | 🤷 → 🤷 | internal invariant; not observable via public API; documented skip |
| S13a.13 — `a = ${?a}foo` → `"foo"` | 🤷 → ❌ | resolves to `"foofoo"` instead; bug filed as [#68](https://github.com/o3co/go.hocon/issues/68) |
| S14a.6 — `x.include` is literal key | 🤷 → ✅ | key `["x","include"]` parsed correctly |
| S14a.8 — no concat on include arg | 🤷 → ✅ | `include "a" "b"` correctly errors |
| S14a.9 — no substitution in include arg | 🤷 → ✅ | `include ${path}` correctly errors |
| S14b.1 — array-root include → error | 🤷 → ✅ | resolver rejects `[1,2,3]` as include root |

Compliance rate updated: **59.6% → 63.1%** (spec-total), **65.9% → 70.1%** (in-scope).

## Test plan

- [x] `go test ./...` — all pass (S13a.13 test is skipped with `t.Skipf`)
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — no files need formatting
- [x] Bug issue [#68](https://github.com/o3co/go.hocon/issues/68) filed for S13a.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)