### PR TITLE
test: align S13.3 test comment with assertion (Copilot follow-up #69)

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -711,14 +711,13 @@ func TestSpecS13_3_OptionalSubstNoWhitespaceBeforeQ(t *testing.T) {
 	if _, err := parser.Parse(`x = ${?foo}`); err != nil {
 		t.Fatalf("expected ${?foo} to parse OK, got: %v", err)
 	}
-	// ${ ?foo} must NOT parse as an optional substitution; the parser may
-	// return an error or treat it differently, but it must NOT be equivalent.
-	_, err2 := parser.Parse(`x = ${ ?foo}`)
-	// The parser must either reject it or treat the ? as part of the path
-	// (not as the optional marker). Either way err2 != nil is acceptable, but
-	// the key requirement is that the two inputs are NOT semantically identical.
-	// We verify by checking that ${ ?foo} actually errors (current impl behaviour).
-	if err2 == nil {
+	// ${ ?foo} must NOT be semantically equivalent to ${?foo}. Pin the current
+	// impl behaviour (parse error) directly — the comment used to permit a
+	// "parses differently" outcome but the assertion required err != nil, which
+	// was inconsistent. If the parser later starts accepting ${ ?foo}, this test
+	// must be revisited: confirm the parsed shape is NOT an optional substitution
+	// (e.g. ? became part of the path) before relaxing the error check.
+	if _, err := parser.Parse(`x = ${ ?foo}`); err == nil {
 		t.Error("expected parse error for ${ ?foo} (whitespace before ?), got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to [#69](https://github.com/o3co/go.hocon/pull/69) (Phase 3 spec compliance). Copilot review flagged a comment/assertion mismatch in S13.3:

- Old comment: \`\${ ?foo}\` may either error OR be parsed differently (with \`?\` as part of the path), as long as it's not equivalent to \`\${?foo}\`.
- Old assertion: \`err != nil\` — strictly requires parse error.

Tighten the comment to pin current impl behaviour (parse error) and document what must be re-verified before relaxing the assertion if the parser ever starts accepting \`\${ ?foo}\`.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)