### PR TITLE
chore(actions): bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,15 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
       - name: Cache expected JSON
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             testdata/expected


### PR DESCRIPTION
## Summary

Purely mechanical version bumps to satisfy GitHub's Node.js 24 runtime requirement before the org deadline of 2026-06-02.

- `actions/checkout@v4` → `actions/checkout@v5`
- `actions/setup-go@v5` → `actions/setup-go@v6`
- `actions/cache@v4` → `actions/cache@v5`

## Files changed

- `.github/workflows/test.yml`
- `.github/workflows/lint.yml`

(`release.yml` uses only `curl`/`jq` run steps — no action references to bump.)

## Notes

- No workflow logic changes whatsoever.
- Go version matrix and other actions (codecov) are untouched.
- `release.yml` required no changes.