### PR TITLE
fix(lexer): expand whitespace recognition to HOCON spec set (S6.1/6.2/6.4)

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -136,13 +136,13 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅ (fixed in fix/s6-whitespace-expansion — was ⚠️ #59)
   behavior-change (fix/s6-whitespace-expansion): CR (U+000D) inside \${...} was previously rejected with "unterminated substitution" error; it is now consumed as inter-segment whitespace per spec §F. CR satisfies isHoconWhitespace but not isHoconNewline, so only LF terminates a substitution. 3-way convergent with ts.hocon and rs.hocon. Pinned by TestSpecS6_CR_InsideSubstBody.
 
-- **S6.6** NEL (U+0085) is not in HOCON_WS and is not a newline — §Whitespace (L165-184)
-  status: ✅ (clarified in fix/s6-whitespace-expansion)
-  behavior-change (fix/s6-whitespace-expansion): previously, unquoted string tokenization used Go's unicode.IsSpace() which includes U+0085 (NEL), causing NEL to be treated as a whitespace separator and excluded from unquoted string tokens. The new isHoconWhitespace predicate does not include NEL (per HOCON spec L165-184). NEL is now allowed in unquoted strings per S8.8 (control chars not in the forbidden set are permitted). Intentional divergence from Go stdlib unicode.IsSpace.
-
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: spec_phase5_test.go (TestSpec_S6_5_NewlineMeansLF)
   status: ✅
+
+- **S6.6** NEL (U+0085) is not in HOCON_WS and is not a newline — §Whitespace (L165-184)
+  status: ✅ (clarified in fix/s6-whitespace-expansion)
+  behavior-change (fix/s6-whitespace-expansion): previously, unquoted string tokenization used Go's unicode.IsSpace() which includes U+0085 (NEL), causing NEL to be treated as a whitespace separator and excluded from unquoted string tokens. The new isHoconWhitespace predicate does not include NEL (per HOCON spec L165-184). NEL is now allowed in unquoted strings per S8.8 (control chars not in the forbidden set are permitted). Intentional divergence from Go stdlib unicode.IsSpace.
 
 ## S7. Duplicate keys and object merging
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -128,12 +128,17 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅ (fixed in fix/s6-whitespace-expansion — was ❌ #59)
 
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
-  tests: config_test.go:408 (TestConfig_BOM_ParseFile); config_test.go:422 (TestConfig_BOM_ParseString); testdata/hocon/bom.conf (fixture); internal/lexer/lexer_test.go:696 (TestSpecS6_3_BOMMidstreamIsWhitespace)
+  tests: config_test.go:408 (TestConfig_BOM_ParseFile); config_test.go:422 (TestConfig_BOM_ParseString); testdata/hocon/bom.conf (fixture); internal/lexer/lexer_test.go:693 (TestSpecS6_3_BOMMidstreamIsWhitespace)
   status: ✅ (broadened in fix/s6-whitespace-expansion — BOM now recognized as whitespace anywhere, not only at start-of-input)
 
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
   tests: internal/lexer/lexer_test.go:558 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:574 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:590 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:609 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:628 (TestSpecS6_4_SeparatorsAreWhitespace)
   status: ✅ (fixed in fix/s6-whitespace-expansion — was ⚠️ #59)
+  behavior-change (fix/s6-whitespace-expansion): CR (U+000D) inside \${...} was previously rejected with "unterminated substitution" error; it is now consumed as inter-segment whitespace per spec §F. CR satisfies isHoconWhitespace but not isHoconNewline, so only LF terminates a substitution. 3-way convergent with ts.hocon and rs.hocon. Pinned by TestSpecS6_CR_InsideSubstBody.
+
+- **S6.6** NEL (U+0085) is not in HOCON_WS and is not a newline — §Whitespace (L165-184)
+  status: ✅ (clarified in fix/s6-whitespace-expansion)
+  behavior-change (fix/s6-whitespace-expansion): previously, unquoted string tokenization used Go's unicode.IsSpace() which includes U+0085 (NEL), causing NEL to be treated as a whitespace separator and excluded from unquoted string tokens. The new isHoconWhitespace predicate does not include NEL (per HOCON spec L165-184). NEL is now allowed in unquoted strings per S8.8 (control chars not in the forbidden set are permitted). Intentional divergence from Go stdlib unicode.IsSpace.
 
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: spec_phase5_test.go (TestSpec_S6_5_NewlineMeansLF)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -120,20 +120,20 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: internal/lexer/lexer_test.go:439 (TestSpecS6_1_UnicodeCategoryZsIsWhitespace); internal/lexer/lexer_test.go:459 (TestSpecS6_1_UnicodeCategoryZlIsWhitespace); internal/lexer/lexer_test.go:478 (TestSpecS6_1_UnicodeCategoryZpIsWhitespace)
-  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — lexer rejects Zs/Zl/Zp chars with "unexpected character" instead of treating them as whitespace separators
+  tests: internal/lexer/lexer_test.go:438 (TestSpecS6_1_UnicodeCategoryZsIsWhitespace); internal/lexer/lexer_test.go:460 (TestSpecS6_1_UnicodeCategoryZlIsWhitespace); internal/lexer/lexer_test.go:481 (TestSpecS6_1_UnicodeCategoryZpIsWhitespace)
+  status: ✅ (fixed in fix/s6-whitespace-expansion — was ❌ #59)
 
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: internal/lexer/lexer_test.go:496 (TestSpecS6_2_NBSPIsWhitespace); internal/lexer/lexer_test.go:513 (TestSpecS6_2_FigureSpaceIsWhitespace); internal/lexer/lexer_test.go:530 (TestSpecS6_2_NarrowNBSPIsWhitespace)
-  status: ❌ ([#59](https://github.com/o3co/go.hocon/issues/59)) — NBSP / figure space / narrow NBSP are rejected with "unexpected character" instead of acting as whitespace
+  tests: internal/lexer/lexer_test.go:501 (TestSpecS6_2_NBSPIsWhitespace); internal/lexer/lexer_test.go:520 (TestSpecS6_2_FigureSpaceIsWhitespace); internal/lexer/lexer_test.go:539 (TestSpecS6_2_NarrowNBSPIsWhitespace)
+  status: ✅ (fixed in fix/s6-whitespace-expansion — was ❌ #59)
 
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
-  tests: config_test.go:408 (TestConfig_BOM_ParseFile); config_test.go:422 (TestConfig_BOM_ParseString); testdata/hocon/bom.conf (fixture)
-  status: ✅
+  tests: config_test.go:408 (TestConfig_BOM_ParseFile); config_test.go:422 (TestConfig_BOM_ParseString); testdata/hocon/bom.conf (fixture); internal/lexer/lexer_test.go:696 (TestSpecS6_3_BOMMidstreamIsWhitespace)
+  status: ✅ (broadened in fix/s6-whitespace-expansion — BOM now recognized as whitespace anywhere, not only at start-of-input)
 
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: internal/lexer/lexer_test.go:547 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:563 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:580 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:598 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:616 (TestSpecS6_4_SeparatorsAreWhitespace)
-  status: ⚠️ ([#59](https://github.com/o3co/go.hocon/issues/59)) — 2 of 8 sub-rules pass: tab (0x09) and CR (0x0D) are recognized; vtab (0x0B) and FF (0x0C) emit "unexpected character"; FS–US (0x1C–0x1F) are absorbed into unquoted string runs
+  tests: internal/lexer/lexer_test.go:558 (TestSpecS6_4_TabIsWhitespace); internal/lexer/lexer_test.go:574 (TestSpecS6_4_CRIsWhitespace); internal/lexer/lexer_test.go:590 (TestSpecS6_4_VtabIsWhitespace); internal/lexer/lexer_test.go:609 (TestSpecS6_4_FFIsWhitespace); internal/lexer/lexer_test.go:628 (TestSpecS6_4_SeparatorsAreWhitespace)
+  status: ✅ (fixed in fix/s6-whitespace-expansion — was ⚠️ #59)
 
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: spec_phase5_test.go (TestSpec_S6_5_NewlineMeansLF)

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
 // TokenType identifies the type of a lexed token.
@@ -203,10 +202,10 @@ func (l *Lexer) skipWhitespaceAndComments() {
 		if !ok {
 			return
 		}
-		if ch == '\n' {
-			return // newlines are significant tokens
+		if isHoconNewline(ch) {
+			return // newlines are significant tokens; emitted by Next() caller
 		}
-		if ch == ' ' || ch == '\t' || ch == '\r' {
+		if isHoconWhitespace(ch) {
 			l.skippedSpace = true
 			l.advance()
 			continue
@@ -496,11 +495,13 @@ func (l *Lexer) parseSubstBody(startLine, startCol int) Token {
 			hasLastDot = true
 			l.advance()
 
-		case ch == ' ' || ch == '\t':
+		case isHoconWhitespace(ch) && !isHoconNewline(ch):
+			// Non-newline whitespace inside ${...} is accumulated as pending
+			// inter-segment whitespace. col advances; line is unchanged.
 			pendingWs += string(ch)
 			l.advance()
 
-		case ch == '\n' || ch == '\r':
+		case isHoconNewline(ch), ch == '\r':
 			return Token{Type: TokenError, Value: "unterminated substitution", Line: startLine, Col: startCol}
 
 		default:
@@ -589,6 +590,46 @@ func (l *Lexer) readNumber(line, col int) Token {
 	return Token{Type: tt, Value: sb.String(), Line: line, Col: col}
 }
 
+// isHoconWhitespace reports whether r is a HOCON whitespace character per
+// HOCON.md §Whitespace (L165-184). The set is:
+//
+//	ASCII control whitespace: HT VT FF CR FS GS RS US (0x09, 0x0B-0x0D, 0x1C-0x1F)
+//	Unicode Zs category:      SP NBSP and all other Zs members
+//	Unicode Zl (line sep):    U+2028
+//	Unicode Zp (para sep):    U+2029
+//	BOM:                      U+FEFF
+//
+// Note: LF (0x0A) is also in HOCON_WS but is the ONLY newline character and
+// must be handled before this predicate in the main lexer loop. See isHoconNewline.
+//
+// Note: Go's unicode.IsSpace includes U+0085 (NEL) which HOCON does not, and
+// excludes U+001C-U+001F which HOCON does include. Do not substitute IsSpace here.
+func isHoconWhitespace(r rune) bool {
+	switch {
+	case r == '\t', r == '\n', r == '\v', r == '\f', r == '\r':
+		return true
+	case r >= 0x1C && r <= 0x1F:
+		return true
+	case r == ' ', r == 0xA0, r == 0xFEFF:
+		return true
+	case r == 0x1680:
+		return true
+	case r >= 0x2000 && r <= 0x200A:
+		return true
+	case r == 0x2028, r == 0x2029, r == 0x202F, r == 0x205F:
+		return true
+	case r == 0x3000:
+		return true
+	}
+	return false
+}
+
+// isHoconNewline reports whether r is the HOCON newline character.
+// Per HOCON.md L182-184, "newline" means exclusively ASCII LF (0x000A).
+// Unicode line separator (U+2028) and paragraph separator (U+2029) are
+// whitespace but NOT newlines in HOCON.
+func isHoconNewline(r rune) bool { return r == '\n' }
+
 // unquotedForbidden are characters that terminate an unquoted string.
 // Per spec: $"{}[]:=,+#\^?!@*& plus all whitespace.
 // Parentheses are not in the spec but are included so that
@@ -596,7 +637,7 @@ func (l *Lexer) readNumber(line, col int) Token {
 const unquotedForbidden = `$"{}[]:=,+#\^?!@*&()`
 
 func isUnquotedForbidden(ch rune) bool {
-	return unicode.IsSpace(ch) || strings.ContainsRune(unquotedForbidden, ch)
+	return isHoconWhitespace(ch) || strings.ContainsRune(unquotedForbidden, ch)
 }
 
 func isHexDigit(ch rune) bool {

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -393,10 +393,16 @@ func (l *Lexer) readTripleQuoted(line, col int) Token {
 
 // isUnquotedSubstChar returns true if ch is allowed inside a ${...} body
 // as an unquoted character. Mirrors rs.hocon's is_unquoted_subst_char.
+//
+// Whitespace is delegated to isHoconWhitespace so that all three
+// whitespace-check sites in the subst-body path machine route through the
+// same predicate (the main loop, parseSubstBody skip, and this function).
 func isUnquotedSubstChar(ch rune) bool {
+	if isHoconWhitespace(ch) {
+		return false
+	}
 	switch ch {
-	case ' ', '\t', '\n', '\r',
-		'"', '\\',
+	case '"', '\\',
 		'{', '}', '[', ']',
 		':', '=', ',', '+', '#',
 		'`', '^', '?', '!', '@', '*', '&',

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -508,10 +508,15 @@ func (l *Lexer) parseSubstBody(startLine, startCol int) Token {
 			l.advance()
 
 		case isHoconNewline(ch):
-			// LF terminates a substitution (unterminated). CR (U+000D) is whitespace
-			// per isHoconWhitespace, not a newline per isHoconNewline, so it is
-			// consumed by the preceding whitespace case — the former `ch == '\r'` arm
-			// here was unreachable.
+			// LF terminates a substitution (unterminated).
+			//
+			// History: before fix/s6-whitespace-expansion, the subst-body whitespace
+			// case matched only ' ' and '\t', so CR (U+000D) fell through to a dedicated
+			// `case ch == '\n' || ch == '\r'` arm and was rejected as "unterminated
+			// substitution". After the fix, the whitespace case matches all of
+			// isHoconWhitespace && !isHoconNewline, which includes CR. CR is now
+			// consumed there before this case is reached, making the old explicit CR
+			// arm dead code — which is why it was removed.
 			return Token{Type: TokenError, Value: "unterminated substitution", Line: startLine, Col: startCol}
 
 		default:

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -507,7 +507,11 @@ func (l *Lexer) parseSubstBody(startLine, startCol int) Token {
 			pendingWs += string(ch)
 			l.advance()
 
-		case isHoconNewline(ch), ch == '\r':
+		case isHoconNewline(ch):
+			// LF terminates a substitution (unterminated). CR (U+000D) is whitespace
+			// per isHoconWhitespace, not a newline per isHoconNewline, so it is
+			// consumed by the preceding whitespace case — the former `ch == '\r'` arm
+			// here was unreachable.
 			return Token{Type: TokenError, Value: "unterminated substitution", Line: startLine, Col: startCol}
 
 		default:

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -685,14 +685,11 @@ func TestSpecS8_7_BackslashRejectedInUnquoted(t *testing.T) {
 	}
 }
 
-// TestSpecS8_8_ControlCharsAllowedInUnquoted verifies that control characters
-// not in the forbidden set (e.g. SOH 0x01, BEL 0x07) are allowed inside
-// unquoted strings. Spec L280. Status: ✅
 // TestSpecS6_3_BOMMidstreamIsWhitespace verifies that BOM (U+FEFF) appearing
 // mid-stream acts as a whitespace separator rather than leaking into an unquoted
 // string run or producing an error. Spec §Whitespace (L173): BOM must be treated
 // as whitespace anywhere, not only at start-of-input.
-// Status: RED — BOM mid-stream currently produces "unexpected character" error.
+// Status: ✅ fixed in fix/s6-whitespace-expansion
 func TestSpecS6_3_BOMMidstreamIsWhitespace(t *testing.T) {
 	src := "a\uFEFFb"
 	toks := tokenize(src)
@@ -727,6 +724,9 @@ func TestSpecS6_LFStillEmitsNewline(t *testing.T) {
 	}
 }
 
+// TestSpecS8_8_ControlCharsAllowedInUnquoted verifies that control characters
+// not in the forbidden set (e.g. SOH 0x01, BEL 0x07) are allowed inside
+// unquoted strings. Spec L280. Status: ✅
 func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -710,6 +710,23 @@ func TestSpecS6_3_BOMMidstreamIsWhitespace(t *testing.T) {
 	}
 }
 
+// TestSpecS6_LFStillEmitsNewline is a regression guard verifying that after
+// predicate centralization, LF (U+000A) still emits a TokenNewline token and
+// is NOT silently consumed as inter-token whitespace. Spec L183.
+func TestSpecS6_LFStillEmitsNewline(t *testing.T) {
+	toks := tokenize("a\nb")
+	var sawNewline bool
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenNewline {
+			sawNewline = true
+			break
+		}
+	}
+	if !sawNewline {
+		t.Fatal("expected TokenNewline for LF but none found")
+	}
+}
+
 func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -586,14 +586,15 @@ func TestSpecS6_4_CRIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_4_VtabIsWhitespace verifies vertical tab (0x0B) is whitespace.
-// Spec L174. Status: ❌ spec violation — lexer rejects with "unexpected character".
-// See issue #59.
+// Spec L174. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_4_VtabIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	src := "a\x0bb"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("vtab: got unexpected error token: %q", tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -604,14 +605,15 @@ func TestSpecS6_4_VtabIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_4_FFIsWhitespace verifies form feed (0x0C) is whitespace.
-// Spec L174. Status: ❌ spec violation — lexer rejects with "unexpected character".
-// See issue #59.
+// Spec L174. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_4_FFIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	src := "a\x0cb"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("FF: got unexpected error token: %q", tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -622,16 +624,17 @@ func TestSpecS6_4_FFIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_4_SeparatorsAreWhitespace verifies FS/GS/RS/US (0x1C-0x1F) are
-// whitespace. Spec L174. Status: ❌ spec violation — these chars are absorbed
-// into unquoted string runs instead of acting as separators. See issue #59.
+// whitespace. Spec L174. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_4_SeparatorsAreWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	// FS=0x1C, GS=0x1D, RS=0x1E, US=0x1F — all must act as whitespace
 	for _, ch := range []rune{'\x1c', '\x1d', '\x1e', '\x1f'} {
 		src := "a" + string(ch) + "b"
 		toks := tokenize(src)
 		var strings_ []string
 		for _, tok := range toks {
+			if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+				t.Errorf("U+%04X: got unexpected error token: %q", ch, tok.Value)
+			}
 			if tok.Type == lexer.TokenString {
 				strings_ = append(strings_, tok.Value)
 			}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -825,3 +825,26 @@ func TestSpecS6_SubstBodyBOMBeforeDot(t *testing.T) {
 		t.Errorf("BOM before dot: seg[1].Text=%q, want %q", segs[1].Text, "bar")
 	}
 }
+
+// TestSpecS6_CR_InsideSubstBody pins the behavior that CR (U+000D) inside
+// ${...} is consumed as inter-segment whitespace, not as a newline that would
+// terminate the substitution with an error. CR satisfies isHoconWhitespace but
+// NOT isHoconNewline, so it is handled by the non-newline whitespace case.
+//
+// Effective behavior: ${foo\rbar} produces one segment with text "foo\rbar"
+// (CR is accumulated as pending whitespace and concatenated into the segment).
+// 3-way convergent with ts.hocon and rs.hocon per spec §F.
+//
+// This test also pins that the refactor removing the dead `ch == '\r'` arm
+// from the isHoconNewline case (commit 3) did not regress CR handling.
+func TestSpecS6_CR_InsideSubstBody(t *testing.T) {
+	// ${foo\rbar}: no dot, CR is whitespace, produces one segment "foo\rbar".
+	segs := substSegments(t, "${foo\rbar}")
+	if len(segs) != 1 {
+		t.Fatalf("CR inside subst: got %d segments, want 1: %v", len(segs), segs)
+	}
+	want := "foo\rbar"
+	if segs[0].Text != want {
+		t.Errorf("CR inside subst: seg[0].Text=%q, want %q", segs[0].Text, want)
+	}
+}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -751,10 +751,48 @@ func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
 	}
 }
 
+// TestSpecS8_8_NELAllowedInUnquoted verifies that NEL (U+0085) is treated as an
+// ordinary character — not as whitespace — in unquoted string tokens.
+//
+// Before fix/s6-whitespace-expansion, isUnquotedForbidden delegated to Go's
+// unicode.IsSpace(), which includes U+0085. That caused "foo<NEL>bar" to be split
+// into two tokens: "foo" and "bar". After the fix, isHoconWhitespace (which does
+// not include NEL per HOCON spec L165-184) is used instead, so NEL is absorbed
+// into the unquoted string and produces a single token. Spec S8.8: control chars
+// not in the forbidden set are permitted in unquoted strings. Status: ✅
+func TestSpecS8_8_NELAllowedInUnquoted(t *testing.T) {
+	nel := string(rune(0x0085))
+	src := "foo" + nel + "bar"
+	want := "foo" + nel + "bar"
+
+	toks := tokenize(src)
+	if len(toks) == 0 {
+		t.Fatal("NEL in unquoted: no tokens produced")
+	}
+	tok := toks[0]
+	if tok.Type != lexer.TokenString {
+		t.Errorf("NEL in unquoted: type=%v, want TokenString", tok.Type)
+	}
+	if tok.Value != want {
+		t.Errorf("NEL in unquoted: value=%q, want %q", tok.Value, want)
+	}
+	// Ensure only one token was produced (NEL did not split the unquoted string).
+	// Ignore any trailing EOF/Newline tokens.
+	meaningful := 0
+	for _, tk := range toks {
+		if tk.Type == lexer.TokenString {
+			meaningful++
+		}
+	}
+	if meaningful != 1 {
+		t.Errorf("NEL in unquoted: got %d TokenString tokens, want 1 (NEL must not split token)", meaningful)
+	}
+}
+
 // TestSpecS6_SubstBodyNBSPBeforeDot verifies that NBSP (U+00A0) inside ${...}
 // before a dot acts as inter-segment whitespace (discarded) rather than being
 // absorbed into the segment text. Spec §D: all three whitespace sites must route
-// through isHoconWhitespace. Status: RED — isUnquotedSubstChar uses hardcoded set.
+// through isHoconWhitespace. Status: ✅ (fixed in fix/s6-whitespace-expansion)
 func TestSpecS6_SubstBodyNBSPBeforeDot(t *testing.T) {
 	nbsp := string(rune(0x00A0))
 	input := "${foo" + nbsp + ".bar}"

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -497,13 +497,15 @@ func TestSpecS6_1_UnicodeCategoryZpIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_2_NBSPIsWhitespace verifies that NBSP (U+00A0) is whitespace.
-// Spec L171. Status: ❌ spec violation — see issue #59.
+// Spec L171. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_2_NBSPIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	src := "a\u00a0b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("NBSP: got unexpected error token: %q", tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -514,13 +516,15 @@ func TestSpecS6_2_NBSPIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_2_FigureSpaceIsWhitespace verifies figure space (U+2007).
-// Spec L171. Status: ❌ spec violation — see issue #59.
+// Spec L171. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_2_FigureSpaceIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	src := "a\u2007b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("figure space: got unexpected error token: %q", tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -531,13 +535,15 @@ func TestSpecS6_2_FigureSpaceIsWhitespace(t *testing.T) {
 }
 
 // TestSpecS6_2_NarrowNBSPIsWhitespace verifies narrow no-break space (U+202F).
-// Spec L171. Status: ❌ spec violation — see issue #59.
+// Spec L171. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_2_NarrowNBSPIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	src := "a\u202fb"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("narrow NBSP: got unexpected error token: %q", tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -810,8 +810,8 @@ func TestSpecS6_SubstBodyNBSPBeforeDot(t *testing.T) {
 
 // TestSpecS6_SubstBodyZlBeforeDot verifies that line separator (U+2028, Zl)
 // inside ${...} before a dot acts as inter-segment whitespace (discarded) rather
-// than being absorbed into the segment text. Status: RED — isUnquotedSubstChar
-// uses hardcoded set.
+// than being absorbed into the segment text. Status: ✅ (fixed in #78 — isUnquotedSubstChar
+// now routes through isHoconWhitespace).
 func TestSpecS6_SubstBodyZlBeforeDot(t *testing.T) {
 	zl := string(rune(0x2028))
 	input := "${foo" + zl + ".bar}"
@@ -829,8 +829,8 @@ func TestSpecS6_SubstBodyZlBeforeDot(t *testing.T) {
 
 // TestSpecS6_SubstBodyVtabBeforeDot verifies that vertical tab (U+000B) inside
 // ${...} before a dot acts as inter-segment whitespace (discarded) rather than
-// being absorbed into the segment text. Status: RED — isUnquotedSubstChar uses
-// hardcoded set.
+// being absorbed into the segment text. Status: ✅ (fixed in #78 — isUnquotedSubstChar
+// now routes through isHoconWhitespace).
 func TestSpecS6_SubstBodyVtabBeforeDot(t *testing.T) {
 	input := "${foo\x0b.bar}"
 	segs := substSegments(t, input)
@@ -847,8 +847,8 @@ func TestSpecS6_SubstBodyVtabBeforeDot(t *testing.T) {
 
 // TestSpecS6_SubstBodyBOMBeforeDot verifies that BOM (U+FEFF) inside ${...}
 // before a dot acts as inter-segment whitespace (discarded) rather than being
-// absorbed into the segment text. Status: RED — isUnquotedSubstChar uses hardcoded
-// set.
+// absorbed into the segment text. Status: ✅ (fixed in #78 — isUnquotedSubstChar
+// now routes through isHoconWhitespace).
 func TestSpecS6_SubstBodyBOMBeforeDot(t *testing.T) {
 	bom := string(rune(0xFEFF))
 	input := "${foo" + bom + ".bar}"

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -688,6 +688,28 @@ func TestSpecS8_7_BackslashRejectedInUnquoted(t *testing.T) {
 // TestSpecS8_8_ControlCharsAllowedInUnquoted verifies that control characters
 // not in the forbidden set (e.g. SOH 0x01, BEL 0x07) are allowed inside
 // unquoted strings. Spec L280. Status: ✅
+// TestSpecS6_3_BOMMidstreamIsWhitespace verifies that BOM (U+FEFF) appearing
+// mid-stream acts as a whitespace separator rather than leaking into an unquoted
+// string run or producing an error. Spec §Whitespace (L173): BOM must be treated
+// as whitespace anywhere, not only at start-of-input.
+// Status: RED — BOM mid-stream currently produces "unexpected character" error.
+func TestSpecS6_3_BOMMidstreamIsWhitespace(t *testing.T) {
+	src := "a\uFEFFb"
+	toks := tokenize(src)
+	var strings_ []string
+	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("BOM mid-stream: got unexpected error token: %q", tok.Value)
+		}
+		if tok.Type == lexer.TokenString {
+			strings_ = append(strings_, tok.Value)
+		}
+	}
+	if len(strings_) != 2 || strings_[0] != "a" || strings_[1] != "b" {
+		t.Errorf("BOM mid-stream: got string tokens %v, want [a b]", strings_)
+	}
+}
+
 func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -750,3 +750,78 @@ func TestSpecS8_8_ControlCharsAllowedInUnquoted(t *testing.T) {
 		}
 	}
 }
+
+// TestSpecS6_SubstBodyNBSPBeforeDot verifies that NBSP (U+00A0) inside ${...}
+// before a dot acts as inter-segment whitespace (discarded) rather than being
+// absorbed into the segment text. Spec §D: all three whitespace sites must route
+// through isHoconWhitespace. Status: RED — isUnquotedSubstChar uses hardcoded set.
+func TestSpecS6_SubstBodyNBSPBeforeDot(t *testing.T) {
+	nbsp := string(rune(0x00A0))
+	input := "${foo" + nbsp + ".bar}"
+	segs := substSegments(t, input)
+	if len(segs) != 2 {
+		t.Fatalf("NBSP before dot: got %d segments, want 2: %v", len(segs), segs)
+	}
+	if segs[0].Text != "foo" {
+		t.Errorf("NBSP before dot: seg[0].Text=%q, want %q", segs[0].Text, "foo")
+	}
+	if segs[1].Text != "bar" {
+		t.Errorf("NBSP before dot: seg[1].Text=%q, want %q", segs[1].Text, "bar")
+	}
+}
+
+// TestSpecS6_SubstBodyZlBeforeDot verifies that line separator (U+2028, Zl)
+// inside ${...} before a dot acts as inter-segment whitespace (discarded) rather
+// than being absorbed into the segment text. Status: RED — isUnquotedSubstChar
+// uses hardcoded set.
+func TestSpecS6_SubstBodyZlBeforeDot(t *testing.T) {
+	zl := string(rune(0x2028))
+	input := "${foo" + zl + ".bar}"
+	segs := substSegments(t, input)
+	if len(segs) != 2 {
+		t.Fatalf("Zl before dot: got %d segments, want 2: %v", len(segs), segs)
+	}
+	if segs[0].Text != "foo" {
+		t.Errorf("Zl before dot: seg[0].Text=%q, want %q", segs[0].Text, "foo")
+	}
+	if segs[1].Text != "bar" {
+		t.Errorf("Zl before dot: seg[1].Text=%q, want %q", segs[1].Text, "bar")
+	}
+}
+
+// TestSpecS6_SubstBodyVtabBeforeDot verifies that vertical tab (U+000B) inside
+// ${...} before a dot acts as inter-segment whitespace (discarded) rather than
+// being absorbed into the segment text. Status: RED — isUnquotedSubstChar uses
+// hardcoded set.
+func TestSpecS6_SubstBodyVtabBeforeDot(t *testing.T) {
+	input := "${foo\x0b.bar}"
+	segs := substSegments(t, input)
+	if len(segs) != 2 {
+		t.Fatalf("vtab before dot: got %d segments, want 2: %v", len(segs), segs)
+	}
+	if segs[0].Text != "foo" {
+		t.Errorf("vtab before dot: seg[0].Text=%q, want %q", segs[0].Text, "foo")
+	}
+	if segs[1].Text != "bar" {
+		t.Errorf("vtab before dot: seg[1].Text=%q, want %q", segs[1].Text, "bar")
+	}
+}
+
+// TestSpecS6_SubstBodyBOMBeforeDot verifies that BOM (U+FEFF) inside ${...}
+// before a dot acts as inter-segment whitespace (discarded) rather than being
+// absorbed into the segment text. Status: RED — isUnquotedSubstChar uses hardcoded
+// set.
+func TestSpecS6_SubstBodyBOMBeforeDot(t *testing.T) {
+	bom := string(rune(0xFEFF))
+	input := "${foo" + bom + ".bar}"
+	segs := substSegments(t, input)
+	if len(segs) != 2 {
+		t.Fatalf("BOM before dot: got %d segments, want 2: %v", len(segs), segs)
+	}
+	if segs[0].Text != "foo" {
+		t.Errorf("BOM before dot: seg[0].Text=%q, want %q", segs[0].Text, "foo")
+	}
+	if segs[1].Text != "bar" {
+		t.Errorf("BOM before dot: seg[1].Text=%q, want %q", segs[1].Text, "bar")
+	}
+}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -434,16 +434,17 @@ func TestSpecS2_3_CommentMarkersInQuotedString(t *testing.T) {
 // TestSpecS6_1_UnicodeCategoryZsIsWhitespace verifies that Unicode Zs-category
 // characters (e.g. em space U+2003) are treated as token separators.
 // Spec L170.
-// Status: ❌ spec violation — lexer rejects Zs chars with "unexpected character"
-// instead of treating them as whitespace. See issue #59.
+// Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_1_UnicodeCategoryZsIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
 	// Em space (U+2003, Zs) between two unquoted tokens should act as a
-	// separator, producing two separate TokenString tokens.
+	// separator, producing two separate TokenString tokens with no error.
 	src := "a\u2003b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("src=%q: got unexpected error token: %q", src, tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -455,14 +456,16 @@ func TestSpecS6_1_UnicodeCategoryZsIsWhitespace(t *testing.T) {
 
 // TestSpecS6_1_UnicodeCategoryZlIsWhitespace verifies that line separator
 // (U+2028, Zl) is treated as whitespace. Spec L170.
-// Status: ❌ spec violation — see issue #59.
+// Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_1_UnicodeCategoryZlIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
-	// Line separator (U+2028, Zl) should separate two unquoted tokens.
+	// Line separator (U+2028, Zl) should separate two unquoted tokens with no error.
 	src := "a\u2028b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("src=%q: got unexpected error token: %q", src, tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}
@@ -474,14 +477,16 @@ func TestSpecS6_1_UnicodeCategoryZlIsWhitespace(t *testing.T) {
 
 // TestSpecS6_1_UnicodeCategoryZpIsWhitespace verifies that paragraph separator
 // (U+2029, Zp) is treated as whitespace. Spec L170 covers Zs/Zl/Zp; this is the
-// Zp half. Status: ❌ spec violation — see issue #59.
+// Zp half. Status: ✅ fixed in fix/s6-whitespace-expansion (was: ❌ #59)
 func TestSpecS6_1_UnicodeCategoryZpIsWhitespace(t *testing.T) {
-	t.Skipf("spec violation, see #59")
-	// Paragraph separator (U+2029, Zp) should separate two unquoted tokens.
+	// Paragraph separator (U+2029, Zp) should separate two unquoted tokens with no error.
 	src := "a\u2029b"
 	toks := tokenize(src)
 	var strings_ []string
 	for _, tok := range toks {
+		if tok.Type == lexer.TokenError || tok.Type == lexer.TokenInvalid {
+			t.Errorf("src=%q: got unexpected error token: %q", src, tok.Value)
+		}
 		if tok.Type == lexer.TokenString {
 			strings_ = append(strings_, tok.Value)
 		}


### PR DESCRIPTION
## Summary

Expand HOCON lexer whitespace recognition to match the [Lightbend HOCON.md §Whitespace](https://github.com/lightbend/config/blob/main/HOCON.md#whitespace) (L165–184). Part of [Phase 6 #1](https://github.com/o3co/xx.hocon/blob/develop/docs/compliance-matrix.md) of the cross-impl compliance program.

## Compliance lift (in-scope)

- S6.1 ❌ → ✅ — Unicode Zs/Zl/Zp category characters recognized as whitespace
- S6.2 ❌ → ✅ — Non-breaking spaces (U+00A0, U+2007, U+202F) recognized
- S6.4 ⚠️ → ✅ — All 8 non-newline ASCII control whitespace chars (U+0009, U+000B–U+000D, U+001C–U+001F) recognized
- S6.3 — broadened: BOM (U+FEFF) now whitespace anywhere, not only at start-of-input

Expected lift: **80.2% → ~81.5%** (closes [#59](https://github.com/o3co/go.hocon/issues/59))

## Behavior changes (intentional)

1. **BOM mid-stream is whitespace** (3-way convergent with ts/rs) — was: stripped only at start-of-input. Spec L173 says BOM "must also be treated as whitespace" with no positional qualifier.
2. **CR (`\r`) inside `\${...}`** (3-way convergent with ts/rs) — was: "unterminated substitution" error alongside LF. Now consumed as inter-segment whitespace per spec L182–184. LF still terminates substitution body as error.
3. **NEL (U+0085) no longer forbidden in unquoted strings** (go-specific) — was: rejected via \`unicode.IsSpace()\` which incorrectly included NEL. Now allowed because NEL is not in HOCON_WS per spec L165–184; S8.8 allows control chars not in the forbidden list.

## Implementation

- Added \`isHoconWhitespace(r)\` + \`isHoconNewline(r)\` predicates matching the spec set exactly (hardcoded, not delegated to \`unicode.IsSpace()\` which has the NEL divergence above).
- Newline check runs before whitespace skip in \`skipWhitespaceAndComments\` (spec §D invariant — LF must still emit \`TokenNewline\`).
- Fixed pre-existing internal inconsistency: \`isUnquotedForbidden\` was using \`unicode.IsSpace()\` while main lexer used hardcoded ASCII — both sites now route through \`isHoconWhitespace\`.
- All four call sites route through the new predicate: main loop, \`parseSubstBody\` whitespace skip, \`isUnquotedSubstChar\`, \`isUnquotedForbidden\`.

## Design references

- Cross-impl design spec + per-impl plan in xx.hocon \`.claude/superpowers/\` (Codex-reviewed, multi-agent-reviewed)
- Lightbend HOCON.md §Whitespace L165–184

## Test plan

- [x] RED commits demonstrate failure before predicate implementation (assertion strengthened with TokenError check)
- [x] LF regression guard test confirms LF still emits \`TokenNewline\` after predicate centralization
- [x] BOM mid-stream regression test (S6.3 broadening verification)
- [x] Subst body whitespace tests cover NBSP / Zl / vtab / BOM / CR inside \`\${...}\` (post-multi-agent-review fix)
- [x] \`make test\` green
- [x] \`go vet ./...\` clean / \`gofmt -l .\` clean