### PR TITLE
docs(spec-compliance): remove S6.6 (NEL) row — not a canonical spec item

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -140,10 +140,6 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   tests: spec_phase5_test.go (TestSpec_S6_5_NewlineMeansLF)
   status: ✅
 
-- **S6.6** NEL (U+0085) is not in HOCON_WS and is not a newline — §Whitespace (L165-184)
-  status: ✅ (clarified in fix/s6-whitespace-expansion)
-  behavior-change (fix/s6-whitespace-expansion): previously, unquoted string tokenization used Go's unicode.IsSpace() which includes U+0085 (NEL), causing NEL to be treated as a whitespace separator and excluded from unquoted string tokens. The new isHoconWhitespace predicate does not include NEL (per HOCON spec L165-184). NEL is now allowed in unquoted strings per S8.8 (control chars not in the forbidden set are permitted). Intentional divergence from Go stdlib unicode.IsSpace.
-
 ## S7. Duplicate keys and object merging
 
 - **S7.1** Later non-object key overrides earlier — §Duplicate keys (L189)


### PR DESCRIPTION
## Summary

Removes the S6.6 (NEL) row from `docs/spec-compliance.md`. Follow-up to [#78](https://github.com/o3co/go.hocon/pull/78).

## Why

S6.6 was added in #78 as a per-impl note documenting the NEL behavior change. On cross-impl review the row was identified as inconsistent with the canonical scope rule:

- `docs/spec-compliance.md` is the per-impl mirror of `xx.hocon/docs/spec-checklist.md` (canonical spec items)
- The HOCON spec (§Whitespace, L165-184) does NOT explicitly state that NEL is excluded — its non-membership in `HOCON_WS` is implicit from absence-in-enumeration
- Implicit-by-absence is not a spec item (the same reasoning would force rows for every Unicode codepoint not enumerated)

S6.5 (newline = LF specifically) IS canonical because the spec asserts it explicitly at L182-184; S6.6 has no such anchoring.

## What stays

- `TestSpecS8_8_NELAllowedInUnquoted` — the regression test in `internal/lexer/lexer_test.go` remains as impl-specific Go-stdlib-footgun guard.
- Merge commit body of #78 — records the NEL behavior change in git history.

## What is moving (separate xx.hocon PR)

A new doc `xx.hocon/docs/extra-spec-conventions.md` will collect cross-impl behaviors that go beyond HOCON.md but should converge across ts/rs/go (E-prefix namespace, distinct from S-prefix spec items). NEL becomes E1 there.

## Test plan

- [x] `make test` green (no test changes; pure docs edit)