### PR TITLE
fix(s15): numericObjectToArray + accessor + pairwise-fold concat (closes #71)

### DIFF
--- a/config.go
+++ b/config.go
@@ -374,10 +374,42 @@ func parseBytes(s string) (int64, error) {
 
 // ── slices ────────────────────────────────────────────────────────
 
+// lookupArray resolves path and returns an *ArrayVal, applying S15 numeric-object
+// conversion when the value is an ObjectVal.  Returns (arr, true) on success,
+// (nil, false) when the path is missing or the value cannot be converted.
+// The caller must NOT call this when the path is expected to panic (use getArray).
+func (c *Config) lookupArray(path string) (*resolver.ArrayVal, bool) {
+	v, ok := c.lookup(path)
+	if !ok {
+		return nil, false
+	}
+	// S15: try numeric-object → array conversion before the type check.
+	if obj, isObj := v.(*resolver.ObjectVal); isObj {
+		if converted, convOK := resolver.NumericObjectToArray(obj); convOK {
+			return converted, true
+		}
+		// Non-eligible object (empty or no int keys) → not an array.
+		return nil, false
+	}
+	arr, isArr := v.(*resolver.ArrayVal)
+	if !isArr {
+		return nil, false
+	}
+	return arr, true
+}
+
 func (c *Config) getArray(path string) *resolver.ArrayVal {
 	v, ok := c.lookup(path)
 	if !ok {
 		panicConfig(path, "key not found")
+	}
+	// S15: if the value is a numerically-indexed object, attempt conversion to
+	// an array before the type check.  Non-eligible objects (empty, no int keys)
+	// fall through to the panic below — preserving existing error semantics.
+	if obj, isObj := v.(*resolver.ObjectVal); isObj {
+		if converted, convOK := resolver.NumericObjectToArray(obj); convOK {
+			return converted
+		}
 	}
 	arr, ok := v.(*resolver.ArrayVal)
 	if !ok {
@@ -400,11 +432,7 @@ func (c *Config) GetStringSlice(path string) []string {
 }
 
 func (c *Config) GetStringSliceOption(path string) Option[[]string] {
-	v, ok := c.lookup(path)
-	if !ok {
-		return None[[]string]()
-	}
-	arr, ok := v.(*resolver.ArrayVal)
+	arr, ok := c.lookupArray(path)
 	if !ok {
 		return None[[]string]()
 	}
@@ -437,11 +465,7 @@ func (c *Config) GetInt64Slice(path string) []int64 {
 }
 
 func (c *Config) GetInt64SliceOption(path string) Option[[]int64] {
-	v, ok := c.lookup(path)
-	if !ok {
-		return None[[]int64]()
-	}
-	arr, ok := v.(*resolver.ArrayVal)
+	arr, ok := c.lookupArray(path)
 	if !ok {
 		return None[[]int64]()
 	}
@@ -470,11 +494,7 @@ func (c *Config) GetIntSlice(path string) []int {
 }
 
 func (c *Config) GetIntSliceOption(path string) Option[[]int] {
-	v, ok := c.lookup(path)
-	if !ok {
-		return None[[]int]()
-	}
-	arr, ok := v.(*resolver.ArrayVal)
+	arr, ok := c.lookupArray(path)
 	if !ok {
 		return None[[]int]()
 	}
@@ -537,11 +557,7 @@ func (c *Config) GetConfigSlice(path string) []*Config {
 }
 
 func (c *Config) GetConfigSliceOption(path string) Option[[]*Config] {
-	v, ok := c.lookup(path)
-	if !ok {
-		return None[[]*Config]()
-	}
-	arr, ok := v.(*resolver.ArrayVal)
+	arr, ok := c.lookupArray(path)
 	if !ok {
 		return None[[]*Config]()
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -968,10 +968,6 @@ func TestConfig_DelayedMergeNestedSubstitution(t *testing.T) {
 
 // ── Spec compliance Phase 4: S15, S17.5, S17.7, S17.8, S21.4, S21.5 ──────────────
 
-// specIssueS15 is the GitHub issue number for the S15 spec violation.
-// Resolved: go.hocon now converts numerically-indexed objects to arrays.
-const specIssueS15 = 71
-
 // specIssueS17_7_8 is the GitHub issue number for the S17.7/S17.8 spec violation.
 // Option accessors return None instead of an error for object/array type mismatches.
 const specIssueS17_7_8 = 72

--- a/config_test.go
+++ b/config_test.go
@@ -969,7 +969,7 @@ func TestConfig_DelayedMergeNestedSubstitution(t *testing.T) {
 // ── Spec compliance Phase 4: S15, S17.5, S17.7, S17.8, S21.4, S21.5 ──────────────
 
 // specIssueS15 is the GitHub issue number for the S15 spec violation.
-// go.hocon does not convert numerically-indexed objects to arrays.
+// Resolved: go.hocon now converts numerically-indexed objects to arrays.
 const specIssueS15 = 71
 
 // specIssueS17_7_8 is the GitHub issue number for the S17.7/S17.8 spec violation.
@@ -986,9 +986,8 @@ const specIssueS21_5 = 74
 
 // TestSpec_S15_1_NumericObjectToArray verifies that an object with integer keys
 // {"0":"a","1":"b"} is converted to ["a","b"] when array access is requested.
-// Currently not implemented — see issue #71.
+// Fixed in fix/s15-numeric-obj-array, see issue #71.
 func TestSpec_S15_1_NumericObjectToArray(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
 	cfg := mustParseCfg(t, `arr: {"0": "a", "1": "b"}`)
 	got := cfg.GetStringSlice("arr")
 	want := []string{"a", "b"}
@@ -1004,9 +1003,8 @@ func TestSpec_S15_1_NumericObjectToArray(t *testing.T) {
 
 // TestSpec_S15_2_ConversionIsLazy verifies that numeric-key objects are not converted
 // eagerly; they remain objects until array access is attempted.
-// Currently not implemented — see issue #71.
+// Fixed in fix/s15-numeric-obj-array, see issue #71.
 func TestSpec_S15_2_ConversionIsLazy(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
 	// Object with numeric keys should still be accessible as an object (lazy).
 	cfg := mustParseCfg(t, `arr: {"0": "a", "1": "b"}`)
 	// String access should still return "a" for key "arr.0"
@@ -1020,33 +1018,10 @@ func TestSpec_S15_2_ConversionIsLazy(t *testing.T) {
 	}
 }
 
-// TestSpec_S15_3_ConversionInConcatenation_Pin pins the current behaviour for a
-// real adjacent-value list concatenation: `arr = [a] ${obj}` with a numeric-keyed
-// object substitution. Spec L1210 requires the object to convert to its array
-// form and flatten in (yielding ["a","x","y"]). Probe (2026-05-12) shows go.hocon
-// parses successfully but the object is inserted un-converted, so:
-//   - GetStringSlice panics ("element 1 is not a non-null scalar")
-//   - GetStringSliceOption returns None
-//
-// Pin asserts the Option-None outcome — when conversion is implemented per #71,
-// this pin flips and the _Spec test below becomes the live assertion.
-func TestSpec_S15_3_ConversionInConcatenation_Pin(t *testing.T) {
-	// pin: see #71
-	_ = specIssueS15
-	cfg := mustParseCfg(t, `
-obj = {"0": "x", "1": "y"}
-arr = [a] ${obj}
-`)
-	if cfg.GetStringSliceOption("arr").IsSome() {
-		t.Error("[pin] GetStringSliceOption(arr) should currently return None (object element not converted)")
-	}
-}
-
-// TestSpec_S15_3_ConversionInConcatenation_Spec is skipped while conversion is
-// unimplemented (#71). When the fix lands, remove the Skip and the assertion
-// should pass: ["a","x","y"] after conversion + flatten per HOCON L1210.
-func TestSpec_S15_3_ConversionInConcatenation_Spec(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
+// TestSpec_S15_3_ConversionInConcatenation verifies that `arr = [a] ${obj}` with a
+// numeric-keyed object substitution converts and flattens to ["a","x","y"] per
+// HOCON L1210. Fixed in fix/s15-numeric-obj-array, see issue #71.
+func TestSpec_S15_3_ConversionInConcatenation(t *testing.T) {
 	cfg := mustParseCfg(t, `
 obj = {"0": "x", "1": "y"}
 arr = [a] ${obj}
@@ -1064,10 +1039,8 @@ arr = [a] ${obj}
 }
 
 // TestSpec_S15_4_EmptyObjectNotConverted verifies that an empty object {} is NOT
-// converted to an array. Currently passes incidentally: go.hocon has no conversion
-// path at all, so `arr: {}` stays an object and GetStringSliceOption returns None.
-// When #71 lands, this test must continue to pass — the implementation needs an
-// explicit empty-object guard before the conversion path, not rely on its absence.
+// converted to an array. The explicit empty-object guard in numericObjectToArray
+// ensures this continues to pass after fix/s15-numeric-obj-array (#71).
 func TestSpec_S15_4_EmptyObjectNotConverted(t *testing.T) {
 	cfg := mustParseCfg(t, `arr: {}`)
 	opt := cfg.GetStringSliceOption("arr")
@@ -1078,9 +1051,8 @@ func TestSpec_S15_4_EmptyObjectNotConverted(t *testing.T) {
 
 // TestSpec_S15_5_NonIntegerKeysIgnored verifies that non-integer keys are skipped
 // during object-to-array conversion; only integer-keyed entries appear in the result.
-// Currently not implemented — see issue #71.
+// Fixed in fix/s15-numeric-obj-array, see issue #71.
 func TestSpec_S15_5_NonIntegerKeysIgnored(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
 	cfg := mustParseCfg(t, `arr: {"0": "a", "foo": "ignored", "1": "b"}`)
 	got := cfg.GetStringSlice("arr")
 	want := []string{"a", "b"}
@@ -1096,9 +1068,8 @@ func TestSpec_S15_5_NonIntegerKeysIgnored(t *testing.T) {
 
 // TestSpec_S15_6_MissingIndicesCompacted verifies that gaps in integer keys are
 // eliminated: {"0":"a","2":"c"} → ["a","c"] (not ["a",<nil>,"c"]).
-// Currently not implemented — see issue #71.
+// Fixed in fix/s15-numeric-obj-array, see issue #71.
 func TestSpec_S15_6_MissingIndicesCompacted(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
 	cfg := mustParseCfg(t, `arr: {"0": "a", "2": "c"}`)
 	got := cfg.GetStringSlice("arr")
 	want := []string{"a", "c"}
@@ -1114,9 +1085,8 @@ func TestSpec_S15_6_MissingIndicesCompacted(t *testing.T) {
 
 // TestSpec_S15_7_SortedByIntegerKey verifies that the resulting array is sorted by
 // the integer value of each key, not by insertion order.
-// Currently not implemented — see issue #71.
+// Fixed in fix/s15-numeric-obj-array, see issue #71.
 func TestSpec_S15_7_SortedByIntegerKey(t *testing.T) {
-	t.Skipf("spec violation: numerically-indexed object-to-array conversion not implemented, see #%d", specIssueS15)
 	cfg := mustParseCfg(t, `arr: {"1": "b", "0": "a"}`)
 	got := cfg.GetStringSlice("arr")
 	want := []string{"a", "b"}

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -700,12 +700,12 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 - **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
   tests: config_test.go (TestSpec_S15_2_ConversionIsLazy); numeric_array_test.go (TestS15_Fixture_na02_LazyGetObject)
   status: ✅
-  note: fixed in fix/s15-numeric-obj-array (#71). Conversion fires only in `getArray`/`lookupArray` (array-typed accessors), not in `GetConfig`/`GetConfigOption` or `Has`.
+  note: fixed in fix/s15-numeric-obj-array (#71). Conversion fires in two places: array-typed accessors (`getArray`/`lookupArray`, used by `Get*Slice` / `Get*SliceOption`) AND resolution-time array concat (`joinPair` in `internal/resolver/resolver.go` — when an Array meets an Object). `GetConfig`/`GetConfigOption` and `Has` remain lazy and do not trigger conversion.
 
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
   tests: config_test.go (TestSpec_S15_3_ConversionInConcatenation); numeric_array_test.go (TestS15_Fixture_na03a_ConcatLeftList, na03b, na03c, na03d)
   status: ✅
-  note: fixed in fix/s15-numeric-obj-array (#71). `concatArraysPermissive` now calls `numericObjectToArray` on any ObjectVal encountered in array-concat context. Multi-piece concat (`na03d`) follows left-to-right pairwise fold per Lightbend `consolidate`.
+  note: fixed in fix/s15-numeric-obj-array (#71). `joinPair` in `internal/resolver/resolver.go` (replacing the earlier `concatArraysPermissive`) calls `numericObjectToArray` on any ObjectVal when the partner is an Array; `concatTwoArrays` then performs the array-array merge. Multi-piece concat (`na03d`) follows true left-to-right pairwise fold per Lightbend `consolidate`.
 
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
   tests: config_test.go (TestSpec_S15_4_EmptyObjectNotConverted); numeric_array_test.go (TestS15_Fixture_na04_EmptyNotConverted)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -693,39 +693,39 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ## S15. Numerically-indexed objects to arrays
 
 - **S15.1** `{"0":"a","1":"b"}` → `["a","b"]` when array context — §Conversion (L1191)
-  tests: config_test.go (TestSpec_S15_1_NumericObjectToArray)
-  status: ❌
-  note: numerically-indexed object-to-array conversion not implemented; see issue #71.
+  tests: config_test.go (TestSpec_S15_1_NumericObjectToArray); numeric_array_test.go (TestS15_Fixture_na01_BasicAccessor)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71) via `numericObjectToArray` helper called from `getArray`.
 
 - **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
-  tests: config_test.go (TestSpec_S15_2_ConversionIsLazy)
-  status: ❌
-  note: conversion not implemented at all; see issue #71.
+  tests: config_test.go (TestSpec_S15_2_ConversionIsLazy); numeric_array_test.go (TestS15_Fixture_na02_LazyGetObject)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71). Conversion fires only in `getArray`/`lookupArray` (array-typed accessors), not in `GetConfig`/`GetConfigOption` or `Has`.
 
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: config_test.go (TestSpec_S15_3_ConversionInConcatenation_Pin); config_test.go (TestSpec_S15_3_ConversionInConcatenation_Spec)
-  status: ❌
-  note: real concat context `arr = [a] ${obj}` (with `obj = {"0":"x","1":"y"}`) parses, but the object is inserted un-converted as an element — `GetStringSlice` panics and `GetStringSliceOption` returns None. Spec L1210 requires conversion + flatten to `["a","x","y"]`. Pin asserts the Option-None outcome. Tracked in #71.
+  tests: config_test.go (TestSpec_S15_3_ConversionInConcatenation); numeric_array_test.go (TestS15_Fixture_na03a_ConcatLeftList, na03b, na03c, na03d)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71). `concatArraysPermissive` now calls `numericObjectToArray` on any ObjectVal encountered in array-concat context. Multi-piece concat (`na03d`) follows left-to-right pairwise fold per Lightbend `consolidate`.
 
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
-  tests: config_test.go (TestSpec_S15_4_EmptyObjectNotConverted)
-  status: ✅ (incidental)
-  note: passes today because no conversion runs at all — `arr: {}` stays an object and `GetStringSliceOption` returns None. When #71 lands, the test must continue to pass via an explicit empty-object guard before the conversion path, not by its absence. Aligns with rs.hocon's identical determination.
+  tests: config_test.go (TestSpec_S15_4_EmptyObjectNotConverted); numeric_array_test.go (TestS15_Fixture_na04_EmptyNotConverted)
+  status: ✅
+  note: `numericObjectToArray` has an explicit empty-object guard (`len(obj.keys) == 0` → return nil, false). Previously passed incidentally; now backed by explicit logic.
 
 - **S15.5** Non-integer keys ignored during conversion — §Conversion (L1214)
-  tests: config_test.go (TestSpec_S15_5_NonIntegerKeysIgnored)
-  status: ❌
-  note: conversion not implemented at all; see issue #71.
+  tests: config_test.go (TestSpec_S15_5_NonIntegerKeysIgnored); numeric_array_test.go (TestS15_Fixture_na05_NonIntKeysIgnored)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71). Pre-filter regex `^(0|[1-9][0-9]*)$` rejects non-integer keys; only eligible keys contribute to the array.
 
 - **S15.6** Missing indices compacted in resulting array — §Conversion (L1216)
-  tests: config_test.go (TestSpec_S15_6_MissingIndicesCompacted)
-  status: ❌
-  note: conversion not implemented at all; see issue #71.
+  tests: config_test.go (TestSpec_S15_6_MissingIndicesCompacted); numeric_array_test.go (TestS15_Fixture_na06_GapCompaction)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71). Eligible entries are sorted by integer key then projected linearly — gaps are naturally eliminated.
 
 - **S15.7** Sorted by integer key value — §Conversion (L1216)
-  tests: config_test.go (TestSpec_S15_7_SortedByIntegerKey)
-  status: ❌
-  note: conversion not implemented at all; see issue #71.
+  tests: config_test.go (TestSpec_S15_7_SortedByIntegerKey); numeric_array_test.go (TestS15_Fixture_na07_SortByKey)
+  status: ✅
+  note: fixed in fix/s15-numeric-obj-array (#71). `sort.Slice` on parsed integer keys ensures correct order regardless of insertion order.
 
 ## S16. MIME Type
 

--- a/internal/resolver/numeric_array.go
+++ b/internal/resolver/numeric_array.go
@@ -1,0 +1,95 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+// eligibleKeyRe is the pre-filter for numerically-eligible object keys per the
+// S15 integer-key parse rule.  Only keys that match this pattern are considered
+// candidate integer keys; all others are silently ignored.
+//
+// The pattern enforces:
+//   - "0" is the only zero form  (leading zeros like "00", "007" are rejected)
+//   - No leading sign character  ("+1", "-0", "-1" are all rejected)
+//   - Decimal digits only        ("0x1", "1e2", "1.0" are rejected)
+//   - No whitespace              (" 1", "1 " are rejected)
+//   - Non-empty                  ("" is rejected)
+//
+// This is intentionally stricter than Go's strconv.ParseInt, which accepts
+// "+1", "-0", "00" etc.  The pre-filter must run BEFORE any native parse call.
+var eligibleKeyRe = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+
+// NumericObjectToArray is the exported entry point for use by the hocon package.
+// It delegates to numericObjectToArray.
+func NumericObjectToArray(obj *ObjectVal) (*ArrayVal, bool) {
+	return numericObjectToArray(obj)
+}
+
+// numericObjectToArray attempts to convert a numerically-indexed ObjectVal into
+// an ArrayVal by the S15 semantics:
+//
+//  1. value must be a non-nil ObjectVal.
+//  2. The object must not be empty (S15.4: empty object is NOT converted).
+//  3. At least one key must be eligible per the integer-key parse rule.
+//
+// Eligible keys are sorted by their integer value ascending; gaps are eliminated
+// (S15.6 compaction); non-eligible keys are silently ignored (S15.5).
+//
+// Returns (arr, true) when conversion succeeds.
+// Returns (nil, false) in all other cases — caller handles type mismatch.
+func numericObjectToArray(obj *ObjectVal) (*ArrayVal, bool) {
+	if obj == nil {
+		return nil, false
+	}
+	// S15.4: empty object is explicitly NOT converted.
+	if len(obj.keys) == 0 {
+		return nil, false
+	}
+
+	type kv struct {
+		n int
+		v Val
+	}
+
+	var eligible []kv
+	for _, key := range obj.keys {
+		// Pre-filter: must match ^(0|[1-9][0-9]*)$.
+		if !eligibleKeyRe.MatchString(key) {
+			continue
+		}
+		// Range check: must fit in i32 (max 2147483647).
+		n, err := strconv.ParseInt(key, 10, 32)
+		if err != nil {
+			// Overflow or other parse failure — reject.
+			continue
+		}
+		eligible = append(eligible, kv{n: int(n), v: obj.values[key]})
+	}
+
+	// No eligible keys → no conversion possible.
+	if len(eligible) == 0 {
+		return nil, false
+	}
+
+	// Sort by integer key ascending (S15.7).
+	sort.Slice(eligible, func(i, j int) bool {
+		return eligible[i].n < eligible[j].n
+	})
+
+	// Project to value array, eliminating gaps (S15.6).
+	arr := &ArrayVal{Elements: make([]Val, len(eligible))}
+	for i, kv := range eligible {
+		arr.Elements[i] = kv.v
+	}
+	return arr, true
+}

--- a/internal/resolver/numeric_array_test.go
+++ b/internal/resolver/numeric_array_test.go
@@ -152,7 +152,8 @@ func TestNumericObjectToArray_NonIntKeysIgnored(t *testing.T) {
 	}
 }
 
-// S15.12: all-non-int keys → no conversion
+// All-non-int keys → no conversion (helper contract; no specific S-row).
+// Spec rows S15.1–S15.7 cover spec-defined cases; this is helper-internal coverage.
 func TestNumericObjectToArray_AllNonInt(t *testing.T) {
 	obj := makeObj("foo", "a", "bar", "b")
 	arr, ok := numericObjectToArray(obj)

--- a/internal/resolver/numeric_array_test.go
+++ b/internal/resolver/numeric_array_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+import (
+	"testing"
+)
+
+// makeScalar is a test helper for building ScalarVal pointers quickly.
+func makeScalar(s string) *ScalarVal { return &ScalarVal{Raw: s, Type: ScalarString} }
+
+// makeObj builds an ObjectVal from a slice of key/string pairs.
+// Keys appear in slice order, values are ScalarString.
+func makeObj(pairs ...string) *ObjectVal {
+	obj := newObjectVal()
+	for i := 0; i+1 < len(pairs); i += 2 {
+		obj.set(pairs[i], makeScalar(pairs[i+1]))
+	}
+	return obj
+}
+
+// scalarStrings extracts the Raw string from each element of arr.
+func scalarStrings(arr *ArrayVal) []string {
+	if arr == nil {
+		return nil
+	}
+	out := make([]string, len(arr.Elements))
+	for i, elem := range arr.Elements {
+		sv, ok := elem.(*ScalarVal)
+		if !ok {
+			out[i] = "<non-scalar>"
+			continue
+		}
+		out[i] = sv.Raw
+	}
+	return out
+}
+
+// ── eligibility table ─────────────────────────────────────────────────────────
+
+func TestNumericObjectToArray_Eligibility(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantIn  bool // should the key appear in the result?
+		comment string
+	}{
+		// eligible
+		{"zero", "0", true, "canonical zero"},
+		{"one", "1", true, "single digit"},
+		{"ten", "10", true, "two digits"},
+		{"max_i32", "2147483647", true, "INT32_MAX"},
+
+		// rejected — leading sign
+		{"plus_one", "+1", false, "leading +"},
+		{"minus_one", "-1", false, "leading -"},
+		{"minus_zero", "-0", false, "leading - on zero"},
+
+		// rejected — leading zero
+		{"double_zero", "00", false, "leading zero (double zero)"},
+		{"zero_one", "01", false, "leading zero (01)"},
+		{"zero_zero_seven", "007", false, "leading zero (007)"},
+
+		// rejected — whitespace
+		{"space_one", " 1", false, "leading space"},
+		{"one_space", "1 ", false, "trailing space"},
+
+		// rejected — empty
+		{"empty", "", false, "empty key"},
+
+		// rejected — overflow
+		{"overflow", "2147483648", false, "INT32_MAX + 1"},
+		{"big", "99999999999", false, "large overflow"},
+
+		// rejected — non-decimal forms
+		{"hex", "0x1", false, "hex prefix"},
+		{"exp", "1e2", false, "exponential"},
+		{"decimal", "1.0", false, "decimal point"},
+		{"binary", "0b10", false, "binary prefix"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build an object with the test key (value="TARGET") plus a guaranteed-eligible
+			// baseline key "999" (value="BASELINE") so the object always has at least one
+			// eligible key and conversion does not short-circuit for unrelated reasons.
+			// Using "999" avoids collision with any of the test keys above.
+			obj := newObjectVal()
+			obj.set(tc.key, makeScalar("TARGET"))
+			obj.set("999", makeScalar("BASELINE"))
+
+			arr, ok := numericObjectToArray(obj)
+			if !ok {
+				t.Fatalf("unexpected nil result (object has the '999' baseline key)")
+			}
+
+			targetFound := false
+			for _, elem := range arr.Elements {
+				if sv, isSV := elem.(*ScalarVal); isSV && sv.Raw == "TARGET" {
+					targetFound = true
+				}
+			}
+			if tc.wantIn && !targetFound {
+				t.Errorf("key %q (%s): expected TARGET in result, not found", tc.key, tc.comment)
+			}
+			if !tc.wantIn && targetFound {
+				t.Errorf("key %q (%s): expected TARGET NOT in result, but it was found", tc.key, tc.comment)
+			}
+		})
+	}
+}
+
+// ── nil / empty input ────────────────────────────────────────────────────────
+
+func TestNumericObjectToArray_NilInput(t *testing.T) {
+	arr, ok := numericObjectToArray(nil)
+	if ok || arr != nil {
+		t.Errorf("nil input: expected (nil,false), got (%v,%v)", arr, ok)
+	}
+}
+
+func TestNumericObjectToArray_EmptyObject(t *testing.T) {
+	arr, ok := numericObjectToArray(newObjectVal())
+	if ok || arr != nil {
+		t.Errorf("empty object: expected (nil,false) per S15.4, got (%v,%v)", arr, ok)
+	}
+}
+
+// ── S15.5: non-integer keys ignored ──────────────────────────────────────────
+
+func TestNumericObjectToArray_NonIntKeysIgnored(t *testing.T) {
+	obj := makeObj("0", "a", "foo", "IGNORED", "1", "c")
+	arr, ok := numericObjectToArray(obj)
+	if !ok {
+		t.Fatal("expected conversion to succeed")
+	}
+	got := scalarStrings(arr)
+	want := []string{"a", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d want %d; got %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// S15.12: all-non-int keys → no conversion
+func TestNumericObjectToArray_AllNonInt(t *testing.T) {
+	obj := makeObj("foo", "a", "bar", "b")
+	arr, ok := numericObjectToArray(obj)
+	if ok || arr != nil {
+		t.Errorf("all-non-int: expected (nil,false), got (%v,%v)", arr, ok)
+	}
+}
+
+// ── S15.6: gap compaction ────────────────────────────────────────────────────
+
+func TestNumericObjectToArray_GapCompaction(t *testing.T) {
+	obj := makeObj("0", "a", "2", "c")
+	arr, ok := numericObjectToArray(obj)
+	if !ok {
+		t.Fatal("expected conversion to succeed")
+	}
+	got := scalarStrings(arr)
+	want := []string{"a", "c"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("gap compaction: got %v want %v", got, want)
+	}
+}
+
+// ── S15.7: sort by integer key ───────────────────────────────────────────────
+
+func TestNumericObjectToArray_SortByKey(t *testing.T) {
+	obj := makeObj("1", "b", "0", "a")
+	arr, ok := numericObjectToArray(obj)
+	if !ok {
+		t.Fatal("expected conversion to succeed")
+	}
+	got := scalarStrings(arr)
+	want := []string{"a", "b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("sort: got %v want %v", got, want)
+	}
+}
+
+// ── basic happy path ─────────────────────────────────────────────────────────
+
+func TestNumericObjectToArray_Basic(t *testing.T) {
+	obj := makeObj("0", "a", "1", "b")
+	arr, ok := numericObjectToArray(obj)
+	if !ok {
+		t.Fatal("expected conversion to succeed")
+	}
+	got := scalarStrings(arr)
+	want := []string{"a", "b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("basic: got %v want %v", got, want)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -627,8 +627,12 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val,
 	}
 
 	// Build the meaningful (non-nil, non-separator) slice for the pairwise fold.
-	// Whitespace between array/object elements is intentionally discarded per
-	// S10.6 leading/trailing whitespace rules for array concatenation.
+	// When any array or object is present in the concat, ALL parser-inserted
+	// separator tokens are stripped — including those between scalar tokens in
+	// a mixed concat. This matches Lightbend's behaviour: in array/object
+	// context, separator whitespace has no semantic role. Pure scalar concat
+	// (handled above when !hasArrayOrObject) keeps separators so string concat
+	// can preserve `"foo bar"` style whitespace.
 	var meaningful []Val
 	for _, rv := range resolved {
 		if rv == nil || isSeparator(rv) {
@@ -714,10 +718,16 @@ func (r *resolver) joinPair(left, right Val) (Val, error) {
 		return result, nil
 
 	default:
-		// Scalar + Scalar: string-concat without separator (separator already stripped).
-		// This branch is only reached when hasArrayOrObject is true but the accumulated
-		// value so far and the next value are both scalars — e.g. a substitution that
-		// resolved to a scalar inside a mixed concat. Concatenate directly.
+		// All remaining type-pair combinations land here: Scalar+Scalar,
+		// Object+Scalar, Scalar+Object (Object+Object is handled by the
+		// case above; Array+anything by the cases above this default).
+		// In a mixed concat where structured types are present, the
+		// remaining non-array/non-array-paired values become a string
+		// concat — separators have already been stripped above, so the
+		// result is the raw concatenation. This matches Lightbend's
+		// fallthrough behaviour: invalid mixes (S10.13) silently become
+		// a string in current spec; S10.13 strict-error is a separate
+		// Phase 6 cluster.
 		return r.concatStrings([]Val{left, right}), nil
 	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -608,34 +608,117 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string) (Val,
 		resolved = append(resolved, rv)
 	}
 
-	// Classify non-nil, non-separator elements to determine concatenation mode.
-	hasArray := false
-	hasObject := false
-	hasScalar := false
+	// Classify non-nil, non-separator elements to detect array/object involvement.
+	hasArrayOrObject := false
 	for _, rv := range resolved {
 		if rv == nil || isSeparator(rv) {
 			continue
 		}
 		switch rv.(type) {
-		case *ArrayVal:
-			hasArray = true
-		case *ObjectVal:
-			hasObject = true
-		default:
-			hasScalar = true
+		case *ArrayVal, *ObjectVal:
+			hasArrayOrObject = true
 		}
 	}
 
-	switch {
-	case hasObject && !hasArray && !hasScalar:
-		// All meaningful elements are objects → deep merge (left to right, later wins)
-		return concatObjects(resolved), nil
-	case hasArray:
-		// Array concatenation (permissive: non-array elements become single items)
-		return concatArraysPermissive(resolved), nil
-	default:
-		// String concatenation (fallback)
+	// Pure-scalar concat: pass the full resolved slice (including whitespace-separator
+	// tokens) to concatStrings so that spaces between tokens are preserved.
+	if !hasArrayOrObject {
 		return r.concatStrings(resolved), nil
+	}
+
+	// Build the meaningful (non-nil, non-separator) slice for the pairwise fold.
+	// Whitespace between array/object elements is intentionally discarded per
+	// S10.6 leading/trailing whitespace rules for array concatenation.
+	var meaningful []Val
+	for _, rv := range resolved {
+		if rv == nil || isSeparator(rv) {
+			continue
+		}
+		meaningful = append(meaningful, rv)
+	}
+
+	if len(meaningful) == 0 {
+		return r.concatStrings(resolved), nil
+	}
+
+	// True left-to-right pairwise fold per spec §"Multi-piece concat is
+	// left-to-right pairwise (NORMATIVE)" and Lightbend ConfigConcatenation.consolidate.
+	//
+	// joinPair accumulates left-to-right so that adjacent objects are merged
+	// (S10.3) before a list partner triggers numericObjectToArray.  A prior
+	// single-pass classify-then-bulk approach produced wrong results when
+	// adjacent objects had overlapping numeric keys (na03e regression).
+	acc := meaningful[0]
+	for _, v := range meaningful[1:] {
+		next, err := r.joinPair(acc, v)
+		if err != nil {
+			return nil, err
+		}
+		acc = next
+	}
+	return acc, nil
+}
+
+// joinPair combines two adjacent resolved values per the HOCON concat rules.
+// It is the inner step of the left-to-right pairwise fold in resolveConcat.
+// All whitespace-separator tokens have already been stripped from the input.
+func (r *resolver) joinPair(left, right Val) (Val, error) {
+	lArr, lIsArr := left.(*ArrayVal)
+	rArr, rIsArr := right.(*ArrayVal)
+	lObj, lIsObj := left.(*ObjectVal)
+	rObj, rIsObj := right.(*ObjectVal)
+
+	switch {
+	case lIsObj && rIsObj:
+		// S10.3: object + object → deep merge (right wins on key conflict).
+		return mergeObjectConcat(lObj, rObj), nil
+
+	case lIsArr && rIsObj:
+		// Array + Object: attempt S15 numeric conversion on the object side.
+		if converted, ok := numericObjectToArray(rObj); ok {
+			return concatTwoArrays(lArr, converted), nil
+		}
+		// Conversion failed → permissive: insert the unconverted object as a single element.
+		result := &ArrayVal{Elements: make([]Val, len(lArr.Elements)+1)}
+		copy(result.Elements, lArr.Elements)
+		result.Elements[len(lArr.Elements)] = right
+		return result, nil
+
+	case lIsObj && rIsArr:
+		// Object + Array: attempt S15 numeric conversion on the object side.
+		if converted, ok := numericObjectToArray(lObj); ok {
+			return concatTwoArrays(converted, rArr), nil
+		}
+		// Conversion failed → permissive: insert the unconverted object as a single element.
+		result := &ArrayVal{Elements: make([]Val, 1+len(rArr.Elements))}
+		result.Elements[0] = left
+		copy(result.Elements[1:], rArr.Elements)
+		return result, nil
+
+	case lIsArr && rIsArr:
+		// Array + Array → plain concatenation.
+		return concatTwoArrays(lArr, rArr), nil
+
+	case lIsArr:
+		// Array + Scalar → permissive: append scalar as element (preserves existing behaviour).
+		result := &ArrayVal{Elements: make([]Val, len(lArr.Elements)+1)}
+		copy(result.Elements, lArr.Elements)
+		result.Elements[len(lArr.Elements)] = right
+		return result, nil
+
+	case rIsArr:
+		// Scalar + Array → permissive: prepend scalar as element.
+		result := &ArrayVal{Elements: make([]Val, 1+len(rArr.Elements))}
+		result.Elements[0] = left
+		copy(result.Elements[1:], rArr.Elements)
+		return result, nil
+
+	default:
+		// Scalar + Scalar: string-concat without separator (separator already stripped).
+		// This branch is only reached when hasArrayOrObject is true but the accumulated
+		// value so far and the next value are both scalars — e.g. a substitution that
+		// resolved to a scalar inside a mixed concat. Concatenate directly.
+		return r.concatStrings([]Val{left, right}), nil
 	}
 }
 
@@ -668,52 +751,11 @@ func mergeObjectConcat(left, right *ObjectVal) *ObjectVal {
 	return result
 }
 
-func concatObjects(vals []Val) Val {
-	var result *ObjectVal
-	for _, v := range vals {
-		if v == nil || isSeparator(v) {
-			continue
-		}
-		obj, ok := v.(*ObjectVal)
-		if !ok {
-			continue
-		}
-		if result == nil {
-			result = obj
-		} else {
-			result = mergeObjectConcat(result, obj)
-		}
-	}
-	if result == nil {
-		return newObjectVal()
-	}
-	return result
-}
-
-func concatArraysPermissive(vals []Val) Val {
-	result := &ArrayVal{}
-	for _, v := range vals {
-		if v == nil || isSeparator(v) {
-			continue
-		}
-		if arr, ok := v.(*ArrayVal); ok {
-			result.Elements = append(result.Elements, arr.Elements...)
-		} else if obj, isObj := v.(*ObjectVal); isObj {
-			// S15 concat-time conversion: when an ObjectVal appears in an array
-			// concatenation context, attempt numeric-object → array conversion.
-			// If conversion succeeds, flatten the resulting elements into the result.
-			// If conversion fails (empty or no eligible keys), insert the object
-			// as a single element — the existing permissive behaviour is preserved
-			// and the accessor-level type check will catch mismatches downstream.
-			if converted, convOK := numericObjectToArray(obj); convOK {
-				result.Elements = append(result.Elements, converted.Elements...)
-			} else {
-				result.Elements = append(result.Elements, v)
-			}
-		} else {
-			result.Elements = append(result.Elements, v)
-		}
-	}
+// concatTwoArrays concatenates two ArrayVals into a new ArrayVal.
+func concatTwoArrays(left, right *ArrayVal) *ArrayVal {
+	result := &ArrayVal{Elements: make([]Val, 0, len(left.Elements)+len(right.Elements))}
+	result.Elements = append(result.Elements, left.Elements...)
+	result.Elements = append(result.Elements, right.Elements...)
 	return result
 }
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -698,6 +698,18 @@ func concatArraysPermissive(vals []Val) Val {
 		}
 		if arr, ok := v.(*ArrayVal); ok {
 			result.Elements = append(result.Elements, arr.Elements...)
+		} else if obj, isObj := v.(*ObjectVal); isObj {
+			// S15 concat-time conversion: when an ObjectVal appears in an array
+			// concatenation context, attempt numeric-object → array conversion.
+			// If conversion succeeds, flatten the resulting elements into the result.
+			// If conversion fails (empty or no eligible keys), insert the object
+			// as a single element — the existing permissive behaviour is preserved
+			// and the accessor-level type check will catch mismatches downstream.
+			if converted, convOK := numericObjectToArray(obj); convOK {
+				result.Elements = append(result.Elements, converted.Elements...)
+			} else {
+				result.Elements = append(result.Elements, v)
+			}
 		} else {
 			result.Elements = append(result.Elements, v)
 		}

--- a/numeric_array_test.go
+++ b/numeric_array_test.go
@@ -116,6 +116,23 @@ func TestS15_Fixture_na03d_MultiPieceConcatNormative(t *testing.T) {
 	assertSlice(t, "arr", got, []string{"x", "y", "z", "w", "a"})
 }
 
+// ── na03e: multi-piece overlap — pairwise fold vs single-pass loop ───────────
+
+// TestS15_Fixture_na03e_MultiPieceOverlap verifies the NORMATIVE left-to-right
+// pairwise fold with overlapping numeric keys across adjacent objects.
+// obj1={"0":"x","1":"y"}, obj2={"0":"z"}, arr = ${obj1} ${obj2} [a]
+// Pairwise fold: join(obj1,obj2) → object-merge → {"0":"z","1":"y"} (obj2 wins key "0")
+//
+//	join(merged, [a]) → numericObjectToArray → ["z","y","a"].
+//
+// A single-pass loop converting each object independently would produce ["x","y","z","a"],
+// which is WRONG. This fixture is the regression guard added after multi-agent review (2026-05-16).
+func TestS15_Fixture_na03e_MultiPieceOverlap(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf")
+	got := cfg.GetStringSlice("arr")
+	assertSlice(t, "arr", got, []string{"z", "y", "a"})
+}
+
 // ── na04: empty object NOT converted ─────────────────────────────────────────
 
 // TestS15_Fixture_na04_EmptyNotConverted verifies S15.4: empty {} is NOT

--- a/numeric_array_test.go
+++ b/numeric_array_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package hocon_test — S15 numeric-object-to-array conformance tests.
+// Loads each xx.hocon fixture from testdata/hocon/numeric-obj-array/ and
+// asserts the o3co accessor result per the spec and divergence docs.
+package hocon_test
+
+import (
+	"testing"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+// mustParseFile is a test helper that parses a fixture file and fatals on error.
+func mustParseFile(t *testing.T, path string) *hocon.Config {
+	t.Helper()
+	cfg, err := hocon.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile(%s): %v", path, err)
+	}
+	return cfg
+}
+
+// assertSlice compares two []string for equality (length + element-wise).
+func assertSlice(t *testing.T, path string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: length=%d want %d; got %v want %v", path, len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s: [%d]=%q want %q", path, i, got[i], want[i])
+		}
+	}
+}
+
+// ── na01: basic accessor conversion ──────────────────────────────────────────
+
+// TestS15_Fixture_na01_BasicAccessor verifies S15.1: object {"0":"a","1":"b"}
+// is converted to ["a","b"] when GetStringSlice is called.
+func TestS15_Fixture_na01_BasicAccessor(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na01-basic.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"a", "b"})
+}
+
+// ── na02: laziness — object is accessible as object ───────────────────────────
+
+// TestS15_Fixture_na02_LazyGetObject verifies S15.2: a numeric-keyed object
+// remains accessible as an object; conversion is NOT eager.
+func TestS15_Fixture_na02_LazyGetObject(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na02-lazy-getobject.conf")
+	// Object access must NOT trigger conversion.
+	sub := cfg.GetConfig("items")
+	if got := sub.GetString("0"); got != "a" {
+		t.Errorf("items.0=%q want %q (laziness violated)", got, "a")
+	}
+	if got := sub.GetString("1"); got != "b" {
+		t.Errorf("items.1=%q want %q (laziness violated)", got, "b")
+	}
+	// Array access DOES trigger conversion.
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"a", "b"})
+}
+
+// ── na03a: concat left-list ───────────────────────────────────────────────────
+
+// TestS15_Fixture_na03a_ConcatLeftList verifies S15.3: [a] ${obj} where obj has
+// numeric keys → arr = ["a", "x", "y"] after concat-time conversion.
+func TestS15_Fixture_na03a_ConcatLeftList(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na03a-concat-left-list.conf")
+	got := cfg.GetStringSlice("arr")
+	assertSlice(t, "arr", got, []string{"a", "x", "y"})
+}
+
+// ── na03b: concat right-list ─────────────────────────────────────────────────
+
+// TestS15_Fixture_na03b_ConcatRightList verifies S15.3 symmetric case: ${obj} [a]
+// → arr = ["x", "y", "a"] after concat-time conversion.
+func TestS15_Fixture_na03b_ConcatRightList(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na03b-concat-right-list.conf")
+	got := cfg.GetStringSlice("arr")
+	assertSlice(t, "arr", got, []string{"x", "y", "a"})
+}
+
+// ── na03c: two-object concat NOT converted ────────────────────────────────────
+
+// TestS15_Fixture_na03c_TwoObjConcatNoConvert verifies that ${obj1} ${obj2} with
+// both sides being objects produces an S10.3 object merge — no array conversion.
+// The merged object IS accessible as an object, and GetStringSlice triggers
+// accessor-side conversion.
+func TestS15_Fixture_na03c_TwoObjConcatNoConvert(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na03c-concat-two-objs.conf")
+	// The resolved arr is the merged object {"0":"x","1":"y","2":"z","3":"w"}.
+	// Accessor-side conversion fires for GetStringSlice.
+	got := cfg.GetStringSlice("arr")
+	assertSlice(t, "arr", got, []string{"x", "y", "z", "w"})
+}
+
+// ── na03d: multi-piece concat left-to-right pairwise (NORMATIVE) ─────────────
+
+// TestS15_Fixture_na03d_MultiPieceConcatNormative verifies the NORMATIVE left-to-right
+// pairwise fold: ${obj1} ${obj2} [a].
+// Fold: join(obj1,obj2) → merged object {0:x,1:y,2:z,3:w};
+//
+//	join(merged, [a]) → numericObjectToArray → ["x","y","z","w","a"].
+func TestS15_Fixture_na03d_MultiPieceConcatNormative(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na03d-concat-multi-piece.conf")
+	got := cfg.GetStringSlice("arr")
+	assertSlice(t, "arr", got, []string{"x", "y", "z", "w", "a"})
+}
+
+// ── na04: empty object NOT converted ─────────────────────────────────────────
+
+// TestS15_Fixture_na04_EmptyNotConverted verifies S15.4: empty {} is NOT
+// converted; GetStringSliceOption returns None (type mismatch).
+func TestS15_Fixture_na04_EmptyNotConverted(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na04-empty.conf")
+	if cfg.GetStringSliceOption("items").IsSome() {
+		t.Errorf("empty object must NOT convert to array (S15.4)")
+	}
+}
+
+// ── na05: non-integer keys ignored ───────────────────────────────────────────
+
+// TestS15_Fixture_na05_NonIntKeysIgnored verifies S15.5: {"0":"a","foo":"b","1":"c"}
+// → ["a","c"] (non-int key "foo" is ignored).
+func TestS15_Fixture_na05_NonIntKeysIgnored(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na05-non-int-keys.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"a", "c"})
+}
+
+// ── na06: gap compaction ──────────────────────────────────────────────────────
+
+// TestS15_Fixture_na06_GapCompaction verifies S15.6: {"0":"a","2":"c"} → ["a","c"]
+// (gap at index 1 is compacted away).
+func TestS15_Fixture_na06_GapCompaction(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na06-gaps.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"a", "c"})
+}
+
+// ── na07: sort by integer key ─────────────────────────────────────────────────
+
+// TestS15_Fixture_na07_SortByKey verifies S15.7: {"1":"b","0":"a"} → ["a","b"]
+// (sorted by integer key value, regardless of insertion order).
+func TestS15_Fixture_na07_SortByKey(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na07-sort.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"a", "b"})
+}
+
+// ── na08: leading zero rejected (E2) ─────────────────────────────────────────
+
+// TestS15_Fixture_na08_LeadingZeroRejected verifies E2 (extra-spec): "00" is
+// non-canonical and ineligible. Only "0" is eligible → result is ["b"].
+// Lightbend divergence: Lightbend accepts "00" as 0 (HashMap collision,
+// non-deterministic winner). o3co rejects "00" for canonical-text guarantee.
+// See testdata/expected/numeric-obj-array/na08-leading-zero.divergence.md.
+func TestS15_Fixture_na08_LeadingZeroRejected(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na08-leading-zero.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"b"})
+}
+
+// ── na09: negative keys ignored ───────────────────────────────────────────────
+
+// TestS15_Fixture_na09_NegativeIgnored verifies that "-1" is ineligible (negative).
+// Only "0" is eligible → result is ["b"].
+func TestS15_Fixture_na09_NegativeIgnored(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na09-negative.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"b"})
+}
+
+// ── na10a: plus sign rejected (E3) ───────────────────────────────────────────
+
+// TestS15_Fixture_na10a_PlusSignRejected verifies E3 (extra-spec): "+1" has a
+// leading sign character and is ineligible. Only "0" is eligible → result is ["b"].
+// Lightbend divergence: Lightbend accepts "+1" as 1 → result would be ["b","a"].
+// See testdata/expected/numeric-obj-array/na10a-plus-sign.divergence.md.
+func TestS15_Fixture_na10a_PlusSignRejected(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na10a-plus-sign.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"b"})
+}
+
+// ── na10b: minus-zero rejected (E4) ──────────────────────────────────────────
+
+// TestS15_Fixture_na10b_MinusZeroRejected verifies E4 (extra-spec): "-0" has a
+// leading sign character and is ineligible. Only "0" is eligible → result is ["b"].
+// Lightbend divergence: Lightbend HashMap collision, non-deterministic winner.
+// See testdata/expected/numeric-obj-array/na10b-minus-zero.divergence.md.
+func TestS15_Fixture_na10b_MinusZeroRejected(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na10b-minus-zero.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"b"})
+}
+
+// ── na11: overflow rejected ───────────────────────────────────────────────────
+
+// TestS15_Fixture_na11_OverflowRejected verifies that "99999999999" exceeds i32
+// range and is rejected. Only "0" is eligible → result is ["b"].
+func TestS15_Fixture_na11_OverflowRejected(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na11-overflow.conf")
+	got := cfg.GetStringSlice("items")
+	assertSlice(t, "items", got, []string{"b"})
+}
+
+// ── na12: all-non-int keys → no conversion ───────────────────────────────────
+
+// TestS15_Fixture_na12_AllNonInt verifies that when no keys are eligible,
+// numericObjectToArray returns None and GetStringSliceOption returns None
+// (type mismatch — no conversion possible).
+func TestS15_Fixture_na12_AllNonInt(t *testing.T) {
+	cfg := mustParseFile(t, "testdata/hocon/numeric-obj-array/na12-no-eligible.conf")
+	if cfg.GetStringSliceOption("items").IsSome() {
+		t.Errorf("all-non-int keys: expected None (no conversion), got Some")
+	}
+}

--- a/testdata/hocon/numeric-obj-array/na01-basic.conf
+++ b/testdata/hocon/numeric-obj-array/na01-basic.conf
@@ -1,0 +1,3 @@
+# S15.1: numerically-keyed object eligible for array conversion when array context is requested.
+# Impl test: getList("items") should return ["a", "b"].
+items = {"0":"a","1":"b"}

--- a/testdata/hocon/numeric-obj-array/na02-lazy-getobject.conf
+++ b/testdata/hocon/numeric-obj-array/na02-lazy-getobject.conf
@@ -1,0 +1,3 @@
+# S15.2: same source as na01 but asserts laziness — get/getObject return the object as-is,
+# no eager conversion at parse/resolve time. Conversion only fires from list-typed accessors.
+items = {"0":"a","1":"b"}

--- a/testdata/hocon/numeric-obj-array/na03a-concat-left-list.conf
+++ b/testdata/hocon/numeric-obj-array/na03a-concat-left-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (left-literal-array case).
+# Pairwise join (left=Array, right=Object) → numericObjectToArray(right) → array-array concat.
+# Expected: arr = ["a", "x", "y"].
+obj = {"0":"x","1":"y"}
+arr = [a] ${obj}

--- a/testdata/hocon/numeric-obj-array/na03b-concat-right-list.conf
+++ b/testdata/hocon/numeric-obj-array/na03b-concat-right-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (right-literal-array case, symmetric to na03a).
+# Pairwise join (left=Object, right=Array) → numericObjectToArray(left) → array-array concat.
+# Expected: arr = ["x", "y", "a"].
+obj = {"0":"x","1":"y"}
+arr = ${obj} [a]

--- a/testdata/hocon/numeric-obj-array/na03c-concat-two-objs.conf
+++ b/testdata/hocon/numeric-obj-array/na03c-concat-two-objs.conf
@@ -1,0 +1,6 @@
+# Spec §"Two-object concat is NOT array-converted": both sides Object → S10.3 object merge,
+# no concat-time conversion. Subsequent getList on `arr` would trigger accessor-side conversion.
+# Expected resolved tree: arr = {"0":"x","1":"y","2":"z","3":"w"}.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2}

--- a/testdata/hocon/numeric-obj-array/na03d-concat-multi-piece.conf
+++ b/testdata/hocon/numeric-obj-array/na03d-concat-multi-piece.conf
@@ -1,0 +1,7 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)".
+# Fold order: join(obj1, obj2) → object-merge {0:x,1:y,2:z,3:w}; join(merged, [a]) →
+# numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["x", "y", "z", "w", "a"].
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2} [a]

--- a/testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf
+++ b/testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf
@@ -1,0 +1,14 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)" — overlapping-keys variant.
+# Pairwise fold: join(obj1, obj2) → object-merge per S10.3 → {0:z, 1:y} (later "0" wins).
+# Then join(merged, [a]) → numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["z", "y", "a"].
+#
+# This fixture distinguishes a true left-to-right pairwise fold from a single-pass loop that
+# converts each Object element independently. The disjoint-keys fixture (na03d) cannot detect
+# the divergence — both algorithms produce the same answer when keys do not overlap.
+#
+# Multi-reviewer code review (2026-05-16) caught all 3 impls (ts/rs/go) initially shipping
+# the single-pass loop variant; this fixture is the regression guard added in followup.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"0":"z"}
+arr = ${obj1} ${obj2} [a]

--- a/testdata/hocon/numeric-obj-array/na04-empty.conf
+++ b/testdata/hocon/numeric-obj-array/na04-empty.conf
@@ -1,0 +1,3 @@
+# S15.4: empty object explicitly NOT converted, even when array is requested.
+# Impl test: getList("items") raises a type-mismatch error.
+items = {}

--- a/testdata/hocon/numeric-obj-array/na05-non-int-keys.conf
+++ b/testdata/hocon/numeric-obj-array/na05-non-int-keys.conf
@@ -1,0 +1,3 @@
+# S15.5: non-integer keys ignored during conversion. Eligible keys: "0", "1".
+# Impl test: getList("items") returns ["a", "c"] (not "b").
+items = {"0":"a","foo":"b","1":"c"}

--- a/testdata/hocon/numeric-obj-array/na06-gaps.conf
+++ b/testdata/hocon/numeric-obj-array/na06-gaps.conf
@@ -1,0 +1,3 @@
+# S15.6: missing indices compacted in resulting array (gap between "0" and "2").
+# Impl test: getList("items") returns ["a", "c"] (no undefined slot for index 1).
+items = {"0":"a","2":"c"}

--- a/testdata/hocon/numeric-obj-array/na07-sort.conf
+++ b/testdata/hocon/numeric-obj-array/na07-sort.conf
@@ -1,0 +1,3 @@
+# S15.7: result sorted by integer key value, regardless of declaration order.
+# Impl test: getList("items") returns ["a", "b"].
+items = {"1":"b","0":"a"}

--- a/testdata/hocon/numeric-obj-array/na08-leading-zero.conf
+++ b/testdata/hocon/numeric-obj-array/na08-leading-zero.conf
@@ -1,0 +1,5 @@
+# E2 (extra-spec): leading zeros rejected. "00" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision (both "00" and "0" parse to 0); winning value depends
+# on iteration order — non-deterministic. Documented in expected/.../na08-leading-zero.divergence.md.
+items = {"00":"a","0":"b"}

--- a/testdata/hocon/numeric-obj-array/na09-negative.conf
+++ b/testdata/hocon/numeric-obj-array/na09-negative.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule": negative integers ineligible (Lightbend-aligned).
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"-1":"a","0":"b"}

--- a/testdata/hocon/numeric-obj-array/na10a-plus-sign.conf
+++ b/testdata/hocon/numeric-obj-array/na10a-plus-sign.conf
@@ -1,0 +1,4 @@
+# E3 (extra-spec): leading + rejected. "+1" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: accepts "+1" as 1; result ["b","a"]. Documented in expected/.../na10a-plus-sign.divergence.md.
+items = {"+1":"a","0":"b"}

--- a/testdata/hocon/numeric-obj-array/na10b-minus-zero.conf
+++ b/testdata/hocon/numeric-obj-array/na10b-minus-zero.conf
@@ -1,0 +1,5 @@
+# E4 (extra-spec): leading sign char on zero rejected. "-0" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision ("-0" and "0" both parse to 0); non-deterministic
+# winner. Documented in expected/.../na10b-minus-zero.divergence.md.
+items = {"-0":"a","0":"b"}

--- a/testdata/hocon/numeric-obj-array/na11-overflow.conf
+++ b/testdata/hocon/numeric-obj-array/na11-overflow.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule" range: "99999999999" exceeds i32 range, rejected.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"99999999999":"a","0":"b"}

--- a/testdata/hocon/numeric-obj-array/na12-no-eligible.conf
+++ b/testdata/hocon/numeric-obj-array/na12-no-eligible.conf
@@ -1,0 +1,3 @@
+# No keys parse as non-negative integers → numericObjectToArray returns None.
+# Impl test: getList("items") raises a type-mismatch error (no conversion possible).
+items = {"foo":"a","bar":"b"}


### PR DESCRIPTION
## Summary

Implements S15 numerically-indexed object → array conversion in go.hocon (Phase 6 #2 of cross-impl HOCON spec compliance work). Closes #71.

- New helper `numericObjectToArray` at `internal/resolver/numeric_array.go` with canonical-text-strict pre-filter regex `^(0|[1-9][0-9]*)$` (rejects `+1`/`-0`/`00` per [extra-spec E2/E3/E4](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md)). Exported via `NumericObjectToArray` shim for the parent `hocon` package — module-private via `internal/`.
- `Config.getArray` (via `lookupArray`) invokes the helper before the panic path; all `Get*Slice` and `Get*SliceOption` accessors benefit. `GetConfig`/`GetConfigOption` stay lazy.
- Resolver concat refactored to true left-to-right **pairwise fold** via new `joinPair` helper. Old `concatArraysPermissive` / `concatObjects` dead code removed.
- 16 + 1 (na03e) xx.hocon fixtures synced; Phase-4 `_Pin` tests deleted, `t.Skipf` removed.

Spec rows flipped: S15.1, S15.2, S15.3, S15.4, S15.5, S15.6, S15.7 → ✅.

## Multi-agent review history

Local `/multi-agent-review` ran on the initial implementation (commit `ce9d463`). Codex + Claude (general-purpose Opus) both caught a critical bug: the initial single-pass loop in `concatArraysPermissive` produced wrong results for overlapping numeric keys. Fix commit `23be8b4` refactors to pairwise fold per the spec NORMATIVE rule. New xx.hocon fixture `na03e-multi-piece-overlap.conf` (xx.hocon#11) pins Lightbend ground truth `["z","y","a"]` and is verified GREEN here.

## Test plan

- [x] `go test ./...`: all pass across `github.com/o3co/go.hocon`, `internal/lexer`, `internal/parser`, `internal/properties`, `internal/resolver`
- [x] na03e (`${obj1} ${obj2} [a]` with overlapping numeric keys) → `["z","y","a"]` confirmed
- [x] na03d (disjoint keys) still passes
- [x] Phase-4 `_Pin` tests removed; spec-form tests un-`Skipf`'d
- [x] Panic semantics for genuine type mismatches unchanged
- [ ] In-flight Phase-2 sibling PRs in ts.hocon and rs.hocon converge on the same xx.hocon ground truth

## Notable design

The pairwise fold replaces the previous classify-then-bulk-dispatch in `resolveConcat`. Two-phase entry: if no Arrays/Objects involved → pass full slice (with separators) to `concatStrings` for `"foo bar 42"` style concat with inter-token spaces; otherwise → strip separators and fold via `joinPair`. The `joinPair` switch covers Obj+Obj (merge), Arr+Obj / Obj+Arr (S15 conversion or permissive insert), Arr+Arr (concat), Arr+Scalar / Scalar+Arr (permissive insert), Scalar+Scalar (string concat).

## Related

- Phase 6 #2 cluster (cross-impl)
- Sibling PRs: ts.hocon#TBD, rs.hocon#TBD
- xx.hocon ground truth: o3co/xx.hocon#10 (16 fixtures + E2/E3/E4) and o3co/xx.hocon#11 (na03e overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)