### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-18
+
 ### Changed
 
 - **BREAKING (S8.6)**: `a = -foo`, `a = -bar`, `a = -` and other `-`-not-followed-by-digit inputs are now lex errors. Per HOCON.md L270–276, a leading `-` must begin a number literal (i.e. be followed by a digit). Previously these were silently accepted (`-foo` tokenized as `TokenInt("-") + TokenString("foo")` and then value-coerced). The same rule is applied per-segment in `parseKey` after dot-split, so `a.-foo = 1` is now rejected. `readNumber` now implements **greedy-with-backtrack** per the HOCON.md number grammar (fractional/exponent productions backtrack to the last valid number end), so `1ex`/`1.x`/`0xff` etc. emit `TokenInt(1)` followed by `TokenString("ex")`/`TokenString(".x")`/`TokenString("xff")` respectively (the value-concat result matches Lightbend's output). Mitigation for the breaking case: quote the value (`a = "-foo"`). Note: this is intentionally stricter than Lightbend's reference implementation, which falls back to unquoted on number-parse failure. Digit-leading inputs that resolve to strings via value-concat are unaffected. See `docs/spec-compliance.md` §S8.6 for the remaining gaps tracked under #60 (digit-leading strict rejection: us13 `01`, us15 `1e+x`). The parser numeric-key support for us08 and us09 is delivered separately in the Fixed section below (#81-followup).


### PR DESCRIPTION
## Summary

go.hocon v1.2.0 release. One BREAKING change + parser numeric-key support + new substitution body tokenization.

## BREAKING changes

- **S8.6** — `a = -foo` / `a = -bar` / `a = -` no-digit hyphen rejected at lex time via greedy-with-backtrack `readNumber`; same rule per-segment in `parseKey` (so `a.-foo = 1` also rejected). Mitigation: quote (`a = "-foo"`).

## Highlights

- **Parser numeric-key support (#81-followup, also closes #62 / #77)**: TokenFloat as key start, TokenInt/Float + adjacent unquoted/keyword concat, gated to prevent quoted-key re-split. Unblocks `123abc = 1`, `3.14 = "v"`, `1.2.3 = x`, `10.0foo = x`, `123true = 1` cases
- Substitution body tokenization via `parseSubstBody`; `readQuotedStringBody` extracted as shared helper for top-level + substitution quoted strings
- Surrogate codepoints (`\uD800`–`\uDFFF`) in `\uXXXX` escapes rejected, matching rs.hocon
- `\b` (backspace) and `\f` (form-feed) escape sequences in top-level quoted strings now supported
- Cross-impl compliance: 86.1% in-scope (S6.1/6.2/6.4 + S15.1–S15.7 + S8.6 partial + S11.3/S11.4 cleared in Phase 6 #1/#2/#3c/#3c-followup)

## Note on Go module versioning

This release stays at `v1.x` (no `/v2` import-path rename). The S8.6 strictness is a behavior change but the exported Go API is unchanged. Consumers update by re-running `go get -u github.com/o3co/go.hocon` — no code changes required (other than the BREAKING input handling).

## Test plan

- [x] All Phase 6 #1/#2/#3c/#3c-followup PRs merged to develop and passed CI individually
- [x] Tag-triggered Go module proxy fetch (`.github/workflows/release.yml`) will run on `v1.2.0` tag push to seed the proxy index

🤖 Generated with [Claude Code](https://claude.com/claude-code)