### PR TITLE
docs(s21.5): flip status to ✅ — side-cleared by Phase 6 #3d

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -874,8 +874,7 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 
 - **S21.5** Fractional values supported (`0.5M`) — §Units format (L1281-1294) + §Size in bytes (L1335-1342)
   tests: config_test.go (TestSpec_S21_5_FractionalByteValues)
-  status: ❌
-  note: parseBytes uses strconv.ParseInt which rejects fractional values; see issue #74.
+  status: ✅ — side-cleared in Phase 6 #3d. `parseBytes` rewritten to truncate AFTER multiply (`int64(f * float64(mult))`) per Lightbend `BigDecimal.toBigInteger()`; multi-letter units (KB/KiB/MB/MiB/...) now accept fractional values. Single-letter byte abbreviations (`0.5K`, `1.5M`) remain blocked by S21.4 (#73). Closes #74.
 
 ## S22. Config object merging API
 


### PR DESCRIPTION
## Summary

S21.5 (fractional byte values like `0.5MB`) was side-cleared by [#89](https://github.com/o3co/go.hocon/pull/89) (Phase 6 #3d). The new `parseBytes` rewrite truncates AFTER multiply (`int64(f * float64(mult))`) per Lightbend `BigDecimal.toBigInteger()`. `TestSpec_S21_5_FractionalByteValues` was un-skipped in that PR but `docs/spec-compliance.md` status field wasn't flipped. This catches up the doc.

Single-letter byte abbreviations (`0.5K`, `1.5M`) remain blocked by S21.4 ([#73](https://github.com/o3co/go.hocon/issues/73)) — separate scope.

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)