### PR TITLE
refactor(s23.4): remove unreachable leaf-existing-object guard

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1172,18 +1172,17 @@ func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, er
 }
 
 // propsToObjectVal converts a flat map[string]string (from a .properties file)
-// into a nested *ObjectVal applying the HOCON.md L1485 "object wins" rule:
-//
-//   - Non-leaf segment + existing scalar: replace the scalar with a new object
-//     and descend (the string is discarded per L1487 "object wins throws out
-//     at most one value, the string").
-//   - Leaf segment + existing object: skip — do not overwrite the object with
-//     the scalar (the object wins).
-//   - All other cases: normal insertion or descent.
+// into a nested *ObjectVal applying the HOCON.md L1485 "object wins" rule.
 //
 // Keys are processed in sorted order (sort.Strings) so conflict resolution is
 // deterministic regardless of the input line order in the .properties file
-// (per HOCON.md L1476–1479: Java properties do not preserve file order).
+// (per HOCON.md L1476–1479: Java properties do not preserve file order). The
+// sort guarantees parent paths (e.g. "a") are processed before child paths
+// (e.g. "a.b"), so the only conflict shape that surfaces at iteration time is
+// non-leaf-meets-existing-scalar — handled by replacing the scalar with a new
+// object and descending (the string is discarded per L1487 "object wins throws
+// out at most one value, the string"). The reverse case (leaf scalar meets
+// existing object) cannot occur under this ordering.
 func propsToObjectVal(props map[string]string) *ObjectVal {
 	keys := make([]string, 0, len(props))
 	for k := range props {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1197,18 +1197,15 @@ func propsToObjectVal(props map[string]string) *ObjectVal {
 		parts := strings.Split(key, ".")
 		cur := root
 		for i, part := range parts {
-			isLeaf := i == len(parts)-1
-			existing, has := cur.values[part]
-			if isLeaf {
-				// Object wins: if an object already occupies this slot, skip
-				// the scalar — do not overwrite (HOCON.md L1485).
-				if _, isObj := existing.(*ObjectVal); has && isObj {
-					break
-				}
+			if i == len(parts)-1 {
+				// Leaf: sort.Strings above guarantees parent paths process
+				// before child paths, so an existing object at this slot
+				// cannot occur — object-wins (HOCON.md L1485) is enforced
+				// by the non-leaf scalar-replace branch below.
 				cur.set(part, &ScalarVal{Raw: value, Type: ScalarString})
 				break
 			}
-			// Non-leaf segment:
+			existing, has := cur.values[part]
 			if !has {
 				child := newObjectVal()
 				cur.set(part, child)


### PR DESCRIPTION
## Summary

- Remove dead defensive `if has && isObj { break }` branch at `propsToObjectVal` leaf step
- Unreachable given `sort.Strings(keys)` lex-order guarantee (parent paths always process before child paths)
- Object-wins (HOCON.md L1485/L1487) remains enforced by the non-leaf scalar-replace branch

## Context

Surfaced via Phase 6 #3h test-case audit. The codecov/patch report (97% in diff range) flagged this one block as the sole uncovered location within cluster 3h's source changes. Analysis confirmed it is structurally unreachable, not an intent gap.

`sort.Strings` orders keys lexicographically. For any pair `("a", "a.b")`, `"a"` < `"a.b"` (shorter prefix first), so the leaf `a` is always set before the non-leaf step of `a.b` encounters it — the conflict surfaces in the non-leaf branch (lines 1218-1227) which already discards the scalar and descends.

## Test plan

- [x] `go test -count=1 ./...` — all packages pass on the refactor branch
- [x] `golangci-lint run ./...` — 0 issues
- [x] Existing S23.4 fixtures pc01-pc04 + inline forward/reverse/deep continue to pin object-wins semantics (no test changes required — the removed branch was dead)
- [ ] CI green across all 6 OS × Go-version matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)