### PR TITLE
test(audit): 7 intent tests for cluster 3e/3d/3g error paths

### DIFF
--- a/bytes_error_test.go
+++ b/bytes_error_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Bytes accessor error paths. Asserts that:
+//   - GetBytes panics with "invalid byte size" (wrapped in *ConfigError) when
+//     the value cannot be parsed as a byte size (e.g. "not-a-size"). Mirrors
+//     Lightbend's ConfigException for non-parseable size strings.
+//   - GetBytesOption returns None for unknown unit suffix (e.g. "10KX"),
+//     reflecting parseBytes's "unknown byte unit" error path.
+
+package hocon_test
+
+import (
+	"strings"
+	"testing"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+func TestGetBytes_InvalidString_Panics(t *testing.T) {
+	cfg, err := hocon.ParseString(`v = "not-a-size"`)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("GetBytes(\"v\"): expected panic for non-parseable byte size, got none")
+		}
+		ce, ok := r.(*hocon.ConfigError)
+		if !ok {
+			t.Fatalf("panic value type = %T, want *hocon.ConfigError", r)
+		}
+		if !strings.Contains(ce.Message, "invalid byte size") {
+			t.Errorf("panic message = %q; want substring %q", ce.Message, "invalid byte size")
+		}
+	}()
+	_ = cfg.GetBytes("v")
+}
+
+func TestGetBytesOption_UnknownUnit_ReturnsNone(t *testing.T) {
+	cfg, err := hocon.ParseString(`v = "10KX"`)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	opt := cfg.GetBytesOption("v")
+	if opt.IsSome() {
+		got, _ := opt.Get()
+		t.Errorf("GetBytesOption(\"v\") on unknown unit %q: expected None, got %d", "10KX", got)
+	}
+}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -283,6 +283,46 @@ func TestUnterminatedSubstitution(t *testing.T) {
 	}
 }
 
+// TestSubstListSuffix_EOFErrors covers the two EOF-truncation paths inside a
+// substitution that uses the `[]` list-suffix grammar. Both are TokenError
+// branches inside the substitution lexer; the existing list-suffix table
+// covers `}`-truncated forms but not bare EOF, so these spec-aligned message
+// assertions pin the specific branches.
+func TestSubstListSuffix_EOFErrors(t *testing.T) {
+	cases := []struct {
+		name        string
+		src         string
+		wantMsgSub  string
+		wantTokType lexer.TokenType
+	}{
+		{
+			name:        "eof-after-open-bracket",
+			src:         "${X[",
+			wantMsgSub:  "expected ']' after '['",
+			wantTokType: lexer.TokenError,
+		},
+		{
+			name:        "eof-after-empty-suffix",
+			src:         "${X[]",
+			wantMsgSub:  "unterminated substitution after '[]' suffix",
+			wantTokType: lexer.TokenError,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			l := lexer.New(tc.src)
+			tok := l.Next()
+			if tok.Type != tc.wantTokType {
+				t.Fatalf("src=%q: token type = %v, want %v (value=%q)", tc.src, tok.Type, tc.wantTokType, tok.Value)
+			}
+			if !strings.Contains(tok.Value, tc.wantMsgSub) {
+				t.Errorf("src=%q: error message = %q; want substring %q", tc.src, tok.Value, tc.wantMsgSub)
+			}
+		})
+	}
+}
+
 func TestUnterminatedTripleQuotedString(t *testing.T) {
 	tests := []string{
 		`a = """unterminated`,

--- a/internal/parser/include_file_error_test.go
+++ b/internal/parser/include_file_error_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package parser_test — include directive argument-shape error paths.
+// These assert spec-aligned rejection for malformed `include file(...)` and
+// `include required(...)` forms whose error messages were uncovered before
+// this file existed. Each test pins a single spec-driven error condition.
+
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/o3co/go.hocon/internal/parser"
+)
+
+// TestIncludeFile_NonStringArgument asserts that `include file(...)` with a
+// non-string argument (e.g. an integer literal or an empty arg list) raises a
+// parse error pointing to "filename string" — per the include grammar where
+// the file(...) form requires a quoted-string filename.
+func TestIncludeFile_NonStringArgument(t *testing.T) {
+	cases := []struct {
+		label string
+		src   string
+	}{
+		{"integer-literal", `include file(42)`},
+		{"empty-arg", `include file()`},
+		{"brace-arg", `include file({a:1})`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			_, err := parser.Parse(tc.src)
+			if err == nil {
+				t.Fatalf("Parse(%q): expected error, got nil", tc.src)
+			}
+			if !strings.Contains(err.Error(), "filename string") {
+				t.Errorf("Parse(%q) error = %q; want substring %q", tc.src, err.Error(), "filename string")
+			}
+		})
+	}
+}
+
+// TestIncludeFile_MissingClosingParen asserts that `include file("foo"` with
+// no closing `)` raises a parse error pointing to "')' after filename".
+func TestIncludeFile_MissingClosingParen(t *testing.T) {
+	src := `include file("foo"`
+	_, err := parser.Parse(src)
+	if err == nil {
+		t.Fatalf("Parse(%q): expected error, got nil", src)
+	}
+	if !strings.Contains(err.Error(), "')' after filename") {
+		t.Errorf("Parse(%q) error = %q; want substring %q", src, err.Error(), "')' after filename")
+	}
+}
+
+// TestIncludeRequired_MissingOuterClosingParen asserts that
+// `include required(file("foo")` (inner `)` for file present, outer `)` for
+// required missing) raises a parse error pointing to "')' to close required".
+func TestIncludeRequired_MissingOuterClosingParen(t *testing.T) {
+	src := `include required(file("foo")`
+	_, err := parser.Parse(src)
+	if err == nil {
+		t.Fatalf("Parse(%q): expected error, got nil", src)
+	}
+	if !strings.Contains(err.Error(), "')' to close required") {
+		t.Errorf("Parse(%q) error = %q; want substring %q", src, err.Error(), "')' to close required")
+	}
+}


### PR DESCRIPTION
## Summary

- Add 7 intent tests covering previously-untested spec-driven error paths surfaced by the Phase 6 #3h test-case audit (follow-up to #94)
- Each test asserts a *spec violation is rejected* — not coverage-chasing
- Brings 7 previously-uncovered blocks (codecov/patch range from PR #94 audit) to covered: parser.go:202/207/231, config.go:411-413/510-512, lexer.go:429-432/512-514

## Tests added

### Cluster 3e (S12.5 / S14a — `internal/parser/include_file_error_test.go`)

- `TestIncludeFile_NonStringArgument` — `include file(42)` / `include file()` / `include file({a:1})` reject with "filename string" message
- `TestIncludeFile_MissingClosingParen` — `include file("foo"` (EOF) rejects with "')' after filename"
- `TestIncludeRequired_MissingOuterClosingParen` — `include required(file("foo")` rejects with "')' to close required"

### Cluster 3d (S18.4 / S21.4 — `bytes_error_test.go`)

- `TestGetBytes_InvalidString_Panics` — `GetBytes("v")` on non-parseable size panics with `*ConfigError` ("invalid byte size")
- `TestGetBytesOption_UnknownUnit_ReturnsNone` — `GetBytesOption("v")` on unknown unit suffix (`"10KX"`) returns None

### Cluster 3g (S13c — `internal/lexer/lexer_test.go`)

- `TestSubstListSuffix_EOFErrors` — `${X[` (EOF after `[`) and `${X[]` (EOF after `]`) emit `TokenError` with EOF-specific messages

## Deliberately not covered (audit principle)

- Defensive `strconv.ParseInt` error after regex pre-check (overflow-only triggers; shallow test would lock in implementation, not contract)
- Empty-segment skip in parser numeric-key concat
- Include-scope `${X[]}` fallback at resolver.go:626 — tracked in [xx.hocon#22](https://github.com/o3co/xx.hocon/issues/22)

## Review

Multi-agent-review (Claude + Codex) — both PASS, no Critical/Important findings. 3 Minor cosmetic suggestions (err discard in diagnostic, function name precision, empty-string follow-up) left as non-blocking — can address in a follow-up if anyone cares.

## Test plan

- [x] `go test -count=1 ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Coverage verified: all 7 previously-uncovered blocks now have count>0 in coverprofile
- [ ] CI green across all 6 OS × Go-version matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)