### PR TITLE
docs: fix codecov badge URL (main → develop)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/o3co/go.hocon)](https://goreportcard.com/report/github.com/o3co/go.hocon)
 [![CI](https://github.com/o3co/go.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/go.hocon/actions/workflows/test.yml)
 [![Lint](https://github.com/o3co/go.hocon/actions/workflows/lint.yml/badge.svg)](https://github.com/o3co/go.hocon/actions/workflows/lint.yml)
-[![codecov](https://codecov.io/gh/o3co/go.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
+[![codecov](https://codecov.io/gh/o3co/go.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 仕様の Go パーサー。現在の準拠率は [仕様準拠](#仕様準拠) を参照。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/o3co/go.hocon)](https://goreportcard.com/report/github.com/o3co/go.hocon)
 [![CI](https://github.com/o3co/go.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/go.hocon/actions/workflows/test.yml)
 [![Lint](https://github.com/o3co/go.hocon/actions/workflows/lint.yml/badge.svg)](https://github.com/o3co/go.hocon/actions/workflows/lint.yml)
-[![codecov](https://codecov.io/gh/o3co/go.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
+[![codecov](https://codecov.io/gh/o3co/go.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/go.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 A [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) parser for Go. See [Spec Compliance](#spec-compliance) for the current conformance rate.


### PR DESCRIPTION
## Summary

- README.md + README.ja.md の codecov badge URL を `branch/main` から `branch/develop` に修正
- このリポは default branch が `develop` で、`main` branch は存在しない

## Why

`https://codecov.io/gh/o3co/go.hocon/branch/main/graph/badge.svg` を fetch すると codecov は存在しない branch を resolve できず badge が **"unknown"** を返していた。

`branch/develop` に修正後、empirically 86% (実際の develop coverage = 86.49%) を返すことを確認済。

## Cross-repo

同じ修正を [ts.hocon](https://github.com/o3co/ts.hocon) と [rs.hocon](https://github.com/o3co/rs.hocon) にも並列 PR で適用。

## Test plan

- [x] curl で新 URL が正しい値を返すことを確認
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)