### PR TITLE
feat(e12): deferred substitution resolution — closes #99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cycle detection: length-prefixed `"package:N:id:file"` cycle key integrated with existing include-cycle detection.
   - `include required(package(...))` — registry miss is unconditional hard error regardless of `Required` flag state (per E11 decision 7).
 
+## [1.4.0] - 2026-05-21
+
+### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/go.hocon/issues/99))
+
+This release adds the Lightbend-aligned `parse → withFallback → resolve()`
+lifecycle requested by [@cgordon in #99](https://github.com/o3co/go.hocon/issues/99).
+Existing `ParseString` / `ParseFile` behaviour is unchanged (still
+parse-and-resolve in one call); the new API surface is purely additive.
+
+**New entry points:**
+
+- `ParseStringWithOptions(input, opts ParseOptions)` and
+  `ParseFileWithOptions(path, opts ParseOptions)` — `opts.ResolveSubstitutions()=false`
+  produces an unresolved `Config` whose `IsResolved()` is `false` when the input
+  contains any `${...}`.
+- `FromMap(values map[string]any, originDescription string)` — construct a
+  Config from an in-memory map.  Lightbend `ConfigValueFactory.fromMap`
+  parallel.
+- `Empty(originDescription string)` — empty Config.
+
+**New methods on `*Config`:**
+
+- `Resolve(opts ResolveOptions) (*Config, error)` — single top-level resolve
+  over the entire merged fallback stack.  Idempotent on already-resolved
+  configs.
+- `ResolveWith(source *Config, opts ResolveOptions) (*Config, error)` —
+  resolves receiver using source for substitution lookup; source's keys are
+  NOT merged into the result.  Precondition: source must be resolved
+  (otherwise returns `ErrNotResolved`).
+- `IsResolved() bool` — reports whole-config resolution state.
+- `WithFallback(other *Config) *Config` — now accepts unresolved operands;
+  preserves substitution placeholders into the merged tree.  Receiver-wins
+  semantics unchanged.  Result is resolved iff both inputs are resolved.
+
+**New types:**
+
+- `ParseOptions` — builder via `DefaultParseOptions().WithResolveSubstitutions(...)`
+  and `.WithOriginDescription(...)`.  `ParseOptions{}` zero-value literal is
+  NOT a valid invocation (documented).
+- `ResolveOptions` — builder via `DefaultResolveOptions().WithUseSystemEnvironment(...)`
+  and `.WithAllowUnresolved(...)`.
+
+**New errors:**
+
+- `ErrNotResolved` sentinel.  Getters on unresolved paths panic with
+  `*ConfigError` whose `Unwrap()` returns `ErrNotResolved` — use
+  `errors.Is(err, hocon.ErrNotResolved)`.
+
+**Cross-spec amendments (no behavioural changes for callers using the existing
+fused `ParseString`; only relevant when using the deferred-resolution lifecycle):**
+
+- S13a × WithFallback: self-reference lookback walks across fallback
+  layers.  Receiver `a = ${?a} extra` with fallback `a = base` resolves
+  to `a = "base extra"`.
+- S10 × AllowUnresolved: type-incompatible concat errors fire even under
+  `AllowUnresolved=true`; only missing-value errors are deferred.
+- Hidden substitutions in overridden values are not evaluated (HOCON.md
+  §Substitutions L670-703 already-specified behaviour, now explicitly
+  pinned for the deferred lifecycle).
+
+### Fixed
+
+- S13.15 multi-optional-undef concat materialisation: `a = ${?x}${?y}` with
+  both `x` and `y` undefined now correctly omits the field (was producing
+  `{"a":""}` empty string).  Per HOCON.md L640.  Bundled with E12 since
+  the dr28 fixture surfaced the spec divergence.
+
+**Spec source:** [xx.hocon#37](https://github.com/o3co/xx.hocon/issues/37) /
+E12 in `docs/extra-spec-conventions.md`.
+
 ## [1.3.1] - 2026-05-21
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ testdata:
 	  mkdir -p testdata/hocon/unquoted-parens && \
 	  cp "$$tmpdir/testdata/hocon/unquoted-parens/"*.conf testdata/hocon/unquoted-parens/ 2>/dev/null || true; \
 	fi && \
+	if [ -d "$$tmpdir/testdata/hocon/deferred-resolution" ]; then \
+	  mkdir -p testdata/hocon/deferred-resolution && \
+	  cp "$$tmpdir/testdata/hocon/deferred-resolution/"*.yaml testdata/hocon/deferred-resolution/ 2>/dev/null || true; \
+	  cp "$$tmpdir/testdata/hocon/deferred-resolution/README.md" testdata/hocon/deferred-resolution/ 2>/dev/null || true; \
+	fi && \
 	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ On top of that, HOCON combines the readability of YAML with the structure of JSO
 - Byte size parsing (`1KB`, `1KiB`, `1MB`, …)
 - Generic `Option[T]` for safe optional access
 - Struct unmarshalling with `hocon` struct tags
-- No external dependencies — standard library only
+- Deferred resolution: separate `Parse` / `WithFallback` / `Resolve` lifecycle for runtime-supplied substitution values (v1.4.0+)
+- `FromMap` / `Empty` value factories for in-memory fallback layers (v1.4.0+)
+- No external runtime dependencies — `gopkg.in/yaml.v3` used only in test code (fixture scenario runner)
 
 ## API
 
@@ -87,7 +89,40 @@ On top of that, HOCON combines the readability of YAML with the structure of JSO
 ```go
 hocon.ParseString(input string) (*Config, error)
 hocon.ParseFile(path string)    (*Config, error)
+
+// Deferred parse (v1.4.0+): returns an unresolved Config when the input
+// contains `${...}` and you want to layer fallback values via WithFallback
+// before resolving.
+hocon.ParseStringWithOptions(input string, opts hocon.ParseOptions) (*Config, error)
+hocon.ParseFileWithOptions(path string,    opts hocon.ParseOptions) (*Config, error)
+hocon.FromMap(values map[string]any, originDescription string)     (*Config, error)
+hocon.Empty(originDescription string)                              *Config
 ```
+
+#### Deferred resolution example (v1.4.0+)
+
+Use when a substitution references a value only available at runtime (e.g. CI
+build number) — see [#99](https://github.com/o3co/go.hocon/issues/99).
+
+```go
+cfg, _ := hocon.ParseStringWithOptions(
+    `version = ${shortversion}-${CI_RUN_NUMBER}
+     variables { shortversion = "1.2.3" }`,
+    hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+)
+runtime, _ := hocon.FromMap(map[string]any{"CI_RUN_NUMBER": "42"}, "")
+vars := cfg.GetConfig("variables")
+resolved, _ := cfg.
+    WithFallback(runtime).
+    WithFallback(vars).
+    Resolve(hocon.DefaultResolveOptions())
+fmt.Println(resolved.GetString("version")) // "1.2.3-42"
+```
+
+Use `ResolveOptions.WithUseSystemEnvironment(false)` for hermetic resolution
+(no `os.Environ` fallback) or `.WithAllowUnresolved(true)` for partial resolve
+(unresolved paths remain placeholders; getter on them returns
+`hocon.ErrNotResolved`).
 
 ### Scalar Getters
 
@@ -244,6 +279,8 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 | Struct unmarshal | ✅ | ❌ |
 | `Option[T]` safe access | ✅ | ❌ |
 | Env variable fallback | ✅ | ✅ |
+| Deferred resolution (parse / withFallback / resolve) | ✅ (v1.4.0) | ❌ |
+| `FromMap` / `Empty` value factories | ✅ (v1.4.0) | ❌ |
 
 ### Config Framework
 

--- a/config.go
+++ b/config.go
@@ -830,6 +830,45 @@ func (c *Config) GetConfigSliceOption(path string) Option[[]*Config] {
 
 // ── merge ─────────────────────────────────────────────────────────
 
+// Resolve performs substitution resolution over the value tree, producing a
+// fully resolved Config.  Per E12 § "Resolution":
+//   - On an already-resolved Config: returns an equivalent Config (idempotent
+//     no-op equivalent to Lightbend's documented behaviour).
+//   - On an unresolved Config: performs a single top-level resolve operation
+//     over the entire tree (including merged fallback layers), with transitive
+//     recursive substitution evaluation.
+//
+// opts.UseSystemEnvironment=false makes resolution hermetic (no os.Environ
+// lookup for substitutions not satisfied in-tree).
+// opts.AllowUnresolved=true leaves required-but-unsatisfied placeholders in
+// place; getter on those paths panics ErrNotResolved.
+func (c *Config) Resolve(opts ResolveOptions) (*Config, error) {
+	if c.IsResolved() {
+		// Idempotent: return a fresh wrapper (or the receiver) — both
+		// satisfy the spec.  Returning a copy avoids aliasing surprises.
+		return &Config{
+			root:              c.root,
+			resolved:          true,
+			parseBaseDir:      c.parseBaseDir,
+			originDescription: c.originDescription,
+		}, nil
+	}
+	res, err := resolver.ResolveTree(c.root, resolver.Options{
+		BaseDir:              c.parseBaseDir,
+		UseSystemEnvironment: opts.UseSystemEnvironment(),
+		AllowUnresolved:      opts.AllowUnresolved(),
+	})
+	if err != nil {
+		return nil, wrapResolveError(err)
+	}
+	return &Config{
+		root:              res.Root,
+		resolved:          !resolver.ContainsPlaceholders(res.Root),
+		parseBaseDir:      c.parseBaseDir,
+		originDescription: c.originDescription,
+	}, nil
+}
+
 // WithFallback returns a new Config that deep-merges receiver over fallback.
 // Neither receiver nor fallback is mutated. If fallback is nil, returns receiver.
 //

--- a/config.go
+++ b/config.go
@@ -85,7 +85,55 @@ func (c *Config) lookup(path string) (resolver.Val, bool) {
 		panicConfig(path, "empty path")
 	}
 	segments := splitPath(path)
-	return lookupSegments(c.root, segments)
+	v, ok := lookupSegments(c.root, segments)
+	if ok && isUnresolvedPlaceholder(v) {
+		panicNotResolved(path)
+	}
+	return v, ok
+}
+
+// lookupSoft is like lookup but returns (nil, false) for unresolved placeholders
+// instead of panicking.  Used by GetXxxOption getters which must not panic
+// on unresolved paths.
+func (c *Config) lookupSoft(path string) (resolver.Val, bool) {
+	if path == "" {
+		panicConfig(path, "empty path")
+	}
+	segments := splitPath(path)
+	v, ok := lookupSegments(c.root, segments)
+	if ok && isUnresolvedPlaceholder(v) {
+		return nil, false
+	}
+	return v, ok
+}
+
+// isUnresolvedPlaceholder reports whether v is (or directly contains) an
+// unresolved substitution / concat placeholder.  Used by lookup() to convert
+// getter access into an ErrNotResolved-wrapped panic.
+func isUnresolvedPlaceholder(v resolver.Val) bool {
+	if v == nil {
+		return false
+	}
+	switch vv := v.(type) {
+	case *resolver.ObjectVal:
+		return resolver.ContainsPlaceholders(vv)
+	default:
+		// Wrap as a single-key object to reuse the existing recursive walker.
+		// Synthetic key "$" is invisible to the caller.
+		wrap := resolver.NewObjectVal()
+		wrap.Set("$", vv)
+		return resolver.ContainsPlaceholders(wrap)
+	}
+}
+
+// panicNotResolved panics with a *ConfigError whose error chain includes
+// ErrNotResolved (for errors.Is matching).
+func panicNotResolved(path string) {
+	panic(&ConfigError{
+		Path:    path,
+		Message: "value is not resolved (call Resolve() first)",
+		cause:   ErrNotResolved,
+	})
 }
 
 func splitPath(path string) []string {
@@ -163,8 +211,14 @@ func (c *Config) IsResolved() bool {
 }
 
 // Has returns true if the path exists, including when the value is null.
+// Unresolved-but-present keys return true (the key exists, value just isn't
+// resolved yet).  Bypasses lookup() / lookupSoft() to avoid placeholder panic.
 func (c *Config) Has(path string) bool {
-	_, ok := c.lookup(path)
+	if path == "" {
+		return false
+	}
+	segments := splitPath(path)
+	_, ok := lookupSegments(c.root, segments)
 	return ok
 }
 
@@ -199,7 +253,7 @@ func (c *Config) GetString(path string) string {
 }
 
 func (c *Config) GetStringOption(path string) Option[string] {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return None[string]()
 	}
@@ -220,7 +274,7 @@ func (c *Config) GetInt64(path string) int64 {
 }
 
 func (c *Config) GetInt64Option(path string) Option[int64] {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return None[int64]()
 	}
@@ -254,7 +308,7 @@ func (c *Config) GetFloat64(path string) float64 {
 }
 
 func (c *Config) GetFloat64Option(path string) Option[float64] {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return None[float64]()
 	}
@@ -288,7 +342,7 @@ func (c *Config) GetBool(path string) bool {
 }
 
 func (c *Config) GetBoolOption(path string) Option[bool] {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return None[bool]()
 	}
@@ -581,7 +635,7 @@ func parseBytes(s string) (int64, error) {
 // (nil, false) when the path is missing or the value cannot be converted.
 // The caller must NOT call this when the path is expected to panic (use getArray).
 func (c *Config) lookupArray(path string) (*resolver.ArrayVal, bool) {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return nil, false
 	}
@@ -730,7 +784,7 @@ func (c *Config) GetConfig(path string) *Config {
 }
 
 func (c *Config) GetConfigOption(path string) Option[*Config] {
-	v, ok := c.lookup(path)
+	v, ok := c.lookupSoft(path)
 	if !ok {
 		return None[*Config]()
 	}

--- a/config.go
+++ b/config.go
@@ -49,15 +49,33 @@ func isHoconWS(r rune) bool {
 	return false
 }
 
-// Config wraps a resolved HOCON value tree.
+// Config wraps a HOCON value tree.  When resolved is true, the tree contains
+// no substitution/concat placeholders and all getters succeed (modulo
+// type-mismatch panics per existing semantics).  When resolved is false, the
+// tree contains placeholders for unresolved substitutions; getters on paths
+// touching a placeholder panic with ErrNotResolved.
 // All *Config values are safe for concurrent read access.
 type Config struct {
-	root *resolver.ObjectVal
+	root              *resolver.ObjectVal
+	resolved          bool
+	parseBaseDir      string // base directory for relative include re-runs (unused in v1)
+	originDescription string // E12 ParseOptions.OriginDescription
 }
 
-// newConfig wraps an ObjectVal.
+// newConfig wraps an ObjectVal as a fully resolved Config.
 func newConfig(obj *resolver.ObjectVal) *Config {
-	return &Config{root: obj}
+	return &Config{root: obj, resolved: true}
+}
+
+// newUnresolvedConfig wraps an ObjectVal that may contain placeholders.
+// Computes the resolved flag by checking the tree once.
+func newUnresolvedConfig(obj *resolver.ObjectVal, baseDir, originDescription string) *Config {
+	return &Config{
+		root:              obj,
+		resolved:          !resolver.ContainsPlaceholders(obj),
+		parseBaseDir:      baseDir,
+		originDescription: originDescription,
+	}
 }
 
 // ── path resolution ──────────────────────────────────────────────
@@ -131,6 +149,18 @@ func lookupSegments(obj *resolver.ObjectVal, segments []string) (resolver.Val, b
 }
 
 // ── Has / Keys ────────────────────────────────────────────────────
+
+// IsResolved reports whether the Config's value tree contains any unresolved
+// substitution placeholders.  Returns true if the tree is fully resolved.
+// Whole-config granularity (no per-value isResolved).  Matches Lightbend
+// Config.isResolved(). Per E12 decision 11.
+func (c *Config) IsResolved() bool {
+	if c.resolved {
+		return true
+	}
+	// re-check (defensive) in case priorValues mutation outpaced the flag.
+	return !resolver.ContainsPlaceholders(c.root)
+}
 
 // Has returns true if the path exists, including when the value is null.
 func (c *Config) Has(path string) bool {

--- a/config.go
+++ b/config.go
@@ -869,6 +869,63 @@ func (c *Config) Resolve(opts ResolveOptions) (*Config, error) {
 	}, nil
 }
 
+// ResolveWith resolves substitutions in c by looking them up in source.
+// Source's keys are NOT merged into the result — differs from
+// c.WithFallback(source).Resolve(opts) which DOES include source keys.
+//
+// Per E12 decision 10 (intentional Lightbend divergence): the source
+// argument MUST be resolved.  If source.IsResolved() is false, ResolveWith
+// returns ErrNotResolved BEFORE attempting to resolve the receiver.
+//
+// On an already-resolved receiver, ResolveWith is a no-op (returns an
+// equivalent Config) — matches the idempotency of Resolve.
+func (c *Config) ResolveWith(source *Config, opts ResolveOptions) (*Config, error) {
+	if source != nil && !source.IsResolved() {
+		return nil, fmt.Errorf("ResolveWith source: %w", ErrNotResolved)
+	}
+	if c.IsResolved() {
+		return &Config{
+			root:              c.root,
+			resolved:          true,
+			parseBaseDir:      c.parseBaseDir,
+			originDescription: c.originDescription,
+		}, nil
+	}
+	// Capture receiver's top-level key set before merging.
+	receiverKeys := make(map[string]struct{}, len(c.root.Keys()))
+	for _, k := range c.root.Keys() {
+		receiverKeys[k] = struct{}{}
+	}
+	// Merge source as fallback (lookup-only effect) then resolve.
+	var mergeWith *resolver.ObjectVal
+	if source != nil {
+		mergeWith = source.root
+	}
+	merged := resolver.MergeUnresolved(c.root, mergeWith)
+	res, err := resolver.ResolveTree(merged, resolver.Options{
+		BaseDir:              c.parseBaseDir,
+		UseSystemEnvironment: opts.UseSystemEnvironment(),
+		AllowUnresolved:      opts.AllowUnresolved(),
+	})
+	if err != nil {
+		return nil, wrapResolveError(err)
+	}
+	// Filter: keep only receiver's top-level keys.
+	filtered := resolver.NewObjectVal()
+	for _, k := range res.Root.Keys() {
+		if _, want := receiverKeys[k]; want {
+			v, _ := res.Root.Get(k)
+			filtered.Set(k, v)
+		}
+	}
+	return &Config{
+		root:              filtered,
+		resolved:          !resolver.ContainsPlaceholders(filtered),
+		parseBaseDir:      c.parseBaseDir,
+		originDescription: c.originDescription,
+	}, nil
+}
+
 // WithFallback returns a new Config that deep-merges receiver over fallback.
 // Neither receiver nor fallback is mutated. If fallback is nil, returns receiver.
 //

--- a/config.go
+++ b/config.go
@@ -844,6 +844,9 @@ func (c *Config) GetConfigSliceOption(path string) Option[[]*Config] {
 // opts.AllowUnresolved=true leaves required-but-unsatisfied placeholders in
 // place; getter on those paths panics ErrNotResolved.
 func (c *Config) Resolve(opts ResolveOptions) (*Config, error) {
+	if !opts.initialized {
+		opts = DefaultResolveOptions()
+	}
 	if c.IsResolved() {
 		// Idempotent: return a fresh wrapper (or the receiver) — both
 		// satisfy the spec.  Returning a copy avoids aliasing surprises.
@@ -919,6 +922,9 @@ func filterByReceiverShape(resolved, shape *resolver.ObjectVal) *resolver.Object
 // On an already-resolved receiver, ResolveWith is a no-op (returns an
 // equivalent Config) — matches the idempotency of Resolve.
 func (c *Config) ResolveWith(source *Config, opts ResolveOptions) (*Config, error) {
+	if !opts.initialized {
+		opts = DefaultResolveOptions()
+	}
 	if source != nil && !source.IsResolved() {
 		return nil, fmt.Errorf("ResolveWith source: %w", ErrNotResolved)
 	}

--- a/config.go
+++ b/config.go
@@ -87,7 +87,7 @@ func (c *Config) lookup(path string) (resolver.Val, bool) {
 	}
 	segments := splitPath(path)
 	v, ok := lookupSegments(c.root, segments)
-	if ok && isUnresolvedPlaceholder(v) {
+	if !c.resolved && ok && isUnresolvedPlaceholder(v) {
 		panicNotResolved(path)
 	}
 	return v, ok
@@ -102,7 +102,7 @@ func (c *Config) lookupSoft(path string) (resolver.Val, bool) {
 	}
 	segments := splitPath(path)
 	v, ok := lookupSegments(c.root, segments)
-	if ok && isUnresolvedPlaceholder(v) {
+	if !c.resolved && ok && isUnresolvedPlaceholder(v) {
 		return nil, false
 	}
 	return v, ok
@@ -860,7 +860,11 @@ func (c *Config) Resolve(opts ResolveOptions) (*Config, error) {
 		AllowUnresolved:      opts.AllowUnresolved(),
 	})
 	if err != nil {
-		return nil, wrapResolveError(err)
+		wrapped := wrapResolveError(err)
+		if re, ok := wrapped.(*ResolveError); ok && re.FilePath == "" {
+			re.OriginDescription = c.originDescription
+		}
+		return nil, wrapped
 	}
 	return &Config{
 		root:              res.Root,
@@ -868,6 +872,40 @@ func (c *Config) Resolve(opts ResolveOptions) (*Config, error) {
 		parseBaseDir:      c.parseBaseDir,
 		originDescription: c.originDescription,
 	}, nil
+}
+
+// filterByReceiverShape walks `resolved` and keeps only keys/paths that
+// existed in `shape` (the receiver's pre-merge tree).  At any node where
+// `shape` had a scalar/array (non-object), the resolved value at that path
+// is kept verbatim (the substitution resolved against source's lookup
+// context, but the path "belonged to" the receiver).  Where `shape` had
+// an object, recurse: keep only keys present in shape's object.
+func filterByReceiverShape(resolved, shape *resolver.ObjectVal) *resolver.ObjectVal {
+	out := resolver.NewObjectVal()
+	if shape == nil {
+		return out
+	}
+	for _, k := range shape.Keys() {
+		rv, has := resolved.Get(k)
+		if !has {
+			continue
+		}
+		shapeVal, _ := shape.Get(k)
+		// If shape had an object, recurse into the resolved object (if it is one).
+		if shapeObj, shapeIsObj := shapeVal.(*resolver.ObjectVal); shapeIsObj {
+			if resolvedObj, resOk := rv.(*resolver.ObjectVal); resOk {
+				out.Set(k, filterByReceiverShape(resolvedObj, shapeObj))
+				continue
+			}
+			// Shape was object, resolved is non-object — composition barrier
+			// replaced receiver's object with source's scalar.  Take resolved
+			// verbatim (receiver's type lost at merge, source's value kept).
+		}
+		// Shape was non-object (scalar/array/placeholder) → keep the resolved
+		// value at this path verbatim.
+		out.Set(k, rv)
+	}
+	return out
 }
 
 // ResolveWith resolves substitutions in c by looking them up in source.
@@ -892,11 +930,8 @@ func (c *Config) ResolveWith(source *Config, opts ResolveOptions) (*Config, erro
 			originDescription: c.originDescription,
 		}, nil
 	}
-	// Capture receiver's top-level key set before merging.
-	receiverKeys := make(map[string]struct{}, len(c.root.Keys()))
-	for _, k := range c.root.Keys() {
-		receiverKeys[k] = struct{}{}
-	}
+	// Capture receiver's shape (the pre-merge tree) for recursive filtering.
+	shape := c.root
 	// Merge source as fallback (lookup-only effect) then resolve.
 	var mergeWith *resolver.ObjectVal
 	if source != nil {
@@ -909,16 +944,15 @@ func (c *Config) ResolveWith(source *Config, opts ResolveOptions) (*Config, erro
 		AllowUnresolved:      opts.AllowUnresolved(),
 	})
 	if err != nil {
-		return nil, wrapResolveError(err)
-	}
-	// Filter: keep only receiver's top-level keys.
-	filtered := resolver.NewObjectVal()
-	for _, k := range res.Root.Keys() {
-		if _, want := receiverKeys[k]; want {
-			v, _ := res.Root.Get(k)
-			filtered.Set(k, v)
+		wrapped := wrapResolveError(err)
+		if re, ok := wrapped.(*ResolveError); ok && re.FilePath == "" {
+			re.OriginDescription = c.originDescription
 		}
+		return nil, wrapped
 	}
+	// Filter recursively by receiver's pre-merge shape — keeps only paths that
+	// existed in the receiver, at any nesting depth.
+	filtered := filterByReceiverShape(res.Root, shape)
 	return &Config{
 		root:              filtered,
 		resolved:          !resolver.ContainsPlaceholders(filtered),

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -924,6 +925,74 @@ func (c *Config) ResolveWith(source *Config, opts ResolveOptions) (*Config, erro
 		parseBaseDir:      c.parseBaseDir,
 		originDescription: c.originDescription,
 	}, nil
+}
+
+// ── renderJSON ────────────────────────────────────────────────────
+
+// renderJSON walks the resolved value tree and emits canonical JSON
+// (sorted-key objects, no whitespace).  Errors on unresolved placeholders.
+// Used by Layer-2 fixture tests to compare against Lightbend ground truth.
+func (c *Config) renderJSON() (string, error) {
+	var sb strings.Builder
+	if err := writeValJSON(&sb, c.root); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+func writeValJSON(sb *strings.Builder, v resolver.Val) error {
+	switch vv := v.(type) {
+	case nil:
+		sb.WriteString("null")
+	case *resolver.ObjectVal:
+		sb.WriteByte('{')
+		keys := vv.Keys()
+		sort.Strings(keys)
+		for i, k := range keys {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(strconv.Quote(k))
+			sb.WriteByte(':')
+			sub, _ := vv.Get(k)
+			if err := writeValJSON(sb, sub); err != nil {
+				return err
+			}
+		}
+		sb.WriteByte('}')
+	case *resolver.ArrayVal:
+		sb.WriteByte('[')
+		for i, e := range vv.Elements {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			if err := writeValJSON(sb, e); err != nil {
+				return err
+			}
+		}
+		sb.WriteByte(']')
+	case *resolver.ScalarVal:
+		switch vv.Type {
+		case resolver.ScalarNull:
+			sb.WriteString("null")
+		case resolver.ScalarBoolean:
+			sb.WriteString(vv.Raw)
+		case resolver.ScalarNumber:
+			// Emit as-is if it's a valid number literal; otherwise quote.
+			if _, err := strconv.ParseFloat(vv.Raw, 64); err == nil {
+				sb.WriteString(vv.Raw)
+			} else {
+				sb.WriteString(strconv.Quote(vv.Raw))
+			}
+		case resolver.ScalarString:
+			sb.WriteString(strconv.Quote(vv.Raw))
+		default:
+			sb.WriteString(strconv.Quote(vv.Raw))
+		}
+	default:
+		return fmt.Errorf("renderJSON: unsupported value type %T (contains unresolved placeholder?)", v)
+	}
+	return nil
 }
 
 // WithFallback returns a new Config that deep-merges receiver over fallback.

--- a/config.go
+++ b/config.go
@@ -832,34 +832,32 @@ func (c *Config) GetConfigSliceOption(path string) Option[[]*Config] {
 
 // WithFallback returns a new Config that deep-merges receiver over fallback.
 // Neither receiver nor fallback is mutated. If fallback is nil, returns receiver.
+//
+// Per E12 § "Composition" (decision 5):
+//   - Receiver's keys win.
+//   - Accepts resolved AND unresolved operands. Result is unresolved iff
+//     either operand is unresolved.
+//   - Substitution placeholders survive merge unchanged. Substitution
+//     lookup at Resolve() time uses the merged tree.
+//   - Non-object collision captures fallback's value as a prior for cross-
+//     layer self-reference lookback (S13a × WithFallback, dr04-dr06).
+//
+// Composition barrier (HOCON.md §Object Merge L1485, dr10):
+//
+//	obj.WithFallback(nonObj).WithFallback(otherObj) ignores otherObj because
+//	nonObj is non-object and bars the merge.  Once a key holds a non-object
+//	scalar, any object at the same key in a subsequent fallback simply does
+//	not replace the scalar (receiver wins; the fallback object is captured
+//	as prior but does not contribute keys to the result).
 func (c *Config) WithFallback(fallback *Config) *Config {
-	if fallback == nil {
+	if fallback == nil || fallback.root == nil {
 		return c
 	}
-	merged := mergeObjectVals(c.root, fallback.root)
-	return newConfig(merged)
-}
-
-// mergeObjectVals merges base into over (over's values win).
-func mergeObjectVals(over, base *resolver.ObjectVal) *resolver.ObjectVal {
-	result := resolver.NewObjectVal()
-	// seed with base
-	for _, k := range base.Keys() {
-		v, _ := base.Get(k)
-		result.Set(k, v)
+	merged := resolver.MergeUnresolved(c.root, fallback.root)
+	return &Config{
+		root:              merged,
+		resolved:          c.resolved && fallback.resolved && !resolver.ContainsPlaceholders(merged),
+		parseBaseDir:      c.parseBaseDir,
+		originDescription: c.originDescription,
 	}
-	// apply over
-	for _, k := range over.Keys() {
-		ov, _ := over.Get(k)
-		if bv, ok := result.GetVal(k); ok {
-			if bo, bok := bv.(*resolver.ObjectVal); bok {
-				if oo, ook := ov.(*resolver.ObjectVal); ook {
-					result.Set(k, mergeObjectVals(oo, bo))
-					continue
-				}
-			}
-		}
-		result.Set(k, ov)
-	}
-	return result
 }

--- a/deferred_resolution_fixture_test.go
+++ b/deferred_resolution_fixture_test.go
@@ -49,6 +49,18 @@ var drYAMLSkip = map[string]string{
 	"dr12": "origin format differs from Lightbend — go.hocon position info covered by dr06 / dr08 / dr18 error tests",
 }
 
+// errorContainsSkip lists scenarios where go.hocon's error message format
+// is intentionally different from Lightbend's, so the YAML errorContains
+// substring doesn't apply.  Scenarios listed here still run; only the
+// errorContains substring check is downgraded to t.Logf.
+//
+// dr12 is already in drYAMLSkip; this map is for scenarios that otherwise
+// pass but whose Lightbend-format errorContains hint doesn't match go.hocon's.
+var errorContainsSkip = map[string]string{
+	// (currently empty — dr08 verified to match; expand if cross-impl
+	//  divergence surfaces in new fixtures)
+}
+
 func TestDeferredResolutionFixtures(t *testing.T) {
 	entries, err := os.ReadDir(drYAMLDir)
 	if err != nil {
@@ -124,7 +136,10 @@ func runScenario(t *testing.T, id, yamlPath string) {
 
 func buildSource(src yamlscenario.Source) (*hocon.Config, error) {
 	if src.ParseString != "" {
-		opts := hocon.DefaultParseOptions()
+		// Per fixture-conventions / scenario YAML README: parseString sources
+		// default to ResolveSubstitutions=false (deferred mode).  Caller can
+		// explicitly opt back into fused mode via parseOptions.resolveSubstitutions: true.
+		opts := hocon.DefaultParseOptions().WithResolveSubstitutions(false)
 		if src.ParseOptions != nil {
 			if src.ParseOptions.ResolveSubstitutions != nil {
 				opts = opts.WithResolveSubstitutions(*src.ParseOptions.ResolveSubstitutions)
@@ -280,7 +295,12 @@ func validateError(t *testing.T, id string, sc yamlscenario.Scenario, stepErrors
 		t.Errorf("scenario %s: error category = %T %v, want %s", id, firstErr, firstErr, sc.Expect.ErrorCategory)
 	}
 	if sc.Expect.ErrorContains != "" && !strings.Contains(firstErr.Error(), sc.Expect.ErrorContains) {
-		t.Logf("scenario %s: errorContains hint %q not found in %q (impl-specific message; not failing)", id, sc.Expect.ErrorContains, firstErr.Error())
+		if _, skip := errorContainsSkip[id]; skip {
+			// Known impl-format divergence — record but don't fail.
+			t.Logf("scenario %s: errorContains %q not in %q (impl-specific format, expected)", id, sc.Expect.ErrorContains, firstErr.Error())
+		} else {
+			t.Errorf("scenario %s: error message %q does not contain expected substring %q", id, firstErr.Error(), sc.Expect.ErrorContains)
+		}
 	}
 }
 

--- a/deferred_resolution_fixture_test.go
+++ b/deferred_resolution_fixture_test.go
@@ -1,0 +1,450 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package hocon_test — Layer-2 E12 YAML scenario runner.
+//
+// Each scenario YAML in testdata/hocon/deferred-resolution/ is interpreted
+// by this runner using the public hocon API.  Outcome is compared to the
+// expected/* artefact (Lightbend ground truth) and to in-YAML assertions.
+package hocon_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/o3co/go.hocon"
+	"github.com/o3co/go.hocon/internal/yamlscenario"
+)
+
+const (
+	drYAMLDir     = "testdata/hocon/deferred-resolution"
+	drExpectedDir = "testdata/expected/deferred-resolution"
+)
+
+// dr17 is the E11 package-include scenario; the YAML runner can't register
+// packages, so we skip it here.  dr17 has dedicated coverage in
+// TestDr17_E11PackageIncludeDeferred (Task 12).
+//
+// dr19 (idempotency double-resolve) has a programmatic counterpart in
+// TestResolve_OnAlreadyResolvedIsIdempotent — the YAML covers the single
+// resolve.
+//
+// dr12 (origin preservation) checks Lightbend-format error position strings
+// that don't translate to go.hocon's format; go.hocon's per-impl test
+// covers the same intent (dr06 / dr08 / dr18 error tests).
+var drYAMLSkip = map[string]string{
+	"dr17": "E11 package-include — covered by TestDr17_E11PackageIncludeDeferred (programmatic)",
+	"dr12": "origin format differs from Lightbend — go.hocon position info covered by dr06 / dr08 / dr18 error tests",
+}
+
+func TestDeferredResolutionFixtures(t *testing.T) {
+	entries, err := os.ReadDir(drYAMLDir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v (did you run 'make testdata'?)", drYAMLDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		id := scenarioID(e.Name())
+		if reason, skip := drYAMLSkip[id]; skip {
+			t.Run(id, func(t *testing.T) { t.Skip(reason) })
+			continue
+		}
+		t.Run(id, func(t *testing.T) { runScenario(t, id, filepath.Join(drYAMLDir, e.Name())) })
+	}
+}
+
+func scenarioID(filename string) string {
+	// "dr01-basic-fallback.yaml" → "dr01"
+	// "dr11a-resolve-with-source-keys-absent.yaml" → "dr11a"
+	base := strings.TrimSuffix(filename, ".yaml")
+	if dash := strings.Index(base, "-"); dash > 0 {
+		return base[:dash]
+	}
+	return base
+}
+
+func runScenario(t *testing.T, id, yamlPath string) {
+	t.Helper()
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", yamlPath, err)
+	}
+	var sc yamlscenario.Scenario
+	if err := yaml.Unmarshal(data, &sc); err != nil {
+		t.Fatalf("yaml.Unmarshal %s: %v", yamlPath, err)
+	}
+
+	// Build sources -> Config artefacts.
+	artefacts := make(map[string]*hocon.Config, len(sc.Sources))
+	sourceErr := make(map[string]error, len(sc.Sources))
+	for name, src := range sc.Sources {
+		cfg, err := buildSource(src)
+		if err != nil {
+			sourceErr[name] = err
+			continue
+		}
+		artefacts[name] = cfg
+	}
+
+	// Walk build steps; record per-step error (if any) for errorAt assertions.
+	var stepErrors []error
+	finalName := "result"
+	for i, step := range sc.Build {
+		stepErr := executeStep(i, step, artefacts, sourceErr)
+		stepErrors = append(stepErrors, stepErr)
+		if step.As != "" {
+			finalName = step.As
+		}
+	}
+
+	switch sc.Expect.Outcome {
+	case "success":
+		validateSuccess(t, id, sc, artefacts, finalName, stepErrors)
+	case "error":
+		validateError(t, id, sc, stepErrors)
+	default:
+		t.Fatalf("scenario %s: unknown expect.outcome %q", id, sc.Expect.Outcome)
+	}
+}
+
+func buildSource(src yamlscenario.Source) (*hocon.Config, error) {
+	if src.ParseString != "" {
+		opts := hocon.DefaultParseOptions()
+		if src.ParseOptions != nil {
+			if src.ParseOptions.ResolveSubstitutions != nil {
+				opts = opts.WithResolveSubstitutions(*src.ParseOptions.ResolveSubstitutions)
+			}
+			if src.ParseOptions.OriginDescription != "" {
+				opts = opts.WithOriginDescription(src.ParseOptions.OriginDescription)
+			}
+		}
+		return hocon.ParseStringWithOptions(src.ParseString, opts)
+	}
+	if src.FromMap != nil {
+		return hocon.FromMap(src.FromMap, src.OriginDescription)
+	}
+	return hocon.Empty(src.OriginDescription), nil
+}
+
+func executeStep(i int, step yamlscenario.Step, artefacts map[string]*hocon.Config, sourceErr map[string]error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if perr, ok := r.(error); ok {
+				err = perr
+			} else {
+				err = fmt.Errorf("step %d panic: %v", i, r)
+			}
+		}
+	}()
+	switch step.Op {
+	case "take":
+		if e, hadErr := sourceErr[step.Source]; hadErr {
+			return e
+		}
+		cfg, ok := artefacts[step.Source]
+		if !ok {
+			return fmt.Errorf("take: source %q not found", step.Source)
+		}
+		artefacts[step.As] = cfg
+		return nil
+	case "extract":
+		base, ok := artefacts[step.This]
+		if !ok {
+			return fmt.Errorf("extract: this=%q not found", step.This)
+		}
+		sub := base.GetConfig(step.Path)
+		artefacts[step.As] = sub
+		return nil
+	case "withFallback":
+		base, ok := artefacts[step.This]
+		if !ok {
+			return fmt.Errorf("withFallback: this=%q not found", step.This)
+		}
+		fb, ok := artefacts[step.Other]
+		if !ok {
+			if e, hadErr := sourceErr[step.Other]; hadErr {
+				return e
+			}
+			return fmt.Errorf("withFallback: other=%q not found", step.Other)
+		}
+		artefacts[step.As] = base.WithFallback(fb)
+		return nil
+	case "resolve":
+		base, ok := artefacts[step.This]
+		if !ok {
+			return fmt.Errorf("resolve: this=%q not found", step.This)
+		}
+		opts := hocon.DefaultResolveOptions()
+		if step.AllowUnresolved != nil {
+			opts = opts.WithAllowUnresolved(*step.AllowUnresolved)
+		}
+		if step.UseSystemEnvironment != nil {
+			opts = opts.WithUseSystemEnvironment(*step.UseSystemEnvironment)
+		}
+		out, err := base.Resolve(opts)
+		if err != nil {
+			return err
+		}
+		artefacts[step.As] = out
+		return nil
+	case "resolveWith":
+		base, ok := artefacts[step.This]
+		if !ok {
+			return fmt.Errorf("resolveWith: this=%q not found", step.This)
+		}
+		src, ok := artefacts[step.Source]
+		if !ok {
+			if e, hadErr := sourceErr[step.Source]; hadErr {
+				return e
+			}
+			return fmt.Errorf("resolveWith: source=%q not found", step.Source)
+		}
+		opts := hocon.DefaultResolveOptions()
+		if step.AllowUnresolved != nil {
+			opts = opts.WithAllowUnresolved(*step.AllowUnresolved)
+		}
+		if step.UseSystemEnvironment != nil {
+			opts = opts.WithUseSystemEnvironment(*step.UseSystemEnvironment)
+		}
+		out, err := base.ResolveWith(src, opts)
+		if err != nil {
+			return err
+		}
+		artefacts[step.As] = out
+		return nil
+	default:
+		return fmt.Errorf("unknown op %q", step.Op)
+	}
+}
+
+func validateSuccess(t *testing.T, id string, sc yamlscenario.Scenario, artefacts map[string]*hocon.Config, finalName string, stepErrors []error) {
+	t.Helper()
+	for i, e := range stepErrors {
+		if e != nil {
+			t.Fatalf("scenario %s: unexpected error at step %d: %v", id, i, e)
+		}
+	}
+	cfg, ok := artefacts[finalName]
+	if !ok {
+		t.Fatalf("scenario %s: final artefact %q not found", id, finalName)
+	}
+	if sc.Expect.IsResolved != nil && cfg.IsResolved() != *sc.Expect.IsResolved {
+		t.Errorf("scenario %s: isResolved = %v, want %v", id, cfg.IsResolved(), *sc.Expect.IsResolved)
+	}
+	if sc.Expect.JSON != "" && cfg.IsResolved() {
+		expectedJSON, err := loadExpectedJSON(id)
+		if err == nil {
+			compareJSON(t, id, expectedJSON, cfg)
+		} else {
+			compareJSONString(t, id, sc.Expect.JSON, cfg)
+		}
+	}
+	for _, g := range sc.Expect.Getter {
+		runGetter(t, id, cfg, g)
+	}
+}
+
+func validateError(t *testing.T, id string, sc yamlscenario.Scenario, stepErrors []error) {
+	t.Helper()
+	idx := -1
+	var firstErr error
+	for i, e := range stepErrors {
+		if e != nil {
+			idx = i
+			firstErr = e
+			break
+		}
+	}
+	if firstErr == nil {
+		t.Fatalf("scenario %s: expected error (category=%s) but all steps succeeded", id, sc.Expect.ErrorCategory)
+	}
+	if sc.Expect.ErrorAt != nil && idx != *sc.Expect.ErrorAt {
+		t.Errorf("scenario %s: errorAt = %d, want %d (err=%v)", id, idx, *sc.Expect.ErrorAt, firstErr)
+	}
+	if !categoryMatches(sc.Expect.ErrorCategory, firstErr) {
+		t.Errorf("scenario %s: error category = %T %v, want %s", id, firstErr, firstErr, sc.Expect.ErrorCategory)
+	}
+	if sc.Expect.ErrorContains != "" && !strings.Contains(firstErr.Error(), sc.Expect.ErrorContains) {
+		t.Logf("scenario %s: errorContains hint %q not found in %q (impl-specific message; not failing)", id, sc.Expect.ErrorContains, firstErr.Error())
+	}
+}
+
+func categoryMatches(category string, err error) bool {
+	switch category {
+	case "ParseError":
+		var pe *hocon.ParseError
+		return errors.As(err, &pe)
+	case "ResolveError":
+		var re *hocon.ResolveError
+		return errors.As(err, &re)
+	case "NotResolved":
+		return errors.Is(err, hocon.ErrNotResolved)
+	case "TypeError":
+		// go.hocon currently surfaces type errors as parse or resolve errors.
+		var pe *hocon.ParseError
+		var re *hocon.ResolveError
+		return errors.As(err, &pe) || errors.As(err, &re)
+	case "CycleError":
+		// go.hocon surfaces cycles as ResolveError with "circular" / "cycle" / "self-referential" message.
+		var re *hocon.ResolveError
+		if !errors.As(err, &re) {
+			return false
+		}
+		msg := strings.ToLower(re.Message)
+		return strings.Contains(msg, "circular") || strings.Contains(msg, "cycle") ||
+			strings.Contains(msg, "self-referential")
+	}
+	return false
+}
+
+func loadExpectedJSON(id string) ([]byte, error) {
+	entries, err := os.ReadDir(drExpectedDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, id+"-") || !strings.HasSuffix(name, "-expected.json") {
+			continue
+		}
+		return os.ReadFile(filepath.Join(drExpectedDir, name))
+	}
+	return nil, fmt.Errorf("no expected json for %s", id)
+}
+
+func compareJSON(t *testing.T, id string, expectedRaw []byte, cfg *hocon.Config) {
+	t.Helper()
+	actualStr, err := hocon.RenderJSON_ForTest(cfg)
+	if err != nil {
+		t.Fatalf("scenario %s: renderJSON: %v", id, err)
+	}
+	if !drJSONEqual(expectedRaw, []byte(actualStr)) {
+		t.Errorf("scenario %s: JSON mismatch\n want: %s\n got:  %s", id, string(expectedRaw), actualStr)
+	}
+}
+
+func compareJSONString(t *testing.T, id, expected string, cfg *hocon.Config) {
+	t.Helper()
+	actual, err := hocon.RenderJSON_ForTest(cfg)
+	if err != nil {
+		t.Fatalf("scenario %s: renderJSON: %v", id, err)
+	}
+	if !drJSONEqual([]byte(expected), []byte(actual)) {
+		t.Errorf("scenario %s: in-YAML JSON mismatch\n want: %s\n got:  %s", id, expected, actual)
+	}
+}
+
+// drJSONEqual compares two JSON byte slices for semantic equality (ignoring
+// whitespace, key ordering, and number representation differences like 42 vs
+// 42.0). Named with "dr" prefix to avoid conflict with lightbend_test.go's
+// jsonEqual(a, b any) helper.
+func drJSONEqual(a, b []byte) bool {
+	var ja, jb any
+	if err := json.Unmarshal(a, &ja); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &jb); err != nil {
+		return false
+	}
+	return drJSONDeepEqual(ja, jb)
+}
+
+func drJSONDeepEqual(a, b any) bool {
+	switch av := a.(type) {
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, v := range av {
+			if !drJSONDeepEqual(v, bv[k]) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !drJSONDeepEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+	}
+}
+
+func runGetter(t *testing.T, id string, cfg *hocon.Config, g yamlscenario.GetterAssert) {
+	t.Helper()
+	if g.ExpectError == "NotResolved" {
+		defer func() {
+			rec := recover()
+			ce, ok := rec.(*hocon.ConfigError)
+			if !ok || !errors.Is(ce, hocon.ErrNotResolved) {
+				t.Errorf("scenario %s getter %q: expected NotResolved panic, got %T %v", id, g.Path, rec, rec)
+			}
+		}()
+		_ = cfg.GetString(g.Path)
+		return
+	}
+	switch {
+	case g.ExpectString != nil:
+		if got := cfg.GetString(g.Path); got != *g.ExpectString {
+			t.Errorf("scenario %s getter %q: got %q want %q", id, g.Path, got, *g.ExpectString)
+		}
+	case g.ExpectInt != nil:
+		if got := cfg.GetInt64(g.Path); got != *g.ExpectInt {
+			t.Errorf("scenario %s getter %q: got %d want %d", id, g.Path, got, *g.ExpectInt)
+		}
+	case g.ExpectBool != nil:
+		if got := cfg.GetBool(g.Path); got != *g.ExpectBool {
+			t.Errorf("scenario %s getter %q: got %v want %v", id, g.Path, got, *g.ExpectBool)
+		}
+	case g.ExpectArray != nil:
+		actual := cfg.GetIntSlice(g.Path)
+		if len(actual) != len(g.ExpectArray) {
+			t.Errorf("scenario %s getter %q: len(actual)=%d want %d", id, g.Path, len(actual), len(g.ExpectArray))
+			return
+		}
+		for i, ev := range g.ExpectArray {
+			expectedInt, ok := numericToInt(ev)
+			if !ok {
+				continue
+			}
+			if int64(actual[i]) != expectedInt {
+				t.Errorf("scenario %s getter %q[%d]: got %d want %d", id, g.Path, i, actual[i], expectedInt)
+			}
+		}
+	}
+}
+
+func numericToInt(v any) (int64, bool) {
+	switch x := v.(type) {
+	case int:
+		return int64(x), true
+	case int64:
+		return x, true
+	case float64:
+		return int64(x), true
+	}
+	return 0, false
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package hocon_test exercises E12 deferred substitution resolution.
+// All tests in this file are Layer-1 (programmatic per-impl) tests; the
+// Layer-2 YAML scenario runner lives in deferred_resolution_fixture_test.go.
+package hocon_test
+
+import (
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+func TestConfig_IsResolved_FusedParseAndResolveIsResolved(t *testing.T) {
+	c, err := hocon.ParseString(`a = 1`)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("fused ParseString must produce a resolved Config")
+	}
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -26,3 +26,46 @@ func TestConfig_IsResolved_FusedParseAndResolveIsResolved(t *testing.T) {
 		t.Fatal("fused ParseString must produce a resolved Config")
 	}
 }
+
+func TestParseStringWithOptions_ResolveSubstitutionsTrue_EquivalentToParseString(t *testing.T) {
+	a, err := hocon.ParseString(`a = 1`)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	b, err := hocon.ParseStringWithOptions(`a = 1`, hocon.DefaultParseOptions())
+	if err != nil {
+		t.Fatalf("ParseStringWithOptions: %v", err)
+	}
+	if !a.IsResolved() || !b.IsResolved() {
+		t.Fatal("both must be resolved")
+	}
+	if a.GetInt("a") != 1 || b.GetInt("a") != 1 {
+		t.Fatalf("a=%d b=%d, want 1", a.GetInt("a"), b.GetInt("a"))
+	}
+}
+
+func TestParseStringWithOptions_ResolveSubstitutionsFalse_IsUnresolvedWhenSubstPresent(t *testing.T) {
+	c, err := hocon.ParseStringWithOptions(
+		`a = ${b}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("ParseStringWithOptions: %v", err)
+	}
+	if c.IsResolved() {
+		t.Fatal("expected unresolved Config (a = ${b} unresolved)")
+	}
+}
+
+func TestParseStringWithOptions_ResolveSubstitutionsFalse_NoSubstReturnsResolved(t *testing.T) {
+	c, err := hocon.ParseStringWithOptions(
+		`a = 1`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("ParseStringWithOptions: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("expected resolved (no substitutions present)")
+	}
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -176,3 +176,104 @@ func TestWithFallback_ObjectMergeRecursive(t *testing.T) {
 		t.Fatalf("a.x=%d a.y=%d, want 1 2", m.GetInt("a.x"), m.GetInt("a.y"))
 	}
 }
+
+func TestResolve_OnAlreadyResolvedIsIdempotent(t *testing.T) {
+	c, _ := hocon.ParseString(`a = 1`)
+	r1, err := c.Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !r1.IsResolved() {
+		t.Fatal("Resolve(resolved) must remain resolved")
+	}
+	// Double-resolve.
+	r2, err := r1.Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("double Resolve: %v", err)
+	}
+	if r2.GetInt("a") != 1 {
+		t.Fatalf("double resolve drift: a=%d", r2.GetInt("a"))
+	}
+}
+
+func TestResolve_DeferredPathSucceeds(t *testing.T) {
+	c, _ := hocon.ParseStringWithOptions(
+		`a = ${b}
+b = 1`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	r, err := c.Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !r.IsResolved() {
+		t.Fatal("Resolve must produce resolved Config")
+	}
+	if r.GetInt("a") != 1 {
+		t.Fatalf("a=%d, want 1", r.GetInt("a"))
+	}
+}
+
+func TestResolve_FallbackThenResolve_IssueNinetyNineExample(t *testing.T) {
+	// dr01 minimal: receiver references CI_RUN_NUMBER and shortversion;
+	// runtime FromMap is not yet available (T11), so use ParseString fallback.
+	r, _ := hocon.ParseStringWithOptions(
+		`version = ${shortversion}-${CI_RUN_NUMBER}
+variables { shortversion = "1.2.3" }`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	rt, _ := hocon.ParseStringWithOptions(
+		`CI_RUN_NUMBER = "42"`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	vars := r.GetConfig("variables")
+	merged := r.WithFallback(rt).WithFallback(vars)
+	resolved, err := merged.Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := resolved.GetString("version"); got != "1.2.3-42" {
+		t.Fatalf("version=%q, want 1.2.3-42", got)
+	}
+}
+
+func TestResolve_NoSystemEnvironment(t *testing.T) {
+	t.Setenv("SHOULD_NOT_BE_READ", "from-env")
+	c, _ := hocon.ParseStringWithOptions(
+		`a = ${SHOULD_NOT_BE_READ}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	_, err := c.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err == nil {
+		t.Fatal("expected ResolveError when env disabled and var absent from config")
+	}
+	var re *hocon.ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *ResolveError, got %T (%v)", err, err)
+	}
+}
+
+func TestResolve_AllowUnresolved_DoesNotError(t *testing.T) {
+	c, _ := hocon.ParseStringWithOptions(
+		`a = ${avail}
+b = ${unavail}
+avail = "hello"`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	r, err := c.Resolve(hocon.DefaultResolveOptions().
+		WithAllowUnresolved(true).
+		WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve(allowUnresolved): %v", err)
+	}
+	if r.IsResolved() {
+		t.Fatal("expected unresolved (b still has placeholder)")
+	}
+	if got := r.GetString("a"); got != "hello" {
+		t.Fatalf("a=%q, want hello", got)
+	}
+	// Getter on b must panic NotResolved.
+	defer func() {
+		rec := recover()
+		ce, ok := rec.(*hocon.ConfigError)
+		if !ok || !errors.Is(ce, hocon.ErrNotResolved) {
+			t.Fatalf("expected NotResolved panic on b, got %T %v", rec, rec)
+		}
+	}()
+	_ = r.GetString("b")
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -129,3 +129,50 @@ func TestGetterOption_OnUnresolvedReturnsNone(t *testing.T) {
 		t.Fatal("expected None for unresolved path via GetStringOption")
 	}
 }
+
+func TestWithFallback_BothResolved_PreservesExistingSemantics(t *testing.T) {
+	a, _ := hocon.ParseString(`a = 1
+b = 2`)
+	b, _ := hocon.ParseString(`b = 99
+c = 3`)
+	m := a.WithFallback(b)
+	if !m.IsResolved() {
+		t.Fatal("both inputs resolved → result resolved")
+	}
+	if m.GetInt("a") != 1 || m.GetInt("b") != 2 || m.GetInt("c") != 3 {
+		t.Fatalf("a=%d b=%d c=%d, want 1 2 3", m.GetInt("a"), m.GetInt("b"), m.GetInt("c"))
+	}
+}
+
+func TestWithFallback_UnresolvedAndResolved_ResultIsUnresolved(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${b}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	f, _ := hocon.ParseString(`b = 7`)
+	m := r.WithFallback(f)
+	if m.IsResolved() {
+		t.Fatal("receiver unresolved → merged result unresolved (until Resolve())")
+	}
+}
+
+func TestWithFallback_NilFallback_ReturnsReceiver(t *testing.T) {
+	c, _ := hocon.ParseString(`a = 1`)
+	if c.WithFallback(nil) != c {
+		t.Fatal("nil fallback must return receiver verbatim")
+	}
+}
+
+func TestWithFallback_ObjectMergeRecursive(t *testing.T) {
+	a, _ := hocon.ParseStringWithOptions(
+		`a { x = 1 }`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	b, _ := hocon.ParseStringWithOptions(
+		`a { y = 2 }`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	m := a.WithFallback(b)
+	if !m.IsResolved() {
+		t.Fatal("both inputs are resolvable (no subs) → result must be resolved")
+	}
+	if m.GetInt("a.x") != 1 || m.GetInt("a.y") != 2 {
+		t.Fatalf("a.x=%d a.y=%d, want 1 2", m.GetInt("a.x"), m.GetInt("a.y"))
+	}
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -218,15 +218,13 @@ b = 1`,
 }
 
 func TestResolve_FallbackThenResolve_IssueNinetyNineExample(t *testing.T) {
-	// dr01 minimal: receiver references CI_RUN_NUMBER and shortversion;
-	// runtime FromMap is not yet available (T11), so use ParseString fallback.
+	// dr01: receiver references CI_RUN_NUMBER and shortversion; FromMap
+	// supplies the runtime value, GetConfig extracts vars subtree.
 	r, _ := hocon.ParseStringWithOptions(
 		`version = ${shortversion}-${CI_RUN_NUMBER}
 variables { shortversion = "1.2.3" }`,
 		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
-	rt, _ := hocon.ParseStringWithOptions(
-		`CI_RUN_NUMBER = "42"`,
-		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	rt, _ := hocon.FromMap(map[string]any{"CI_RUN_NUMBER": "42"}, "")
 	vars := r.GetConfig("variables")
 	merged := r.WithFallback(rt).WithFallback(vars)
 	resolved, err := merged.Resolve(hocon.DefaultResolveOptions())

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -572,6 +572,24 @@ func TestDr10_CompositionBarrier(t *testing.T) {
 	}
 }
 
+func TestRenderJSON_BasicScalarsAndObjects(t *testing.T) {
+	c, _ := hocon.ParseString(`
+		a = 1
+		b = "hello"
+		c { x = true
+		    y = null }
+		d = [1, 2, 3]
+	`)
+	got, err := hocon.RenderJSON_ForTest(c) // export-for-test shim
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	expected := `{"a":1,"b":"hello","c":{"x":true,"y":null},"d":[1,2,3]}`
+	if got != expected {
+		t.Fatalf("renderJSON mismatch:\n got  %s\n want %s", got, expected)
+	}
+}
+
 func TestDr17_E11PackageIncludeDeferred(t *testing.T) {
 	// Register a package that itself contains a substitution.  After parse-
 	// only, the include is expanded — the substitution placeholder remains.

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -249,6 +249,56 @@ func TestResolve_NoSystemEnvironment(t *testing.T) {
 	}
 }
 
+func TestResolveWith_SourceKeysAbsentFromResult(t *testing.T) {
+	// dr11a equivalent.
+	r, _ := hocon.ParseStringWithOptions(
+		`r = ${value}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	src, _ := hocon.ParseString(`value = "found"`)
+	out, err := r.ResolveWith(src, hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("ResolveWith: %v", err)
+	}
+	if out.GetString("r") != "found" {
+		t.Fatalf("r=%q, want 'found'", out.GetString("r"))
+	}
+	// source's `value` key must NOT appear in the result.
+	if out.Has("value") {
+		t.Fatal("source's key 'value' must not appear in ResolveWith result")
+	}
+}
+
+func TestResolveWith_UnresolvedSource_RaisesNotResolved(t *testing.T) {
+	// dr11b: source is unresolved → ResolveWith MUST raise ErrNotResolved
+	// BEFORE attempting to resolve the receiver (decision 10).
+	r, _ := hocon.ParseStringWithOptions(
+		`r = ${value}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	src, _ := hocon.ParseStringWithOptions(
+		`value = ${still_unresolved}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	_, err := r.ResolveWith(src, hocon.DefaultResolveOptions())
+	if err == nil {
+		t.Fatal("expected ErrNotResolved when source is unresolved")
+	}
+	if !errors.Is(err, hocon.ErrNotResolved) {
+		t.Fatalf("expected errors.Is(err, ErrNotResolved); got %v", err)
+	}
+}
+
+func TestResolveWith_OnResolvedReceiver_IsNoOp(t *testing.T) {
+	r, _ := hocon.ParseString(`r = 5`)
+	src, _ := hocon.ParseString(`unused = 99`)
+	out, err := r.ResolveWith(src, hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("ResolveWith: %v", err)
+	}
+	if out.GetInt("r") != 5 || out.Has("unused") {
+		t.Fatalf("ResolveWith on resolved receiver must be a no-op (r=%d has-unused=%v)",
+			out.GetInt("r"), out.Has("unused"))
+	}
+}
+
 func TestResolve_AllowUnresolved_DoesNotError(t *testing.T) {
 	c, _ := hocon.ParseStringWithOptions(
 		`a = ${avail}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -13,6 +13,9 @@ package hocon_test
 
 import (
 	"errors"
+	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -672,6 +675,152 @@ func TestOriginDescription_AppearsInResolveError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "test-config") {
 		t.Errorf("expected error to contain 'test-config', got: %s", err.Error())
+	}
+}
+
+// ── Coverage-uplift tests for E12 (codecov/patch) ────────────────────────────
+
+func TestFromMap_AllNumericTypes(t *testing.T) {
+	// Exercise every integer/float branch in coerceValue.
+	c, err := hocon.FromMap(map[string]any{
+		"i":   int(1),
+		"i8":  int8(2),
+		"i16": int16(3),
+		"i32": int32(4),
+		"i64": int64(5),
+		"u":   uint(6),
+		"u8":  uint8(7),
+		"u16": uint16(8),
+		"u32": uint32(9),
+		"u64": uint64(10),
+		"f32": float32(1.5),
+		"f64": float64(2.5),
+	}, "all-numerics")
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("expected resolved")
+	}
+	if c.GetInt("i") != 1 || c.GetInt("i8") != 2 || c.GetInt("i16") != 3 ||
+		c.GetInt("i32") != 4 || c.GetInt("i64") != 5 ||
+		c.GetInt("u") != 6 || c.GetInt("u8") != 7 || c.GetInt("u16") != 8 ||
+		c.GetInt("u32") != 9 || c.GetInt("u64") != 10 {
+		t.Fatalf("integer round-trip: %+v", c.Keys())
+	}
+	if c.GetFloat64("f32") != 1.5 || c.GetFloat64("f64") != 2.5 {
+		t.Fatalf("float round-trip: f32=%v f64=%v", c.GetFloat64("f32"), c.GetFloat64("f64"))
+	}
+}
+
+func TestFromMap_NestedListErrorPropagates(t *testing.T) {
+	// Nested list with bad element type → error wraps the path.
+	_, err := hocon.FromMap(map[string]any{
+		"list": []any{1, make(chan int)},
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for bad nested element type")
+	}
+}
+
+func TestFromMap_NestedMapErrorPropagates(t *testing.T) {
+	_, err := hocon.FromMap(map[string]any{
+		"nested": map[string]any{
+			"bad": make(chan int),
+		},
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for bad nested map value type")
+	}
+}
+
+func TestFromMap_NaN_Errors(t *testing.T) {
+	_, err := hocon.FromMap(map[string]any{
+		"bad": math.NaN(),
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for NaN")
+	}
+}
+
+func TestFromMap_Inf_Errors(t *testing.T) {
+	_, err := hocon.FromMap(map[string]any{
+		"bad": math.Inf(1),
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for +Inf")
+	}
+}
+
+func TestParseFileWithOptions_DeferredPath(t *testing.T) {
+	// Write a temp file, then ParseFileWithOptions with ResolveSubstitutions=false.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.conf")
+	if err := os.WriteFile(path, []byte("a = ${b}\nb = 1"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c, err := hocon.ParseFileWithOptions(path, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	if err != nil {
+		t.Fatalf("ParseFileWithOptions: %v", err)
+	}
+	if c.IsResolved() {
+		t.Fatal("expected unresolved")
+	}
+	resolved, err := c.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.GetInt("a") != 1 {
+		t.Fatalf("a=%d, want 1", resolved.GetInt("a"))
+	}
+}
+
+func TestParseFileWithOptions_FusedPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.conf")
+	if err := os.WriteFile(path, []byte("x = 42"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c, err := hocon.ParseFileWithOptions(path, hocon.DefaultParseOptions())
+	if err != nil {
+		t.Fatalf("ParseFileWithOptions: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("fused path must produce resolved Config")
+	}
+	if c.GetInt("x") != 42 {
+		t.Fatalf("x=%d, want 42", c.GetInt("x"))
+	}
+}
+
+func TestParseFileWithOptions_FileNotFound(t *testing.T) {
+	_, err := hocon.ParseFileWithOptions("/nonexistent/test.conf", hocon.DefaultParseOptions())
+	if err == nil {
+		t.Fatal("expected file-not-found error")
+	}
+	var pe *hocon.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+}
+
+func TestRenderJSON_FloatAndString(t *testing.T) {
+	c, _ := hocon.ParseString(`
+		i = 1
+		f = 3.14
+		s = "with \"quotes\""
+		n = null
+		b = true
+	`)
+	got, err := hocon.RenderJSON_ForTest(c)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	// Check each scalar branch is hit.
+	for _, frag := range []string{`"i":1`, `"f":3.14`, `"with \"quotes\""`, `"n":null`, `"b":true`} {
+		if !strings.Contains(got, frag) {
+			t.Errorf("missing fragment %q in output: %s", frag, got)
+		}
 	}
 }
 

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -12,6 +12,7 @@
 package hocon_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/o3co/go.hocon"
@@ -67,5 +68,64 @@ func TestParseStringWithOptions_ResolveSubstitutionsFalse_NoSubstReturnsResolved
 	}
 	if !c.IsResolved() {
 		t.Fatal("expected resolved (no substitutions present)")
+	}
+}
+
+func TestGetter_OnUnresolvedSubstitutionPanicsErrNotResolved(t *testing.T) {
+	c, err := hocon.ParseStringWithOptions(
+		`a = ${b}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on getter against unresolved path")
+		}
+		ce, ok := r.(*hocon.ConfigError)
+		if !ok {
+			t.Fatalf("expected *ConfigError, got %T (%v)", r, r)
+		}
+		if !errors.Is(ce, hocon.ErrNotResolved) {
+			t.Fatalf("expected ConfigError to wrap ErrNotResolved, got %v", ce)
+		}
+		if ce.Path != "a" {
+			t.Fatalf("expected path 'a', got %q", ce.Path)
+		}
+	}()
+
+	_ = c.GetString("a") // must panic
+}
+
+func TestGetter_OnResolvedLiteralWithinUnresolvedConfigSucceeds(t *testing.T) {
+	// dr15 boundary: literal value accessible before resolve; substitution panics.
+	c, err := hocon.ParseStringWithOptions(
+		`lit = "value"
+		 sub = ${KEY}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := c.GetString("lit"); got != "value" {
+		t.Fatalf("lit=%q want 'value'", got)
+	}
+}
+
+func TestGetterOption_OnUnresolvedReturnsNone(t *testing.T) {
+	// Option-flavoured getters do not panic; an unresolved placeholder is
+	// "not a scalar" and therefore not present from the Option's perspective.
+	c, err := hocon.ParseStringWithOptions(
+		`a = ${b}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !c.GetStringOption("a").IsNone() {
+		t.Fatal("expected None for unresolved path via GetStringOption")
 	}
 }

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -331,12 +331,12 @@ avail = "hello"`,
 
 func TestFromMap_ScalarTypes(t *testing.T) {
 	c, err := hocon.FromMap(map[string]any{
-		"flag":   true,
-		"count":  42,
-		"ratio":  3.14,
-		"label":  "hello",
-		"items":  []any{int64(1), int64(2), int64(3)},
-		"nested": map[string]any{"inner": "deep"},
+		"flag":    true,
+		"count":   42,
+		"ratio":   3.14,
+		"label":   "hello",
+		"items":   []any{int64(1), int64(2), int64(3)},
+		"nested":  map[string]any{"inner": "deep"},
 		"nothing": nil,
 	}, "")
 	if err != nil {

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -435,3 +435,175 @@ func TestEmpty_Resolve_IsNoOp(t *testing.T) {
 		t.Fatalf("Empty().Resolve() must be {}; keys=%v", r.Keys())
 	}
 }
+
+// ── E12 Layer-1 programmatic conformance tests (T12) ──────────────────────────
+// Covers spec edges not directly expressible in YAML scenarios.
+
+func TestS13a_OptionalSelfRefAcrossFallback_Dr04(t *testing.T) {
+	// receiver: a = ${?a} extra
+	// fallback: a = base
+	// result:   a = "base extra"
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${?a} extra`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f, _ := hocon.ParseStringWithOptions(
+		`a = base`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.WithFallback(f).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := resolved.GetString("a"); got != "base extra" {
+		t.Fatalf("a=%q, want 'base extra'", got)
+	}
+}
+
+func TestS13a_RequiredSelfRefWithFallbackPrior_Dr05(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${a} extra`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f, _ := hocon.ParseStringWithOptions(
+		`a = base`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.WithFallback(f).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := resolved.GetString("a"); got != "base extra" {
+		t.Fatalf("a=%q, want 'base extra'", got)
+	}
+}
+
+func TestS13a_RequiredSelfRefNoFallback_Dr06(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${a} extra`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	_, err := r.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err == nil {
+		t.Fatal("required self-ref with no prior must error")
+	}
+}
+
+func TestTransitive_CrossLayer_Dr21(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${b}`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f1, _ := hocon.ParseStringWithOptions(
+		`b = ${c}`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f2, _ := hocon.ParseStringWithOptions(
+		`c = 1`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.WithFallback(f1).WithFallback(f2).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := resolved.GetInt("a"); got != 1 {
+		t.Fatalf("a=%d, want 1", got)
+	}
+}
+
+func TestHidden_AcrossLayers_Dr23(t *testing.T) {
+	// Receiver foo = 42, fallback foo = ${nonexist} → {foo:42} no error.
+	r, _ := hocon.ParseStringWithOptions(
+		`foo = 42`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f, _ := hocon.ParseStringWithOptions(
+		`foo = ${nonexist}`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.WithFallback(f).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("hidden substitution must not error; got %v", err)
+	}
+	if got := resolved.GetInt("foo"); got != 42 {
+		t.Fatalf("foo=%d, want 42", got)
+	}
+}
+
+func TestCrossLayerCycle_Dr18(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${b}`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	f, _ := hocon.ParseStringWithOptions(
+		`b = ${a}`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	_, err := r.WithFallback(f).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err == nil {
+		t.Fatal("cross-layer cycle must raise ResolveError")
+	}
+}
+
+func TestOptionalUndefMaterialisation_Standalone(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${?x}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Has("a") {
+		t.Fatal("standalone optional undefined → field must be omitted")
+	}
+}
+
+func TestOptionalUndefMaterialisation_StringConcat(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a = ${?x} "tail"`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	resolved, err := r.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := resolved.GetString("a"); got != " tail" {
+		t.Fatalf("a=%q, want ' tail' (leading space preserved)", got)
+	}
+}
+
+func TestDr10_CompositionBarrier(t *testing.T) {
+	r, _ := hocon.ParseStringWithOptions(
+		`a { x = 1 }`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	fb1, _ := hocon.ParseStringWithOptions(
+		`a = "scalar"`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	fb2, _ := hocon.ParseStringWithOptions(
+		`a { y = 2 }`, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	m := r.WithFallback(fb1).WithFallback(fb2)
+	resolved, err := m.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.GetInt("a.x") != 1 {
+		t.Fatalf("a.x=%d, want 1", resolved.GetInt("a.x"))
+	}
+	if resolved.GetConfig("a").Has("y") {
+		t.Fatal("composition barrier: fb2's y must not contribute")
+	}
+}
+
+func TestDr17_E11PackageIncludeDeferred(t *testing.T) {
+	// Register a package that itself contains a substitution.  After parse-
+	// only, the include is expanded — the substitution placeholder remains.
+	// After Resolve with a FromMap providing EXTERNAL, value resolves.
+	hocon.ResetPackageRegistry()
+	t.Cleanup(hocon.ResetPackageRegistry)
+
+	pkgContent := []byte(`value = ${EXTERNAL}`)
+	if err := hocon.RegisterPackage("dr17-test-pkg", "ref.conf", pkgContent); err != nil {
+		t.Fatalf("RegisterPackage: %v", err)
+	}
+	defer hocon.UnregisterPackage("dr17-test-pkg", "ref.conf")
+
+	r, err := hocon.ParseStringWithOptions(
+		`include package("dr17-test-pkg", "ref.conf")
+outer = "top"`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	if err != nil {
+		t.Fatalf("ParseStringWithOptions: %v", err)
+	}
+	if r.IsResolved() {
+		t.Fatal("expected unresolved (EXTERNAL placeholder remains)")
+	}
+	fb, _ := hocon.FromMap(map[string]any{"EXTERNAL": "injected"}, "")
+	resolved, err := r.WithFallback(fb).Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.GetString("value") != "injected" {
+		t.Fatalf("value=%q, want 'injected'", resolved.GetString("value"))
+	}
+	if resolved.GetString("outer") != "top" {
+		t.Fatalf("outer=%q, want 'top'", resolved.GetString("outer"))
+	}
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -327,3 +327,111 @@ avail = "hello"`,
 	}()
 	_ = r.GetString("b")
 }
+
+func TestFromMap_ScalarTypes(t *testing.T) {
+	c, err := hocon.FromMap(map[string]any{
+		"flag":   true,
+		"count":  42,
+		"ratio":  3.14,
+		"label":  "hello",
+		"items":  []any{int64(1), int64(2), int64(3)},
+		"nested": map[string]any{"inner": "deep"},
+		"nothing": nil,
+	}, "")
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("FromMap must produce resolved Config")
+	}
+	if c.GetBool("flag") != true {
+		t.Fatalf("flag=%v", c.GetBool("flag"))
+	}
+	if c.GetInt("count") != 42 {
+		t.Fatalf("count=%d", c.GetInt("count"))
+	}
+	if c.GetFloat64("ratio") != 3.14 {
+		t.Fatalf("ratio=%v", c.GetFloat64("ratio"))
+	}
+	if c.GetString("label") != "hello" {
+		t.Fatalf("label=%q", c.GetString("label"))
+	}
+	if c.GetString("nested.inner") != "deep" {
+		t.Fatalf("nested.inner=%q", c.GetString("nested.inner"))
+	}
+	if got := c.GetIntSlice("items"); len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Fatalf("items=%v", got)
+	}
+	// `nothing` is null: GetStringOption returns None.
+	if !c.GetStringOption("nothing").IsNone() {
+		t.Fatal("nothing must be None (null)")
+	}
+}
+
+func TestFromMap_NilMap_ReturnsEmpty(t *testing.T) {
+	c, err := hocon.FromMap(nil, "")
+	if err != nil {
+		t.Fatalf("FromMap(nil): %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("must be resolved (no substitutions)")
+	}
+	if len(c.Keys()) != 0 {
+		t.Fatalf("expected empty, got %v", c.Keys())
+	}
+}
+
+func TestFromMap_Uint64Overflow_Errors(t *testing.T) {
+	_, err := hocon.FromMap(map[string]any{
+		"big": uint64(1<<63 + 1), // exceeds int64 range
+	}, "")
+	if err == nil {
+		t.Fatal("expected overflow error for uint64 > int64.Max")
+	}
+}
+
+func TestFromMap_UnsupportedType_Errors(t *testing.T) {
+	_, err := hocon.FromMap(map[string]any{
+		"oops": make(chan int),
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for unsupported type chan int")
+	}
+}
+
+func TestEmpty_HasNoKeys(t *testing.T) {
+	c := hocon.Empty("")
+	if !c.IsResolved() {
+		t.Fatal("Empty must be resolved")
+	}
+	if len(c.Keys()) != 0 {
+		t.Fatalf("expected empty, got %v", c.Keys())
+	}
+}
+
+func TestEmpty_AsFallbackIsNoOp(t *testing.T) {
+	c, _ := hocon.ParseString(`a = 1`)
+	m := c.WithFallback(hocon.Empty(""))
+	if m.GetInt("a") != 1 {
+		t.Fatalf("Empty() fallback must be no-op; a=%d", m.GetInt("a"))
+	}
+}
+
+func TestEmpty_AsReceiverWithFallback(t *testing.T) {
+	c, _ := hocon.ParseString(`a = 1
+b = 2`)
+	m := hocon.Empty("").WithFallback(c)
+	if m.GetInt("a") != 1 || m.GetInt("b") != 2 {
+		t.Fatalf("Empty().WithFallback(c) must expose c's keys; a=%d b=%d", m.GetInt("a"), m.GetInt("b"))
+	}
+}
+
+func TestEmpty_Resolve_IsNoOp(t *testing.T) {
+	r, err := hocon.Empty("").Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("Resolve(Empty): %v", err)
+	}
+	if !r.IsResolved() || len(r.Keys()) != 0 {
+		t.Fatalf("Empty().Resolve() must be {}; keys=%v", r.Keys())
+	}
+}

--- a/deferred_resolution_test.go
+++ b/deferred_resolution_test.go
@@ -13,6 +13,7 @@ package hocon_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/o3co/go.hocon"
@@ -587,6 +588,90 @@ func TestRenderJSON_BasicScalarsAndObjects(t *testing.T) {
 	expected := `{"a":1,"b":"hello","c":{"x":true,"y":null},"d":[1,2,3]}`
 	if got != expected {
 		t.Fatalf("renderJSON mismatch:\n got  %s\n want %s", got, expected)
+	}
+}
+
+func TestResolveWith_NestedSourceKeysAlsoFiltered(t *testing.T) {
+	// C1 regression: when receiver and source share a top-level key, source's
+	// nested keys at that path must NOT appear in the result.
+	r, _ := hocon.ParseStringWithOptions(
+		`a { r = ${value} }`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	src, _ := hocon.ParseString(`a { leaked = 1 }
+value = "ok"`)
+	out, err := r.ResolveWith(src, hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("ResolveWith: %v", err)
+	}
+	if out.GetString("a.r") != "ok" {
+		t.Fatalf("a.r=%q, want 'ok'", out.GetString("a.r"))
+	}
+	// source's nested `a.leaked` must NOT appear in the result.
+	if out.Has("a.leaked") {
+		t.Fatal("source's nested key a.leaked must not appear in ResolveWith result")
+	}
+	// source's top-level `value` must also NOT appear (already covered by dr11a).
+	if out.Has("value") {
+		t.Fatal("source's top-level key 'value' must not appear")
+	}
+}
+
+func TestResolveWith_ReceiverHadScalarSourceHadObject_ReceiverScalarWins(t *testing.T) {
+	// Edge: receiver has a top-level scalar at key x; source has an object at
+	// key x. Composition barrier handles the merge level. After resolve+filter,
+	// receiver's scalar wins (consistent with WithFallback semantics).
+	r, _ := hocon.ParseStringWithOptions(
+		`x = 42
+ref = ${y}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	src, _ := hocon.ParseString(`x { leaked = 1 }
+y = "found"`)
+	out, err := r.ResolveWith(src, hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("ResolveWith: %v", err)
+	}
+	if out.GetInt("x") != 42 {
+		t.Fatalf("x=%d, want 42 (receiver scalar)", out.GetInt("x"))
+	}
+	if out.GetString("ref") != "found" {
+		t.Fatalf("ref=%q, want 'found'", out.GetString("ref"))
+	}
+	// source's x.leaked must NOT appear.
+	if out.Has("x.leaked") {
+		t.Fatal("source's x.leaked must not appear")
+	}
+}
+
+func TestOriginDescription_AppearsInParseError(t *testing.T) {
+	// Bad HOCON triggers a parse error. With originDescription set,
+	// the error message should include the user-supplied label.
+	_, err := hocon.ParseStringWithOptions(
+		`{ a = 1`, // unbalanced — parse error
+		hocon.DefaultParseOptions().WithOriginDescription("inline-config"),
+	)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "inline-config") {
+		t.Errorf("expected error to contain 'inline-config', got: %s", err.Error())
+	}
+}
+
+func TestOriginDescription_AppearsInResolveError(t *testing.T) {
+	c, _ := hocon.ParseStringWithOptions(
+		`a = ${missing_required}`,
+		hocon.DefaultParseOptions().
+			WithResolveSubstitutions(false).
+			WithOriginDescription("test-config"),
+	)
+	_, err := c.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err == nil {
+		t.Fatal("expected resolve error")
+	}
+	if !strings.Contains(err.Error(), "test-config") {
+		t.Errorf("expected error to contain 'test-config', got: %s", err.Error())
 	}
 }
 

--- a/docs/proposals/E12-deferred-resolution-design.md
+++ b/docs/proposals/E12-deferred-resolution-design.md
@@ -69,7 +69,7 @@ OQ-1 through OQ-10 from the Open-Questions pass on 2026-05-21:
 | OQ | Decision |
 |---|---|
 | OQ-1 (default `ResolveSubstitutions`) | Keep existing `ParseString`/`ParseFile` fused (parse+resolve) for back-compat. New opt-in `ParseStringWithOptions` for parse-only. Future v2 may flip default; not in scope. |
-| OQ-2 (options shape) | `ParseOptions` / `ResolveOptions` struct passed to `*WithOptions` entry points. No builder pattern. |
+| OQ-2 (options shape) | `ParseOptions` / `ResolveOptions` value types passed to `*WithOptions` entry points. **Go**: builder pattern via `DefaultParseOptions()` / `DefaultResolveOptions()` factories + chainable `WithX()` setters (decision 4 in final spec). **TS**: `Partial<Options>` interface. **Rust**: `Default` impl + chainable builder methods. |
 | OQ-3 (`WithFallback` on unresolved) | Existing `WithFallback` is extended to accept both resolved and unresolved configs. Merge operates at unresolved-tree level when either operand is unresolved. |
 | OQ-4 (`ResolveWith`) | Spec text includes `ResolveWith(source)` (Lightbend semantic: source used for lookup only, not merged into result). Impl conformance: MUST in v1 for the impl where the issue was filed (go.hocon); MAY for ts/rs in v1 (follow-on PR ok). |
 | OQ-5 (`FromMap`) | `FromMap(values, originDescription)` (plain keys, Lightbend `ConfigValueFactory.fromMap`). **`FromAnyRef` deferred to follow-on** (requires public `ConfigValue` type — see § "Value factories"). Path-expression `parseMap` also deferred. |

--- a/docs/proposals/E12-deferred-resolution-design.md
+++ b/docs/proposals/E12-deferred-resolution-design.md
@@ -1,0 +1,639 @@
+> **Project-local copy** of the cross-impl E12 design spec.  Canonical source:
+> `.claude/superpowers/specs/2026-05-21-e12-deferred-resolution-design.md`
+> in the hocon scope (not part of this repo).  Spec reference:
+> [xx.hocon `docs/extra-spec-conventions.md` § E12](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md#e12).
+
+---
+
+# E12 — Deferred substitution resolution (parse / merge / resolve lifecycle)
+
+**Date**: 2026-05-21
+**Phase**: E-series (extra-spec conventions)
+**Target item**: E12 (new, will be appended to `docs/extra-spec-conventions.md` after E11)
+**External request**: [o3co/go.hocon#99](https://github.com/o3co/go.hocon/issues/99) (cgordon)
+**Tracking**: xx.hocon#TBD (to be filed after ★1)
+
+---
+
+## Summary
+
+Expose Lightbend's `parse / withFallback / resolve` lifecycle as a public API in all three impls. Currently `ParseString`/`ParseFile` parse-and-resolve in a single step, which prevents callers from composing fallback layers before resolution and forces ugly workarounds (synthetic HOCON injection, env mutation, pre-serialised fallback layers).
+
+The internal pipeline in all three impls is **already two-phase** (parse → unresolved tree → resolve to value tree). This spec only exposes the existing seam — no resolution-engine redesign is required.
+
+---
+
+## Motivation
+
+### Current behaviour (all three impls)
+
+`ParseString` / `parseString` / `parse` invokes parse and substitution resolution in one shot. A HOCON like:
+
+```hocon
+version = ${shortversion}-${CI_RUN_NUMBER}
+variables { shortversion = "1.2.3" }
+```
+
+fails at parse time if `CI_RUN_NUMBER` is not in `os.Environ` / `process.env` / `std::env`, even when the caller wants to supply `CI_RUN_NUMBER` from a programmatic fallback layer after parsing.
+
+### Lightbend reference behaviour
+
+In `com.typesafe.config`:
+
+- `ConfigFactory.parseString(str)` returns an **unresolved** `Config` by default.
+- `Config.withFallback(ConfigMergeable other)` composes configs (receiver wins).
+- `Config.resolve()` / `resolve(ConfigResolveOptions)` resolves substitutions explicitly.
+- `Config.isResolved()` reports completion.
+- `ConfigFactory.defaultReferenceUnresolved()` exists specifically to return unresolved configs for callers that want to defer resolution.
+
+The three impls deviated from Lightbend by fusing parse+resolve. Restoring the lifecycle separation is a Lightbend-parity fix, not a feature addition.
+
+### Acceptance criteria (from issue #99)
+
+- Existing `ParseString` / `ParseFile` behaviour remains backward compatible.
+- A caller can parse a config containing unresolved substitutions without receiving an error.
+- A caller can merge fallback layers after parsing and before resolution.
+- A caller can resolve the merged config explicitly.
+- Substitutions resolve against the full merged fallback stack.
+- `WithFallback` precedence matches Lightbend (receiver wins).
+- `AllowUnresolved` supports partial resolution.
+- `UseSystemEnvironment=false` supports deterministic, explicit-source-only resolution.
+- Error messages after explicit `Resolve` still preserve useful source path, line, and column information.
+
+---
+
+## Resolved decisions (★1-pending — see Open Q)
+
+OQ-1 through OQ-10 from the Open-Questions pass on 2026-05-21:
+
+| OQ | Decision |
+|---|---|
+| OQ-1 (default `ResolveSubstitutions`) | Keep existing `ParseString`/`ParseFile` fused (parse+resolve) for back-compat. New opt-in `ParseStringWithOptions` for parse-only. Future v2 may flip default; not in scope. |
+| OQ-2 (options shape) | `ParseOptions` / `ResolveOptions` struct passed to `*WithOptions` entry points. No builder pattern. |
+| OQ-3 (`WithFallback` on unresolved) | Existing `WithFallback` is extended to accept both resolved and unresolved configs. Merge operates at unresolved-tree level when either operand is unresolved. |
+| OQ-4 (`ResolveWith`) | Spec text includes `ResolveWith(source)` (Lightbend semantic: source used for lookup only, not merged into result). Impl conformance: MUST in v1 for the impl where the issue was filed (go.hocon); MAY for ts/rs in v1 (follow-on PR ok). |
+| OQ-5 (`FromMap`) | `FromMap(values, originDescription)` (plain keys, Lightbend `ConfigValueFactory.fromMap`). **`FromAnyRef` deferred to follow-on** (requires public `ConfigValue` type — see § "Value factories"). Path-expression `parseMap` also deferred. |
+| OQ-6 (Unresolved getter) | Getters on unresolved `Config` return language-idiomatic `NotResolved` error. `AllowUnresolved=true` still errors on getters that hit unresolved paths. |
+| OQ-7 (Custom resolver chain) | Out of scope for v1. Lightbend `ConfigResolveOptions.appendResolver` is a v1.3.2+ feature; track as follow-on E-item if needed. |
+| OQ-8 (xx.hocon spec category) | `docs/extra-spec-conventions.md` E12 entry (HOCON.md is silent on API surface, so cross-impl convention applies). |
+| OQ-9 (Include timing) | Includes are resolved at parse phase, NOT deferred. `UnresolvedConfig` has includes already expanded; only `${...}` substitutions are deferred. E11 `package(...)` resolver runs at parse time. |
+| OQ-10 (Other ConfigParseOptions fields) | v1 `ParseOptions`: **`ResolveSubstitutions` + `OriginDescription`**. `FromMap`/`Empty` also accept `originDescription`. Other Lightbend `ConfigParseOptions` fields (`setAllowMissing`, `setIncluder`, `setClassLoader`, `setSyntax`) deferred. (Revised from initial "ResolveSubstitutions only" — adding parse origin was trivial and improves error messages for non-file sources.) |
+
+---
+
+## Definitions
+
+- **Unresolved Config**: a `Config` produced by parsing where one or more `${...}` substitutions remain unresolved. `IsResolved()` returns `false`. Getters raise `NotResolved` for paths whose value (or transitive parent) contains an unresolved substitution.
+- **Resolved Config**: a `Config` where no `${...}` substitution remains. `IsResolved()` returns `true`. Getters operate normally.
+- **Substitution placeholder**: the in-memory representation of an unresolved `${foo}` / `${?foo}` / `${X[]}` reference. Each impl already has an internal type for this (go: `substPlaceholder`, ts: `SubstPlaceholder`, rs: `ResolverValue::Subst`). The type stays internal; the public surface only exposes it via `IsResolved()` and error paths.
+- **Phase-1 (parse)**: tokenize → AST → unresolved value tree (with includes expanded, substitution placeholders intact).
+- **Phase-2 (resolve)**: walk unresolved tree, look up each substitution path against the merged tree + (optionally) env, replace placeholders with values.
+- **Merged tree**: the value tree resulting from a chain of `WithFallback` invocations. Logical structure: `[receiver, fallback₁, fallback₂, …]`, with receiver winning. Substitution placeholders within any layer survive into the merged tree.
+- **Fallback stack**: synonym for *merged tree* when emphasising the layered composition.
+
+### Immutability invariant
+
+All `Config` instances are immutable. `WithFallback`, `Resolve`, `ResolveWith` return new `Config` instances; receivers are never mutated. This matches Lightbend `Config` (immutable, all "modifier" methods return new instances).
+
+### Idempotency of Resolve
+
+`Resolve` on an already-resolved `Config` is a no-op that returns an equivalent `Config` (either the same instance or a copy with identical value tree). Matches Lightbend's documented `resolve()` behaviour: "Resolving an already-resolved config is a harmless no-op".
+
+### Single-pass resolution over fallback stack (one top-level operation)
+
+`Resolve()` performs **one top-level resolve operation over the entire fallback stack**. This is the Lightbend recommendation: "ideally [resolve] should be invoked on root config objects … resolved one time for your entire stack of fallbacks". Per-layer resolution before `WithFallback` is allowed but discouraged because substitutions in upper layers cannot see lower-layer values.
+
+"One top-level operation" does NOT mean "one tree walk". Substitution resolution is **transitive and lazy** within that one operation: resolving `${a}` where `a = ${b}` and `b = ${c}` and `c = 1` MUST yield `1` (not leave `${b}` unresolved). Cycles within the transitive chain are detected per § "Cross-layer cycle detection".
+
+Transitive resolution fixture: dr20 (chained substitution within a single source) and dr21 (chained substitution across fallback layers).
+
+### Hidden substitutions are not evaluated
+
+HOCON's substitution semantics (HOCON.md §Substitutions L670–L703) require that **substitutions in overridden values are discarded before resolution**:
+
+```hocon
+foo = ${does-not-exist}
+foo = 42
+```
+
+This MUST resolve to `{ foo: 42 }` without error. The first `foo = ${does-not-exist}` is overridden by the second definition and removed from the resolution tree.
+
+The same rule applies across fallback layers. `A.WithFallback(B)` produces a merged tree where A's keys win. If A has `foo = ${does-not-exist}` and B has `foo = 42`, then **A's substitution wins** (A is receiver) — error. But `B.WithFallback(A)` makes B the receiver, B's `foo = 42` wins, and A's substitution is dropped — no error.
+
+**Definition refinement**: the **merged tree** (the input to resolution) is the *visible* value tree post-merge. Overridden values, including their substitution placeholders, are NOT in the merged tree and are NOT evaluated.
+
+**Lookback exception**: self-reference lookback (s13a) preserves a separate "lookback chain" of prior values that were overridden by the substituting definition. This chain is consulted only by self-reference resolution and is otherwise invisible. See § "s13a × WithFallback".
+
+Fixtures dr22 (hidden unresolved within single source) and dr23 (hidden unresolved across fallback layers) pin this behaviour.
+
+### Transitive substitution resolution
+
+`${a}` where `a` resolves to a value containing `${b}` MUST trigger resolution of `${b}` as part of the same top-level resolve operation. Resolution does not stop at one level of indirection.
+
+Implementations typically achieve this via lazy / recursive evaluation of the substitution graph with cycle detection. The conformance requirement is the outcome, not the algorithm. Fixtures dr20/dr21 cover direct and cross-layer cases.
+
+### Cross-layer cycle detection
+
+Substitution cycles must be detected in the merged tree, including cycles that emerge only after merging:
+
+```hocon
+# receiver
+a = ${b}
+# fallback
+b = ${a}
+```
+
+After `WithFallback`, resolving the merged tree must detect the `a → b → a` cycle and raise `ResolveError` (or `NotResolved` with `AllowUnresolved=true`, per § "Conformance levels"). The cycle-detection algorithm is impl-internal; the conformance requirement is that emerging-on-merge cycles are detected.
+
+---
+
+## Public API surface
+
+The surface is defined here language-agnostically; per-impl naming follows each language's idiom (see § "Per-impl naming").
+
+### Parse entry points
+
+```text
+ParseString(input) -> Config                    (existing, fused parse+resolve)
+ParseFile(path)    -> Config                    (existing, fused parse+resolve)
+
+ParseStringWithOptions(input, ParseOptions) -> Config   (new)
+ParseFileWithOptions(path, ParseOptions)    -> Config   (new)
+```
+
+When `ParseOptions.ResolveSubstitutions = true` (the spec-defined default), `ParseStringWithOptions` produces a `Config` indistinguishable from `ParseString` (same resolved value tree, same origin chain). When `false`, the returned `Config` has `IsResolved() == false` if the input contains any `${...}`, otherwise `true`.
+
+`ParseOptions` v1 *semantic* fields (per-language encoding follows § "Options encoding per language"):
+
+```text
+ResolveSubstitutions: bool    // default true
+OriginDescription:    string  // optional, default ""; user-visible source name (Lightbend ConfigParseOptions.setOriginDescription)
+```
+
+`OriginDescription` is included in v1 because it is trivial to plumb through and improves error messages when the source isn't a file path (e.g. in-memory strings, REST API payloads). Other Lightbend `ConfigParseOptions` fields (`setSyntax`, `setAllowMissing`, `setIncluder`, `setClassLoader`) are deferred (see § "Out of scope").
+
+### Options encoding per language
+
+The spec defines option **semantics** (which defaults are which). Each impl encodes options idiomatically to its language. The hard constraint: an invocation equivalent to "use all defaults" MUST produce Lightbend default behaviour without requiring the caller to set anything.
+
+| Lang | Encoding | Default invocation |
+|---|---|---|
+| **Go** | Builder pattern: unexported fields + `DefaultParseOptions()` / `DefaultResolveOptions()` factory functions + `WithX(v) ParseOptions` setter methods that return modified copies. **`ParseOptions{}` zero-value literal is NOT a valid invocation** and is documented as such — package-level lint or runtime check MAY reject it. Idiomatic Go convention (cf. `tls.Config`-style builders, `gRPC` `DialOption`). | `hocon.ParseString(s)` (no opts); or `hocon.ParseStringWithOptions(s, hocon.DefaultParseOptions())` |
+| **TS** | `Partial<ParseOptions>` (interface where every field is optional). Omitted field → spec default. | `parseString(s)` (no opts); or `parseString(s, { resolveSubstitutions: false })` |
+| **Rust** | `Default` impl returning spec defaults + chainable builder methods. `ParseOptions::default()` returns defaults. | `hocon::parse(s)` (no opts); or `hocon::parse_with_options(s, ParseOptions::default().with_resolve_substitutions(false))` |
+
+**Rationale for Go builder over struct literal**: in Go, `ResolveOptions{}` with `UseSystemEnvironment bool` would mean `false`, contradicting Lightbend's "default true". Inverting the field name (`NoSystemEnvironment`) would lose Lightbend-name parity and confuse maintainers. Builder pattern is the standard Go idiom for "struct with non-zero defaults" and aligns with `gRPC` `DialOption`, `tls.Config` builders, etc.
+
+**Rejected alternatives**:
+- Tri-state `*bool` fields: ergonomically poor (callers write `&true`).
+- Variadic `ResolveOption` functions: works but diverges further from struct-based TS/Rust.
+- Exported fields with documented zero-value semantic inversion: brittle and Lightbend-incompatible naming.
+
+**TS / Rust note**: in both languages, the zero-value problem doesn't bite because the language provides natural ways to express "unspecified = default" (optional fields, `Default` trait). Struct/object literal idioms work for them.
+
+### Value factories
+
+```text
+FromMap(values, originDescription) -> Config            (Lightbend ConfigValueFactory.fromMap)
+Empty(originDescription) -> Config                      (Lightbend ConfigFactory.empty)
+```
+
+**`FromAnyRef` is OUT OF SCOPE for v1**. Lightbend's `ConfigValueFactory.fromAnyRef` returns `ConfigValue` (not `Config`) and accepts scalars / lists / null at the root. To expose this we would need to publish a `ConfigValue` type and define its public surface (getters? rendering? `WithFallback` for non-object roots? `IsResolved` for scalar roots?). That is a separate, larger spec. v1 ships `FromMap` (object-root only) which satisfies issue #99's fallback-injection use case. Track `FromAnyRef` + `ConfigValue` public surface as a follow-on E-item.
+
+**Origin description handling per language** (since Lightbend uses Java overloads which don't translate uniformly):
+
+| Lang | Pattern | Default-origin form |
+|---|---|---|
+| Go | required `string` arg, empty string `""` means "use default origin" | `hocon.FromMap(m, "")` |
+| TS | optional second arg | `fromMap(m)` (origin omitted) or `fromMap(m, "name")` |
+| Rust | `origin: Option<&str>` | `from_map(m, None)` or `from_map(m, Some("name"))` |
+
+**`Empty()` equivalence**: `Empty(o)` is equivalent to `FromMap({}, o)`. Impls MAY implement one in terms of the other.
+
+**`FromMap` input type per language** (`values` parameter):
+
+| Lang | Type |
+|---|---|
+| Go | `map[string]any` |
+| TS | `Record<string, unknown>` |
+| Rust | `HashMap<String, FromMapValue>` (typed enum: see "Type coercion") OR `serde_json::Value::Object` if `serde-compat` feature flag is enabled |
+
+**Type coercion table** for `FromMap` values (keys are plain — NOT path expressions; nested objects use the same rules recursively):
+
+| HOCON type | Go input | TS input | Rust input |
+|---|---|---|---|
+| `null` | `nil` | `null` (not `undefined`) | `Value::Null` or `Option::None` wrapper |
+| `boolean` | `bool` | `boolean` | `bool` |
+| `number` (int) | `int`, `int8/16/32/64`, `uint`, `uint8/16/32` | `number` (integral via `Number.isInteger`) | `i8/16/32/64`, `u8/16/32/64` |
+| `number` (float) | `float32`, `float64` | `number` (non-integral) | `f32`, `f64` |
+| `string` | `string` | `string` | `String`, `&str` |
+| `array` | `[]any` | `unknown[]` | `Vec<T>` (T = supported) |
+| `object` | `map[string]any` | `Record<string, unknown>` | `HashMap<String, T>` / `BTreeMap<String, T>` |
+
+Type coercion edge cases:
+
+- **Go `uint64` exceeding `int64` range**: error (HOCON numbers map to int64-equivalent precision). Document as known limitation.
+- **TS `undefined`**: error (use explicit `null`). Lightbend equivalent is "throw"; we mirror.
+- **TS `bigint`**: error in v1. Future enhancement under separate spec.
+- **TS non-integer `number` requested as int via getter**: existing impl behaviour. Out of scope for this spec.
+- **Rust `Option::None` field**: skip the key (omit from object). `Option::Some(v)` → emit `v`. This differs from Lightbend (no `Option`), but is the idiomatic Rust mapping.
+- **Map key ordering**: HOCON object key ordering follows insertion order. Go `map` is unordered; impls must use a stable iteration order — recommend sorted keys when origin is `FromMap` (no source-file order to preserve). TS uses object key order. Rust uses `BTreeMap` for sorted, `IndexMap` for insertion-preserving. v1: each impl documents its choice; cross-impl tests assert resolved values, not iteration order.
+
+### Composition
+
+```text
+config.WithFallback(other) -> Config
+```
+
+- Receiver's keys win.
+- Accepts both resolved and unresolved operands. Result is unresolved iff either operand is unresolved.
+- Non-object values do not merge: `obj.WithFallback(nonObj).WithFallback(otherObj)` ignores `otherObj` (Lightbend `ConfigMergeable` semantic).
+- Substitution placeholders survive merge unchanged. Substitution lookup at `Resolve()` time uses the merged tree.
+
+### Resolution
+
+```text
+config.Resolve(ResolveOptions) -> Config
+config.ResolveWith(source, ResolveOptions) -> Config
+config.IsResolved() -> bool
+```
+
+`ResolveOptions` fields (Lightbend `ConfigResolveOptions` subset):
+
+```text
+UseSystemEnvironment: bool   // default true; if false, no os.Environ/process.env fallback
+AllowUnresolved:      bool   // default false; if true, partial resolution doesn't error
+```
+
+`Resolve(ResolveOptions{})` with default values is equivalent to Lightbend `Config.resolve()`. Each impl SHOULD also provide a no-arg `Resolve()` overload as ergonomic shortcut, equivalent to `Resolve(default ResolveOptions)`.
+
+`Resolve()` recommendation: callers SHOULD resolve once at the top of the fallback stack, not per layer (matches Lightbend's documented advice; see § "Single-pass resolution over fallback stack").
+
+`ResolveWith(source, opts)` semantic: substitutions in receiver are looked up in `source`, but `source`'s keys are NOT merged into the result. Differs from `WithFallback(source).Resolve(opts)` because the latter includes `source`'s keys in the resulting `Config`.
+
+**Precondition on `ResolveWith` source**: `source` MUST be resolved (or empty of substitutions). If `source` is unresolved, `ResolveWith` MUST error with `NotResolved` BEFORE attempting to resolve the receiver. The error path is the same `NotResolved` category used elsewhere in this spec; impls SHOULD include a marker in the error message indicating the violation occurred at `ResolveWith` source (not at a getter). Test in dr11b.
+
+Rationale: Lightbend documents calling `resolveWith` with an unresolved source as a bug-condition. Making this a normative MUST avoids cross-impl divergence on a corner case.
+
+**Behaviour on already-resolved receiver**: `ResolveWith` on a resolved `Config` is a no-op (no substitutions remain to look up). Same idempotency rule as `Resolve()`.
+
+`IsResolved()` returns `false` if any substitution placeholder remains in the value tree (whole-config granularity, matching Lightbend; no per-value `isResolved`).
+
+### Getters on unresolved Config
+
+Reading any path whose value (or any transitive parent's value) contains an unresolved substitution placeholder returns the language-idiomatic `NotResolved` error.
+
+`AllowUnresolved=true` does NOT make getters lenient — it only makes `Resolve()` itself non-erroring. Paths that resolve cleanly are returned; paths that don't error at getter call. Matches Lightbend.
+
+**Required substitution under `AllowUnresolved=true`**: `${foo}` (required, not `${?foo}`) that cannot be resolved does NOT raise at `Resolve()` time when `AllowUnresolved=true`. It survives as a placeholder. A subsequent getter on its path raises `NotResolved`. The fact that the substitution was *required* (vs optional) is preserved on the placeholder — used only for diagnostic messages.
+
+**Optional substitution under `AllowUnresolved=true`**: `${?foo}` that cannot be resolved is **resolved to "missing"** (the same way it would under `AllowUnresolved=false`) — optional semantics already define the "missing" outcome, so there is no remaining substitution to defer. This matches Lightbend.
+
+### Optional substitution materialisation in concat contexts
+
+Per HOCON.md §Substitutions L626–L645 + §Concatenation L387–L441, when an optional `${?foo}` is undefined, the materialised value depends on the surrounding concat context. Normative rules:
+
+| Context | Undefined `${?foo}` materialises as | Example | Result |
+|---|---|---|---|
+| Standalone field value | Field is **omitted** from parent object | `a = ${?x}` (x undef) | `{}` (no `a` key) |
+| String concat | Empty string | `a = ${?x} "tail"` | `a = " tail"` (leading space preserved per HOCON whitespace rules) |
+| String concat (multiple optional, all undef) | Empty string; if entire value is empty, field is omitted | `a = ${?x}${?y}` (both undef) | `{}` (no `a` key) |
+| Array concat | Empty array (no elements contributed) | `a = ${?x} [1,2]` (x undef) | `a = [1,2]` |
+| Object merge | Empty object (no keys contributed) | `a = ${?x} { k = 1 }` (x undef) | `a = { k = 1 }` |
+| Type-mixed concat (e.g. `${?x}` between string and array) | Type-determined: empty string for string-context, empty array for array-context — disambiguation per s10 (concat type-check) rules | `a = "p" ${?x} [1]` | s10 type error (string + array, not compatible) — `${?x}` does not bridge incompatible types |
+
+**Under `AllowUnresolved=true`** with required `${foo}` in concat: the concat survives as a partial concat-placeholder per § "s10 × AllowUnresolved". The placeholder records the optional/required status of each operand. Getter behaviour matches the standalone case: `NotResolved` error.
+
+Fixtures dr24–dr28 cover these cases (see updated inventory).
+
+---
+
+## Per-impl naming
+
+Lightbend names are the reference. Each impl adopts the language-idiomatic form:
+
+| Lightbend (Java) | Go (`hocon` pkg) | TS (`@o3co/hocon`) | Rust (`hocon` crate) |
+|---|---|---|---|
+| `ConfigFactory.parseString(s)` | `hocon.ParseString(s)` | `parseString(s)` (or `parse(s)`) | `hocon::parse(s)` |
+| `(opts variant)` | `hocon.ParseStringWithOptions(s, opts)` | `parseString(s, opts)` | `hocon::parse_with_options(s, opts)` |
+| `ConfigParseOptions` | `hocon.ParseOptions` (struct) | `ParseOptions` (interface) | `hocon::ParseOptions` (struct) |
+| `ConfigResolveOptions` | `hocon.ResolveOptions` | `ResolveOptions` | `hocon::ResolveOptions` |
+| `Config.withFallback` | `(*Config).WithFallback` | `Config.withFallback` | `Config::with_fallback` |
+| `Config.resolve()` | `(*Config).Resolve(opts)` | `Config.resolve(opts?)` | `Config::resolve(&self, opts)` |
+| `Config.resolveWith(src)` | `(*Config).ResolveWith(src, opts)` | `Config.resolveWith(src, opts?)` | `Config::resolve_with(&self, src, opts)` |
+| `Config.isResolved()` | `(*Config).IsResolved()` | `Config.isResolved()` | `Config::is_resolved(&self)` |
+| `ConfigValueFactory.fromMap(m, origin)` | `hocon.FromMap(m, originDescription)` | `fromMap(m, originDescription?)` | `hocon::from_map(m, origin)` |
+| `ConfigFactory.empty()` | `hocon.Empty(originDescription)` | `empty(originDescription?)` | `hocon::empty(origin)` |
+
+**Public-API self-check (per CLAUDE.md "公開 API 面トリガー")**:
+
+Each new identifier is a responsibility name pinned by Lightbend reference; future implementations of the responsibility will not invalidate the name:
+
+- `ParseOptions` / `ResolveOptions` — responsibility = "options for parse/resolve". Stable beyond current options set.
+- `WithFallback` — responsibility = "compose with fallback". Stable; matches Lightbend.
+- `Resolve` / `ResolveWith` — responsibility = "resolve substitutions"; `ResolveWith` distinguishes external-source variant. Stable.
+- `IsResolved` — responsibility = "report resolution completeness". Stable.
+- `FromMap` — responsibility = "construct Config from in-memory map (plain keys)". Stable; matches Lightbend `ConfigValueFactory.fromMap`.
+- `Empty` — responsibility = "empty Config with optional origin". Stable.
+
+No "minimal-implementation" naming used. All identifiers are Lightbend-pinned responsibility names.
+
+---
+
+## Cross-spec interactions
+
+### s13a (self-reference lookback) × WithFallback
+
+S13a defines that `${?a}` inside the definition of `a` looks at the **prior value** of `a`. The "prior value" semantic must extend to merged trees:
+
+> After `WithFallback`, the receiver's definition of `a` (if any) is the "current" value, and the fallback's definition of `a` is the "prior value" for self-reference lookback purposes within the receiver's `a` definition.
+
+Edge cases:
+
+1. Receiver has `a = ${?a} extra`, fallback has `a = base`. After merge + resolve: `a = "base extra"`.
+2. Receiver has `a = ${?a} extra`, fallback has no `a`. After merge + resolve: `a = " extra"` (optional self-ref to undefined → empty per S13a).
+3. Receiver has `a = ${a} extra` (required, not optional), fallback has `a = base`. After merge + resolve: `a = "base extra"`. (Required self-ref resolves successfully because the fallback layer supplies the prior value.)
+4. Receiver has `a = ${a} extra`, fallback has no `a`. After merge + resolve: **error** (required self-ref with no prior value, per S13a).
+
+**Spec text addition**: s13a's lookback algorithm walks merged tree, not just current-source AST. This is consistent with HOCON.md §Substitutions (L608–614: "evaluate to the merged object, or the last non-object value"), but our s13a spec implicitly assumed single-source. Add a clarifying paragraph.
+
+**Action**: amend `2026-05-17-s13a-self-ref-lookback-design.md` with a new "Self-reference across fallback layers" section. No new S-item or E-item; this is a clarification within s13a.
+
+### s10 (concat type-check) × AllowUnresolved
+
+S10 type-checks value concatenations during resolve:
+
+- `a = "str" 42` → string concat ("str42")
+- `a = [1,2] [3,4]` → array concat
+- `a = "str" [1,2]` → type error
+- `a = ${foo} [1,2]` → type-check depends on `${foo}` resolution
+
+Under `AllowUnresolved=true`, `${foo}` may not resolve. The concat type-check must:
+
+- **Resolved operands present**: type-check fires if at least one operand's type is determined.
+- **All operands unresolved**: no type-check; concat remains as concat-placeholder. Getter on this path → `NotResolved`.
+- **Mixed operands, types compatible**: concat succeeds for the resolved portion; placeholder remains for unresolved portion. Getter → `NotResolved`.
+- **Mixed operands, types incompatible**: type-error fires immediately (e.g. `a = ${foo} [1,2]` where `${foo}` resolves to a string → type error even under `AllowUnresolved`).
+
+Rationale: `AllowUnresolved` defers *missing-value* errors, not *type* errors. A type error is structurally invalid regardless of resolution status.
+
+**Action**: amend `2026-05-17-s10-concat-type-check-design.md` with a new "Type-check under AllowUnresolved" section.
+
+### E11 (`include package(...)`) × parse phase
+
+E11 specifies `include package("<id>", "<file>")` as a service-locator include resolver. Per OQ-9, all includes (including E11 package includes) are resolved at parse phase. This means:
+
+- A parse-only result (`ParseStringWithOptions(... ResolveSubstitutions:false)`) has all `include` directives — including `package(...)` — fully expanded.
+- Substitutions inside an included file are deferred along with the outer substitutions.
+
+**Spec text**: E12 explicitly references E11 and states "include resolution is a parse-phase operation. Deferred substitution resolution does not defer include resolution."
+
+No amendment to E11 needed; E12 just cross-references.
+
+---
+
+## Error types
+
+Each impl defines a `NotResolved` error idiomatic to the language:
+
+| Impl | Error | Where raised |
+|---|---|---|
+| Go | `var ErrNotResolved = errors.New(...)` (sentinel); wrapped via `fmt.Errorf("%w: path=%s", ErrNotResolved, path)` | `(*Config).GetString` etc. on unresolved value |
+| TS | `class NotResolvedError extends Error { path: string }` | getter call |
+| Rust | `ConfigError::NotResolved { path: String, origin: Origin }` | getter call |
+
+Existing resolution-time errors (`ResolveError` etc.) remain unchanged; they fire from `Resolve()` when `AllowUnresolved=false` and a substitution can't be resolved.
+
+---
+
+## Origin preservation
+
+Each `ConfigValue` (and each substitution placeholder) carries an `Origin` (file, line, column) per Lightbend. Origin survives:
+
+- Parse → unresolved tree: ✓ already preserved by all three impls.
+- WithFallback merge: each merged value retains its origin from the source layer. For object-merge, child values retain their source-layer origin; the parent object's origin is the receiver's. **Action**: verify in each impl during plan execution.
+- Resolve: resolved value adopts the resolution-time origin (the value the substitution resolved to). Substitution placeholder's origin is preserved on the resulting value's `Origin` chain (Lightbend uses an origin-comment chain).
+
+Error messages MUST include the relevant `Origin`. Verified against issue #99 acceptance criterion "error messages after explicit `Resolve` still preserve useful source path, line, and column information."
+
+---
+
+## Conformance levels
+
+Per RFC 2119 / `extra-spec-conventions.md` convention:
+
+| Item | Level | Notes |
+|---|---|---|
+| Existing `ParseString`/`ParseFile` parse+resolve | MUST | Backward compatibility. |
+| `ParseStringWithOptions(s, ParseOptions{ResolveSubstitutions:false})` returns unresolved | MUST | Core feature. |
+| `WithFallback` accepts unresolved operands | MUST | Required for issue #99 use case. |
+| `Resolve(ResolveOptions{})` defaults match Lightbend (`UseSystemEnvironment=true`, `AllowUnresolved=false`) | MUST | |
+| `Resolve` with `UseSystemEnvironment=false` does not consult env | MUST | Hermetic mode required by issue. |
+| `Resolve` with `AllowUnresolved=true` does not error on unresolved | MUST | Required by issue. |
+| `IsResolved()` reports completeness accurately | MUST | |
+| Getters on unresolved → `NotResolved` error | MUST | Lightbend-aligned. |
+| `FromMap(values, origin)` accepts plain-key map | MUST | Lightbend `ConfigValueFactory.fromMap`. |
+| `Empty(origin)` | SHOULD | Convenience; trivial. |
+| Transitive substitution (`a=${b}`, `b=${c}`, `c=1`) resolves to `a=1` | MUST | Per § "Transitive substitution resolution". |
+| Hidden substitution in overridden value not evaluated | MUST | Per § "Hidden substitutions are not evaluated". |
+| Optional `${?foo}` materialisation in concat contexts per § "Optional substitution materialisation in concat contexts" | MUST | Cross-impl divergence risk; explicit normative table. |
+| `ResolveWith` with unresolved source errors with `NotResolved` | MUST | Per § ResolveWith precondition. |
+| `ResolveWith(source, opts)` distinguishes from `WithFallback().Resolve()` | MUST in go.hocon (issue origin); MAY in ts/rs v1 | Follow-on PR ok for ts/rs. |
+| Origin preserved through merge + resolve | MUST | |
+| s13a lookback walks merged tree | MUST | Cross-spec interaction. |
+| s10 type-check under `AllowUnresolved=true` per § "s10 × AllowUnresolved" | MUST | Cross-spec interaction. |
+| Custom resolver chain (Lightbend `appendResolver`) | OUT OF SCOPE v1 | Future E-item if needed. |
+| Path-expression `parseMap` (Lightbend `ConfigFactory.parseMap`) | OUT OF SCOPE v1 | Future. |
+
+---
+
+## Fixture / test design
+
+### Cross-impl conformance test design
+
+Two-layer test strategy:
+
+**Layer 1 — programmatic per-impl tests** (each impl owns):
+
+- 3 impl test directories each gain a `deferred-resolution/` test file:
+  - `repos/go.hocon/deferred_resolution_test.go`
+  - `repos/ts.hocon/tests/deferred-resolution.test.ts`
+  - `repos/rs.hocon/tests/conformance_deferred_resolution.rs`
+- Each test programmatically constructs (parse → fallback → resolve) scenarios via the public API. Assertions check resolved values, `IsResolved()`, getter-on-unresolved error, etc.
+
+**Layer 2 — xx.hocon scenario fixtures** (shared spec):
+
+- New `testdata/hocon/deferred-resolution/` directory with **scenario YAML files** (not raw .conf):
+
+  ```yaml
+  # dr01-basic-fallback.yaml
+  layers:
+    - source: |
+        version = ${shortversion}-${CI_RUN_NUMBER}
+        variables { shortversion = "1.2.3" }
+      role: receiver
+    - fromMap:
+        CI_RUN_NUMBER: "42"
+      role: fallback
+    - fromConfig: receiver.variables
+      role: fallback
+  resolve:
+    allowUnresolved: false
+    useSystemEnvironment: false
+  expected:
+    version: "1.2.3-42"
+  ```
+
+- Each per-impl test loads the scenario YAML and exercises the public API. The YAML schema is language-agnostic.
+
+- Java generator: **Lightbend ground truth via generator**. The Java generator (`generate/`) gains a `runDeferredScenario(scenario)` helper that executes the scenario through Lightbend's `ConfigFactory.parseString` + `withFallback` + `resolve` chain and emits the expected JSON. This makes xx.hocon fixtures Lightbend-verified the same way other fixtures are.
+
+### Fixture inventory (30 scenarios)
+
+| ID | Scenario |
+|---|---|
+| dr01 | Basic fallback (issue #99 example) |
+| dr02 | FromMap-only fallback (no receiver-side var) |
+| dr03 | Multi-layer fallback (3+ layers) |
+| dr04 | Self-reference across fallback (`a = ${?a} extra` + fallback `a = base`) |
+| dr05 | Required self-reference with fallback prior |
+| dr06 | Required self-reference without fallback prior → error |
+| dr07 | AllowUnresolved=true partial resolution |
+| dr08 | UseSystemEnvironment=false ignores process env |
+| dr09 | Getter on unresolved → NotResolved error |
+| dr10 | WithFallback non-object override (`obj.WithFallback(num).WithFallback(otherObj)` ignores otherObj) |
+| dr11a | ResolveWith vs WithFallback().Resolve(): source keys present in latter, absent in former |
+| dr11b | ResolveWith with unresolved source → NotResolved error (MUST per § ResolveWith precondition) |
+| dr12 | Origin preserved through merge + resolve (error message includes source position) |
+| dr13 | Type-check under AllowUnresolved (type error fires even when partial — incompatible operand types) |
+| dr14 | Type-check under AllowUnresolved (deferred concat-placeholder for fully-unresolved) |
+| dr15 | Include + deferred resolve (include already expanded; only `${...}` deferred) |
+| dr16 | FromMap nested coercion (scalars, lists, nested maps) |
+| dr17 | E11 `include package(...)` + deferred resolve (package resolved at parse, substitutions inside deferred) |
+| dr18 | Cross-layer cycle (receiver `a = ${b}`, fallback `b = ${a}`) → error |
+| dr19 | Resolve idempotency (`c.Resolve().Resolve()` yields equivalent Config) |
+| dr20 | Transitive substitution within single source (`a = ${b}`, `b = ${c}`, `c = 1`) → `a = 1` |
+| dr21 | Transitive substitution across fallback layers (`a = ${b}` in receiver, `b = ${c}` in fallback₁, `c = 1` in fallback₂) → `a = 1` |
+| dr22 | Hidden unresolved within single source (`foo = ${does-not-exist}` then `foo = 42`) → `{foo: 42}` no error |
+| dr23 | Hidden unresolved across fallback layers (receiver `foo = 42`, fallback `foo = ${does-not-exist}`) → `{foo: 42}` no error |
+| dr24 | Optional `${?x}` standalone, undefined → field omitted |
+| dr25 | Optional `${?x}` in string concat, undefined → empty-string contribution |
+| dr26 | Optional `${?x}` in array concat, undefined → empty-array contribution |
+| dr27 | Optional `${?x}` in object merge, undefined → empty-object contribution |
+| dr28 | Multiple optional `${?x}${?y}` all undefined → field omitted |
+| dr29 | Empty config edge cases: `Empty().Resolve()`, `c.WithFallback(Empty())`, `Empty().WithFallback(c)` |
+| dr30 | Object-merge barrier: receiver-non-object blocks fallback-object (`receiver.a = 42`, `fallback.a = {k: 1}`) → `{a: 42}` (Lightbend non-object override semantic) |
+
+---
+
+## Per-impl placement (preliminary)
+
+### go.hocon
+
+**Files touched**:
+- `hocon.go`: add `ParseStringWithOptions`, `ParseFileWithOptions`, `FromMap`, `FromAnyRef`, `Empty`.
+- `option.go`: add `ParseOptions`, `ResolveOptions` (separate from existing generic `Option[T]` monad).
+- `config.go`: extend `Config` to hold either resolved or unresolved tree (tagged union with `resolved bool` flag), add `Resolve`, `ResolveWith`, `IsResolved`, modify `WithFallback` to handle unresolved.
+- `errors.go`: add `ErrNotResolved`.
+- `internal/resolver/resolver.go`: split `Resolve()` into "build unresolved tree" + "resolve substitutions" entry points (already separated internally; needs public hooks).
+
+**Tear point**: `parseWith()` in `hocon.go:33-55`. Currently calls `parser.Parse(input)` then `resolver.Resolve(ast, opts)`. New path: when `ParseOptions.ResolveSubstitutions=false`, return `Config{root: unresolvedAST, resolved: false}`. `Resolve()` then calls `resolver.Resolve` with the stored AST + merged fallback.
+
+**Test**: `s99_deferred_resolution_test.go` (issue-tracked test file naming convention).
+
+**Release**: v1.4.0 (minor, new public API). Lands AFTER go.hocon v1.3.1 (#100 fix) ships, per release-hygiene workflow.
+
+### ts.hocon
+
+**Files touched**:
+- `src/index.ts`: export new symbols.
+- `src/parse.ts`: extend `ParseOptions` with `resolveSubstitutions?: boolean`. When false, return `Config` wrapping `ResObj` directly.
+- `src/config.ts`: `Config` class gains `resolve(opts?)`, `resolveWith(source, opts?)`, `isResolved()`. Extend `withFallback` to handle unresolved.
+- `src/value-factory.ts` (new): `fromMap`, `fromAnyRef`, `empty`.
+- `src/errors.ts`: add `NotResolvedError`.
+- `src/resolver.ts`: split `StructureBuilder` + `SubstitutionResolver` execution into explicit phases.
+
+**Tear point**: `resolver.ts:9-11` (StructureBuilder → SubstitutionResolver seam). Wrap `ResObj` as `Config` directly when `resolveSubstitutions=false`; defer `SubstitutionResolver` until `.resolve()` call.
+
+**Test**: `tests/deferred-resolution.test.ts`.
+
+**Release**: v1.X.0 (minor). Coordinate version number after current ts.hocon release cadence.
+
+### rs.hocon
+
+**Files touched**:
+- `src/lib.rs`: add `parse_with_options`, `parse_file_with_options`, `from_map`, `from_any_ref`, `empty`. Export `ParseOptions`, `ResolveOptions`.
+- `src/config.rs`: `Config` gains `resolve(&self, opts)`, `resolve_with(&self, src, opts)`, `is_resolved(&self)`. Extend `with_fallback` to handle unresolved.
+- `src/value_factory.rs` (new): `from_map`, `from_any_ref`, `empty`.
+- `src/error.rs`: add `ConfigError::NotResolved` variant.
+- `src/resolver/mod.rs`: split phase 1 / phase 2 with explicit entry points.
+
+**Tear point**: `resolver/mod.rs:18-21`. Currently `StructureBuilder::build(ast)` immediately followed by `SubstitutionResolver::new(...).resolve()`. New path: return `Config` wrapping the unresolved tree when `parse_options.resolve_substitutions=false`.
+
+**API surface concern**: `StructureBuilder` and `SubstitutionResolver` are `pub(crate)`. Keep them crate-private; expose only `Config` with the new methods. Internal `ResObj` does NOT become public.
+
+**Test**: `tests/conformance_deferred_resolution.rs`.
+
+**Release**: v1.X.0 (minor).
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Merge of substitution placeholders breaks origin tracking | Medium | dr12 fixture explicitly tests origin preservation. Verify each impl during plan execution. |
+| `WithFallback` semantic change (extension) silently breaks existing callers | Low | Extension is additive: existing callers pass resolved configs and get current behaviour. Only new (unresolved) operands invoke new merge path. |
+| s13a lookback algorithm regression on merged tree | Medium | dr04–dr06 fixtures cover the cross-impl scenarios. Cross-link to s13a spec. |
+| Concat type-check under AllowUnresolved corner case missed | Medium | dr13/dr14 cover. Lightbend behaviour must be verified during plan (typesafe-config 1.4.3 test fixture). |
+| Origin preservation in merge: which layer's origin wins for parent object? | Low | Spec text already pins: receiver's origin for parent, source-layer's origin for child. Lightbend mirrors. |
+| Custom resolver chain demand emerges late, forcing breaking add | Low | Future E-item. `ResolveOptions` struct can gain field non-breakingly. |
+| Go `uint64` overflow at FromMap call: silent corruption vs error | Low | Spec mandates error. Test in dr16. |
+| TS `bigint` users complain about v1 omission | Low | Document v1 scope; track as follow-on. |
+
+---
+
+## Out of scope (deferred)
+
+1. **`FromAnyRef` + public `ConfigValue` type** (Lightbend `ConfigValueFactory.fromAnyRef` returning scalar/list/object roots). Requires a separate spec that defines the public `ConfigValue` surface (getters, rendering, `WithFallback` for non-object roots, `IsResolved` for scalar roots). v1 ships `FromMap` (object-root only).
+2. **Custom resolver chain** (Lightbend `ConfigResolveOptions.appendResolver`). v1 ResolveOptions only has `UseSystemEnvironment` and `AllowUnresolved`. Future E-item if user demand surfaces.
+3. **Path-expression `parseMap`** (Lightbend `ConfigFactory.parseMap`). v1 has `FromMap` (plain keys) only.
+4. **Other `ConfigParseOptions` fields**: `setAllowMissing`, `setIncluder`, `setClassLoader`, `setSyntax`. Each is a separate follow-on.
+5. **`Config.atPath(p)` / `Config.atKey(k)`** (Lightbend wrappers): not in issue #99. Future.
+6. **`ConfigResolver` interface** (pluggable external resolvers): tied to #2, future.
+7. **Default-loading-chain replication** (Lightbend `ConfigFactory.load()` with reference.conf / application.conf): platform-specific, future.
+8. **JSON / properties parsing entry points**: HOCON.md mentions JSON is a subset; explicit JSON/properties parse APIs are Lightbend conveniences. Future.
+
+---
+
+## Success criteria
+
+- All three impls expose the public surface defined in § "Public API surface".
+- All MUST conformance levels pass in all three impls.
+- All `dr01`–`dr30` fixtures pass in all three impls via Layer-1 + Layer-2 tests.
+- Lightbend ground truth verified for all fixtures via Java generator.
+- `compliance-matrix.md` reflects: no S-item changes (E12 doesn't affect spec-total denominator); E12 entry added.
+- Issue go.hocon#99 closed with reference to xx.hocon tracking issue + go.hocon v1.4.0 release.
+
+---
+
+## Open questions for follow-on
+
+These are deferred — not blocking spec ★1 — but flagged for future specs / refinement:
+
+1. **Custom resolver chain**: confirm with cgordon and other downstream users whether Lightbend's `appendResolver` (1.3.2+) is a demanded feature. Track as candidate E-item.
+2. **`ConfigParseOptions.setIncluder`**: enables custom include resolution. Likely demanded once E11 lands and users want to plug their own resolvers. Track as candidate E-item or part of include refactor.
+3. **TS `bigint`** support in `FromAnyRef`. Track as follow-on tied to broader number-precision spec.
+4. **`Config.atPath` / `atKey`**: Lightbend convenience wrappers. Tied to value-tree access patterns, candidate for separate spec.
+
+---
+
+## Rollout plan (after ★1 approval)
+
+1. **xx.hocon spec PR**: append E12 to `docs/extra-spec-conventions.md`, add s13a/s10 amendments, add `testdata/hocon/deferred-resolution/` fixture scenarios + Java generator support. Track at xx.hocon#TBD.
+2. **go.hocon impl PR** (after #100 v1.3.1 release): full E12 conformance + v1.4.0 release. Closes go.hocon#99.
+3. **ts.hocon impl PR**: full conformance (MAY items: `ResolveWith` may slip to follow-on).
+4. **rs.hocon impl PR**: full conformance (MAY items: `ResolveWith` may slip to follow-on).
+5. **xx.hocon compliance-matrix.md re-roll**: add E12 row, no S-item denominator change.
+
+Per `overnight-worktree-spec-pattern`, the spec PR is C1+C5 (spec + fixtures) and the impl PRs are C2/C6, C3/C7, C4/C8 (one cluster per impl).

--- a/errors.go
+++ b/errors.go
@@ -15,15 +15,20 @@ import (
 
 // ParseError is returned when lexing or parsing fails.
 type ParseError struct {
-	Message  string
-	Line     int
-	Col      int
-	FilePath string // non-empty when inside an include file
+	Message           string
+	Line              int
+	Col               int
+	FilePath          string // non-empty when inside an include file
+	OriginDescription string // E12: user-supplied label when no FilePath available
 }
 
 func (e *ParseError) Error() string {
-	if e.FilePath != "" {
-		return fmt.Sprintf("parse error in %s at line %d, col %d: %s", e.FilePath, e.Line, e.Col, e.Message)
+	src := e.FilePath
+	if src == "" {
+		src = e.OriginDescription
+	}
+	if src != "" {
+		return fmt.Sprintf("parse error in %s at line %d, col %d: %s", src, e.Line, e.Col, e.Message)
 	}
 	if e.Line > 0 {
 		return fmt.Sprintf("parse error at line %d, col %d: %s", e.Line, e.Col, e.Message)
@@ -33,16 +38,27 @@ func (e *ParseError) Error() string {
 
 // ResolveError is returned when resolution fails (substitution, include, circular ref).
 type ResolveError struct {
-	Message  string
-	Path     string // HOCON substitution path e.g. "server.host"
-	Line     int    // source line where the substitution appears (0 if unavailable)
-	Col      int
-	FilePath string // file path when resolving an include
+	Message           string
+	Path              string // HOCON substitution path e.g. "server.host"
+	Line              int    // source line where the substitution appears (0 if unavailable)
+	Col               int
+	FilePath          string // file path when resolving an include
+	OriginDescription string // E12: user-supplied label when no FilePath available
 }
 
 func (e *ResolveError) Error() string {
+	src := e.FilePath
+	if src == "" {
+		src = e.OriginDescription
+	}
 	if e.Path != "" {
+		if src != "" {
+			return fmt.Sprintf("resolve error in %s at path %q: %s", src, e.Path, e.Message)
+		}
 		return fmt.Sprintf("resolve error at path %q: %s", e.Path, e.Message)
+	}
+	if src != "" {
+		return fmt.Sprintf("resolve error in %s: %s", src, e.Message)
 	}
 	return fmt.Sprintf("resolve error: %s", e.Message)
 }

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,10 @@
 
 package hocon
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ParseError is returned when lexing or parsing fails.
 type ParseError struct {
@@ -58,3 +61,10 @@ func (e *ConfigError) Error() string {
 func panicConfig(path, msg string) {
 	panic(&ConfigError{Path: path, Message: msg})
 }
+
+// ErrNotResolved is the sentinel returned (wrapped) when a getter is called on
+// a Config path whose value (or any transitive parent) contains an unresolved
+// substitution placeholder.  E12 § "Getters on unresolved Config" pins this
+// as a MUST.  Wrap via fmt.Errorf("...: %w", ErrNotResolved, ...) so callers
+// can use errors.Is(err, hocon.ErrNotResolved).
+var ErrNotResolved = errors.New("config: value is not resolved (call Resolve() first)")

--- a/errors.go
+++ b/errors.go
@@ -51,10 +51,16 @@ func (e *ResolveError) Error() string {
 type ConfigError struct {
 	Message string
 	Path    string // HOCON access path e.g. "server.host"
+	cause   error  // underlying sentinel (e.g. ErrNotResolved) for errors.Is
 }
 
 func (e *ConfigError) Error() string {
 	return fmt.Sprintf("config error at path %q: %s", e.Path, e.Message)
+}
+
+// Unwrap returns the underlying cause for errors.Is / errors.As.
+func (e *ConfigError) Unwrap() error {
+	return e.cause
 }
 
 // panicConfig panics with a ConfigError.

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,7 @@ package hocon_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -42,6 +43,16 @@ func TestParseError_IsError(t *testing.T) {
 	var target *hocon.ParseError
 	if !errors.As(err, &target) {
 		t.Fatal("errors.As failed for ParseError")
+	}
+}
+
+func TestErrNotResolved_Sentinel(t *testing.T) {
+	if hocon.ErrNotResolved == nil {
+		t.Fatal("ErrNotResolved must be defined as a sentinel")
+	}
+	wrapped := fmt.Errorf("getter at path %q: %w", "foo.bar", hocon.ErrNotResolved)
+	if !errors.Is(wrapped, hocon.ErrNotResolved) {
+		t.Fatal("errors.Is must match ErrNotResolved through wrapping")
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon
+
+// TestRenderJSON exposes the private renderJSON method for use by external
+// test files (deferred_resolution_test.go, deferred_resolution_fixture_test.go).
+// Lives in *_test.go so it is not compiled into the public binary.
+func RenderJSON_ForTest(c *Config) (string, error) {
+	return c.renderJSON()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/o3co/go.hocon
 go 1.23.0
 
 retract v0.1.0 // released before LICENSE was added
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hocon.go
+++ b/hocon.go
@@ -55,7 +55,7 @@ func parseWith(input, filePath string) (*Config, error) {
 	if err != nil {
 		return nil, wrapResolveError(err)
 	}
-	return &Config{root: res.Root}, nil
+	return newConfig(res.Root), nil
 }
 
 func dirOf(path string) string {

--- a/hocon.go
+++ b/hocon.go
@@ -16,21 +16,40 @@ import (
 	"github.com/o3co/go.hocon/internal/resolver"
 )
 
-// ParseString parses a HOCON string and returns a Config.
+// ParseString parses a HOCON string and returns a fully resolved Config.
+// Equivalent to ParseStringWithOptions(input, DefaultParseOptions()).
 func ParseString(input string) (*Config, error) {
-	return parseWith(input, "")
+	return parseWithOptions(input, "", DefaultParseOptions())
 }
 
-// ParseFile parses a HOCON file and returns a Config.
+// ParseFile parses a HOCON file and returns a fully resolved Config.
+// Equivalent to ParseFileWithOptions(path, DefaultParseOptions()).
 func ParseFile(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, &ParseError{Message: err.Error(), FilePath: path}
 	}
-	return parseWith(string(data), path)
+	return parseWithOptions(string(data), path, DefaultParseOptions())
 }
 
-func parseWith(input, filePath string) (*Config, error) {
+// ParseStringWithOptions parses a HOCON string and returns a Config that is
+// either fully resolved (opts.ResolveSubstitutions()=true, default) or possibly
+// unresolved (opts.ResolveSubstitutions()=false).  See E12 for the deferred-
+// resolution lifecycle.
+func ParseStringWithOptions(input string, opts ParseOptions) (*Config, error) {
+	return parseWithOptions(input, "", opts)
+}
+
+// ParseFileWithOptions parses a HOCON file and returns a Config per opts.
+func ParseFileWithOptions(path string, opts ParseOptions) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, &ParseError{Message: err.Error(), FilePath: path}
+	}
+	return parseWithOptions(string(data), path, opts)
+}
+
+func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error) {
 	ast, err := parser.Parse(input)
 	if err != nil {
 		pe := &ParseError{FilePath: filePath}
@@ -48,14 +67,29 @@ func parseWith(input, filePath string) (*Config, error) {
 	if filePath != "" {
 		baseDir = dirOf(filePath)
 	}
-	res, err := resolver.Resolve(ast, resolver.Options{
-		BaseDir:       baseDir,
-		PackageLookup: globalRegistry.lookup, // E11: inject global package registry
-	})
+	resolveOpts := resolver.Options{
+		BaseDir:              baseDir,
+		PackageLookup:        globalRegistry.lookup,
+		UseSystemEnvironment: true, // fused path: env always available; ResolveOptions gates phase 2 separately when called.
+	}
+	if opts.ResolveSubstitutions() {
+		// Existing fused path: phase 1 + phase 2 via resolver.Resolve.
+		res, err := resolver.Resolve(ast, resolveOpts)
+		if err != nil {
+			return nil, wrapResolveError(err)
+		}
+		c := newConfig(res.Root)
+		c.parseBaseDir = baseDir
+		c.originDescription = opts.OriginDescription()
+		return c, nil
+	}
+	// Deferred path: phase 1 only.  Includes are fully expanded; substitutions
+	// remain as placeholders.
+	tree, err := resolver.BuildTree(ast, resolveOpts)
 	if err != nil {
 		return nil, wrapResolveError(err)
 	}
-	return newConfig(res.Root), nil
+	return newUnresolvedConfig(tree, baseDir, opts.OriginDescription()), nil
 }
 
 func dirOf(path string) string {

--- a/hocon.go
+++ b/hocon.go
@@ -50,6 +50,9 @@ func ParseFileWithOptions(path string, opts ParseOptions) (*Config, error) {
 }
 
 func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error) {
+	if !opts.initialized {
+		opts = DefaultParseOptions()
+	}
 	ast, err := parser.Parse(input)
 	if err != nil {
 		pe := &ParseError{FilePath: filePath}

--- a/hocon.go
+++ b/hocon.go
@@ -53,6 +53,9 @@ func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error
 	ast, err := parser.Parse(input)
 	if err != nil {
 		pe := &ParseError{FilePath: filePath}
+		if filePath == "" {
+			pe.OriginDescription = opts.OriginDescription()
+		}
 		var parserErr *parser.Error
 		if errors.As(err, &parserErr) {
 			pe.Message = parserErr.Message
@@ -76,7 +79,11 @@ func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error
 		// Existing fused path: phase 1 + phase 2 via resolver.Resolve.
 		res, err := resolver.Resolve(ast, resolveOpts)
 		if err != nil {
-			return nil, wrapResolveError(err)
+			wrapped := wrapResolveError(err)
+			if re, ok := wrapped.(*ResolveError); ok && re.FilePath == "" {
+				re.OriginDescription = opts.OriginDescription()
+			}
+			return nil, wrapped
 		}
 		c := newConfig(res.Root)
 		c.parseBaseDir = baseDir
@@ -87,7 +94,11 @@ func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error
 	// remain as placeholders.
 	tree, err := resolver.BuildTree(ast, resolveOpts)
 	if err != nil {
-		return nil, wrapResolveError(err)
+		wrapped := wrapResolveError(err)
+		if re, ok := wrapped.(*ResolveError); ok && re.FilePath == "" {
+			re.OriginDescription = opts.OriginDescription()
+		}
+		return nil, wrapped
 	}
 	return newUnresolvedConfig(tree, baseDir, opts.OriginDescription()), nil
 }

--- a/internal/resolver/merge_unresolved_test.go
+++ b/internal/resolver/merge_unresolved_test.go
@@ -95,6 +95,14 @@ func TestMergeUnresolved_NonObjectReceiverBlocksFallbackObject(t *testing.T) {
 	if sv.Raw != "42" {
 		t.Fatalf("expected 42, got %q", sv.Raw)
 	}
+	// Verify the fallback's object was captured as a prior.
+	prior, ok := merged.GetPrior("a")
+	if !ok {
+		t.Fatal("expected fallback object captured as prior")
+	}
+	if _, isObj := prior.(*ObjectVal); !isObj {
+		t.Fatalf("expected prior to be the fallback ObjectVal, got %T", prior)
+	}
 }
 
 func TestMergeUnresolved_ReceiverObjectBlocksFallbackNonObjectMergeOfThirdLayer(t *testing.T) {
@@ -134,5 +142,55 @@ func TestMergeUnresolved_ReceiverObjectBlocksFallbackNonObjectMergeOfThirdLayer(
 	_, hasY := ao.Get("y")
 	if !hasX || !hasY {
 		t.Fatalf("expected deep-merged {x,y}; got x=%v y=%v", hasX, hasY)
+	}
+}
+
+func TestMergeUnresolved_ReceiverOnlyKeyHasNoPrior(t *testing.T) {
+	receiver := NewObjectVal()
+	receiver.Set("a", &ScalarVal{Raw: "only-in-receiver", Type: ScalarString})
+	fallback := NewObjectVal()
+	merged := MergeUnresolved(receiver, fallback)
+	if _, ok := merged.GetPrior("a"); ok {
+		t.Fatal("receiver-only key must not produce a prior (no fallback value to capture)")
+	}
+}
+
+func TestMergeUnresolved_ThreeLayerPreservesEarlierFallbackAsPrior(t *testing.T) {
+	// Composition: r0.M(fb1).M(fb2)
+	// r0:  { a = "rcv" }
+	// fb1: { b = "fb1-only" }            (fb1 contributes b only)
+	// fb2: { b = "fb2-collides-with-fb1" } (fb2 collides with fb1's b)
+	//
+	// After r0.M(fb1): m1.values = { a: "rcv", b: "fb1-only" }, no priors.
+	// After m1.M(fb2): final.values = { a: "rcv", b: "fb1-only" }. fb2's "b"
+	// collides with m1's "b" (which came from fb1 originally). m1's "b" was
+	// NOT in m1's "receiver" (r0 had no "b"), but m1 still owns it. So step 2
+	// captures fb2's "fb2-collides-with-fb1" as the prior for "b".
+	//
+	// Verifies that prior capture works correctly when the "receiver" in a
+	// merge is itself a previously-merged object whose values came from its
+	// fallback.
+	r0 := NewObjectVal()
+	r0.Set("a", &ScalarVal{Raw: "rcv", Type: ScalarString})
+
+	fb1 := NewObjectVal()
+	fb1.Set("b", &ScalarVal{Raw: "fb1-only", Type: ScalarString})
+
+	fb2 := NewObjectVal()
+	fb2.Set("b", &ScalarVal{Raw: "fb2-collides-with-fb1", Type: ScalarString})
+
+	m1 := MergeUnresolved(r0, fb1)
+	final := MergeUnresolved(m1, fb2)
+
+	bv, _ := final.Get("b")
+	if bv.(*ScalarVal).Raw != "fb1-only" {
+		t.Fatalf("expected m1 (receiver in second merge) wins, got %q", bv.(*ScalarVal).Raw)
+	}
+	prior, ok := final.GetPrior("b")
+	if !ok {
+		t.Fatal("expected fb2's value captured as prior for b")
+	}
+	if prior.(*ScalarVal).Raw != "fb2-collides-with-fb1" {
+		t.Fatalf("expected prior 'fb2-collides-with-fb1', got %q", prior.(*ScalarVal).Raw)
 	}
 }

--- a/internal/resolver/merge_unresolved_test.go
+++ b/internal/resolver/merge_unresolved_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+import "testing"
+
+func TestObjectVal_SetPrior(t *testing.T) {
+	o := NewObjectVal()
+	o.Set("a", &ScalarVal{Raw: "current", Type: ScalarString})
+	o.SetPrior("a", &ScalarVal{Raw: "old", Type: ScalarString})
+	prior, ok := o.GetPrior("a")
+	if !ok {
+		t.Fatal("expected prior")
+	}
+	sv := prior.(*ScalarVal)
+	if sv.Raw != "old" {
+		t.Fatalf("expected prior raw 'old', got %q", sv.Raw)
+	}
+}
+
+func TestMergeUnresolved_NonObjectReceiverWinsCapturesFallbackAsPrior(t *testing.T) {
+	// receiver: { a = "current" }
+	// fallback: { a = "old" }
+	// merged:   receiver wins; "old" stored as prior for self-ref lookback.
+	receiver := NewObjectVal()
+	receiver.Set("a", &ScalarVal{Raw: "current", Type: ScalarString})
+
+	fallback := NewObjectVal()
+	fallback.Set("a", &ScalarVal{Raw: "old", Type: ScalarString})
+
+	merged := MergeUnresolved(receiver, fallback)
+
+	v, _ := merged.Get("a")
+	sv := v.(*ScalarVal)
+	if sv.Raw != "current" {
+		t.Fatalf("expected receiver wins (current), got %q", sv.Raw)
+	}
+	prior, ok := merged.GetPrior("a")
+	if !ok {
+		t.Fatalf("expected fallback value captured as prior")
+	}
+	psv := prior.(*ScalarVal)
+	if psv.Raw != "old" {
+		t.Fatalf("expected prior 'old', got %q", psv.Raw)
+	}
+}
+
+func TestMergeUnresolved_ObjectBothRecurses(t *testing.T) {
+	receiver := NewObjectVal()
+	a1 := NewObjectVal()
+	a1.Set("x", &ScalarVal{Raw: "1", Type: ScalarNumber})
+	receiver.Set("a", a1)
+
+	fallback := NewObjectVal()
+	a2 := NewObjectVal()
+	a2.Set("y", &ScalarVal{Raw: "2", Type: ScalarNumber})
+	fallback.Set("a", a2)
+
+	merged := MergeUnresolved(receiver, fallback)
+
+	a, _ := merged.Get("a")
+	ao := a.(*ObjectVal)
+	x, _ := ao.Get("x")
+	y, _ := ao.Get("y")
+	if x.(*ScalarVal).Raw != "1" || y.(*ScalarVal).Raw != "2" {
+		t.Fatalf("expected merged {x:1, y:2}; got x=%v y=%v", x, y)
+	}
+}
+
+func TestMergeUnresolved_NonObjectReceiverBlocksFallbackObject(t *testing.T) {
+	// receiver: { a = 42 }       — non-object
+	// fallback: { a = { y = 2 } } — object; blocked by receiver
+	// merged:   { a = 42 }, fallback object stored as prior.
+	receiver := NewObjectVal()
+	receiver.Set("a", &ScalarVal{Raw: "42", Type: ScalarNumber})
+
+	fallback := NewObjectVal()
+	a := NewObjectVal()
+	a.Set("y", &ScalarVal{Raw: "2", Type: ScalarNumber})
+	fallback.Set("a", a)
+
+	merged := MergeUnresolved(receiver, fallback)
+
+	v, _ := merged.Get("a")
+	if _, isObj := v.(*ObjectVal); isObj {
+		t.Fatalf("expected receiver scalar wins, got object")
+	}
+	sv := v.(*ScalarVal)
+	if sv.Raw != "42" {
+		t.Fatalf("expected 42, got %q", sv.Raw)
+	}
+}
+
+func TestMergeUnresolved_ReceiverObjectBlocksFallbackNonObjectMergeOfThirdLayer(t *testing.T) {
+	// This is the dr10 scenario:
+	//   r0:  { a = { x = 1 } }       object
+	//   fb1: { a = "scalar" }         non-object — barrier
+	//   fb2: { a = { y = 2 } }        object — blocked
+	// MergeUnresolved is binary; the iterative composition is r0.M(fb1).M(fb2).
+	// After r0.M(fb1): merged.a = {x:1}, prior = "scalar".
+	// After that.M(fb2): receiver-a is an object {x:1}, fallback-a is object
+	// {y:2}. They DEEP MERGE per HOCON object-merge rules, producing {x:1, y:2}.
+	// BUT the dr10 spec says fb2's `a = {y:2}` should be blocked. Why?
+	//
+	// Because the dr10 composition is r0.WithFallback(fb1).WithFallback(fb2),
+	// and the spec rule is: "Once a non-object value at a path has barred
+	// merging at that path, subsequent fallback objects at the same path do
+	// not contribute." The barrier is recorded between step 1 and step 2.
+	//
+	// MergeUnresolved is the binary primitive; the barrier-tracking is done
+	// by the caller (Config.WithFallback) via a per-path "barred set". This
+	// test asserts the binary primitive itself: receiver-object + fallback-object
+	// deep-merges (which is correct for the binary call; barrier is upstream).
+	r0 := NewObjectVal()
+	a1 := NewObjectVal()
+	a1.Set("x", &ScalarVal{Raw: "1", Type: ScalarNumber})
+	r0.Set("a", a1)
+
+	fb2 := NewObjectVal()
+	a2 := NewObjectVal()
+	a2.Set("y", &ScalarVal{Raw: "2", Type: ScalarNumber})
+	fb2.Set("a", a2)
+
+	merged := MergeUnresolved(r0, fb2)
+	a, _ := merged.Get("a")
+	ao := a.(*ObjectVal)
+	_, hasX := ao.Get("x")
+	_, hasY := ao.Get("y")
+	if !hasX || !hasY {
+		t.Fatalf("expected deep-merged {x,y}; got x=%v y=%v", hasX, hasY)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -937,16 +937,29 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string, line,
 		}
 	}
 
-	// Classify non-nil, non-separator elements to detect array/object involvement.
+	// Classify non-nil, non-separator elements to detect array/object involvement
+	// and whether any concrete (non-nil, non-separator) value is present.
 	hasArrayOrObject := false
+	hasConcreteValue := false
 	for _, rv := range resolved {
 		if rv == nil || isSeparator(rv) {
 			continue
 		}
+		hasConcreteValue = true
 		switch rv.(type) {
 		case *ArrayVal, *ObjectVal:
 			hasArrayOrObject = true
 		}
+	}
+
+	// Per HOCON spec § "Optional substitution materialisation in concat contexts":
+	// when the entire concat consists only of undefined optional substitutions
+	// (all operands resolved to nil, no real scalar/array/object content),
+	// the field is omitted — return nil so the parent drops this key.
+	// This differs from a mixed concat like `${?x} "tail"` where the separator
+	// and the literal "tail" count as concrete values.
+	if !hasConcreteValue {
+		return nil, nil
 	}
 
 	// Pure-scalar concat: pass the full resolved slice (including whitespace-separator

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -129,10 +129,29 @@ func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
 	for _, k := range receiver.Keys() {
 		rv, _ := receiver.Get(k)
 		if existing, hasExisting := result.values[k]; hasExisting {
-			// both objects → recurse
+			// both objects → recurse, but only when no composition barrier is in effect.
+			// A composition barrier exists when the receiver already has a non-object
+			// priorValues[k] from a previous merge (e.g. r.WithFallback(scalar).WithFallback(obj)):
+			// the scalar in the middle layer bars subsequent object layers from contributing.
+			// HOCON.md §Object Merge L1485 / dr10.
 			if recObj, recOk := rv.(*ObjectVal); recOk {
 				if existObj, existOk := existing.(*ObjectVal); existOk {
-					result.set(k, MergeUnresolved(recObj, existObj))
+					// Check composition barrier: receiver's own prior for k is non-object.
+					barrierActive := false
+					if recPrior, hasPrior := receiver.priorValues[k]; hasPrior {
+						if _, priorIsObj := recPrior.(*ObjectVal); !priorIsObj {
+							barrierActive = true
+						}
+					}
+					if !barrierActive {
+						result.set(k, MergeUnresolved(recObj, existObj))
+						continue
+					}
+					// Barrier active: receiver's object wins; discard fallback's object.
+					// Do NOT update result.priorValues[k] — the existing prior (the scalar)
+					// already represents the barrier and must not be overwritten by the object.
+					_ = existObj // fallback's object is intentionally discarded
+					result.set(k, rv)
 					continue
 				}
 			}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -166,6 +166,14 @@ type Options struct {
 	// E11: child resolvers created during include resolution MUST copy this field from the
 	// parent so that package includes within included files are resolved correctly.
 	PackageLookup func(identifier, file string) ([]byte, error)
+	// UseSystemEnvironment, when false, disables fallback to os.LookupEnv for
+	// unresolved substitution paths (E12 ResolveOptions.UseSystemEnvironment).
+	// Default zero-value is false; the public Config layer must pass true to
+	// preserve current behaviour for fused parseAndResolve.
+	UseSystemEnvironment bool
+	// AllowUnresolved, when true, leaves unresolved (non-optional) substitution
+	// placeholders in place instead of returning a ResolveError (E12 ResolveOptions.AllowUnresolved).
+	AllowUnresolved bool
 }
 
 // ResolveError wraps resolution failures.
@@ -192,8 +200,28 @@ func (e *ResolveError) Unwrap() error {
 	return e.Cause
 }
 
-// Resolve transforms an AST into a fully resolved Result.
+// Resolve transforms an AST into a fully resolved Result. Preserved for
+// backward compatibility — equivalent to BuildTree(...) followed by
+// ResolveTree(...) with UseSystemEnvironment=true (current behaviour).
 func Resolve(root *parser.ObjectNode, opts Options) (*Result, error) {
+	// Phase 1: build tree.
+	tree, err := BuildTree(root, opts)
+	if err != nil {
+		return nil, err
+	}
+	// Phase 2: resolve substitutions. Preserve current behaviour: env is
+	// always consulted for fused parseAndResolve; AllowUnresolved=false.
+	phase2Opts := opts
+	phase2Opts.UseSystemEnvironment = true
+	phase2Opts.AllowUnresolved = false
+	return ResolveTree(tree, phase2Opts)
+}
+
+// BuildTree runs phase 1 — parsing AST into an ObjectVal tree containing
+// substitution/concat placeholders for any unresolved values. Includes are
+// fully expanded (file/url/package). Phase 2 (ResolveTree) replaces the
+// placeholders.
+func BuildTree(root *parser.ObjectNode, opts Options) (*ObjectVal, error) {
 	if opts.BaseDir == "" {
 		wd, err := os.Getwd()
 		if err != nil {
@@ -202,17 +230,72 @@ func Resolve(root *parser.ObjectNode, opts Options) (*Result, error) {
 		opts.BaseDir = wd
 	}
 	stack := make([]string, 0, 8)
-	r := &resolver{opts: opts, resolving: make(map[string]bool), resolvedCache: make(map[string]Val), priorValues: make(map[string]Val), includeStack: &stack}
-	obj, err := r.resolveObject(root, opts.Fallback, nil)
+	r := &resolver{
+		opts:          opts,
+		resolving:     make(map[string]bool),
+		resolvedCache: make(map[string]Val),
+		priorValues:   make(map[string]Val),
+		includeStack:  &stack,
+	}
+	return r.resolveObject(root, opts.Fallback, nil)
+}
+
+// ResolveTree runs phase 2 — replacing substitution and concat placeholders
+// in tree with their resolved values. tree may have been merged from multiple
+// BuildTree results via MergeUnresolved (E12 WithFallback). The opts'
+// UseSystemEnvironment and AllowUnresolved fields control phase-2 behaviour;
+// BaseDir / Fallback / PackageLookup are not consulted (those are phase-1 inputs).
+func ResolveTree(tree *ObjectVal, opts Options) (*Result, error) {
+	r := &resolver{
+		opts:          opts,
+		resolving:     make(map[string]bool),
+		resolvedCache: make(map[string]Val),
+		priorValues:   make(map[string]Val),
+		includeStack:  nil, // not used in phase 2
+		lenient:       opts.AllowUnresolved,
+	}
+	// Re-populate top-level priorValues from the tree (phase 1 stored them on
+	// each ObjectVal; phase 2's self-reference lookback consults both the
+	// per-object map AND the resolver's top-level map).
+	for k, v := range tree.priorValues {
+		r.priorValues[k] = v
+	}
+	out, err := r.resolveSubstitutions(tree, tree)
 	if err != nil {
 		return nil, err
 	}
-	// second pass: resolve substitutions with full object context
-	obj2, err := r.resolveSubstitutions(obj, obj)
-	if err != nil {
-		return nil, err
+	return &Result{Root: out}, nil
+}
+
+// ContainsPlaceholders reports whether any value in the tree is an unresolved
+// substitution or concat placeholder. Used by Config.IsResolved.
+func ContainsPlaceholders(tree *ObjectVal) bool {
+	if tree == nil {
+		return false
 	}
-	return &Result{Root: obj2}, nil
+	for _, k := range tree.Keys() {
+		v, _ := tree.Get(k)
+		if valContainsPlaceholders(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func valContainsPlaceholders(v Val) bool {
+	switch vv := v.(type) {
+	case *substPlaceholder, *concatPlaceholder:
+		return true
+	case *ObjectVal:
+		return ContainsPlaceholders(vv)
+	case *ArrayVal:
+		for _, e := range vv.Elements {
+			if valContainsPlaceholders(e) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type resolver struct {
@@ -604,14 +687,18 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 			return resolved, nil
 		}
 		// Also try env var with original path (raw dot-join, no quoting)
-		if ev, ok := os.LookupEnv(strings.Join(originalStrs, ".")); ok {
-			return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+		if r.opts.UseSystemEnvironment {
+			if ev, ok := os.LookupEnv(strings.Join(originalStrs, ".")); ok {
+				return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+			}
 		}
 	}
 
 	// env var fallback — use raw dot-join (no quoting) to match Lightbend behavior
-	if ev, ok := os.LookupEnv(strings.Join(segStrs, ".")); ok {
-		return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+	if r.opts.UseSystemEnvironment {
+		if ev, ok := os.LookupEnv(strings.Join(segStrs, ".")); ok {
+			return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+		}
 	}
 	if n.Optional {
 		return nil, nil // field will be dropped
@@ -718,6 +805,21 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string, line,
 			return nil, err
 		}
 		resolved = append(resolved, rv)
+	}
+
+	// In lenient (AllowUnresolved) mode, if any resolved element is still a
+	// placeholder, defer the whole concat rather than error or produce a broken
+	// string. The placeholder will be resolved by a subsequent ResolveTree call
+	// (e.g. after WithFallback merges the missing value).
+	if r.lenient {
+		for _, rv := range resolved {
+			if _, isSP := rv.(*substPlaceholder); isSP {
+				return &concatPlaceholder{vals: resolved, line: line, col: col}, nil
+			}
+			if _, isCP := rv.(*concatPlaceholder); isCP {
+				return &concatPlaceholder{vals: resolved, line: line, col: col}, nil
+			}
+		}
 	}
 
 	// Classify non-nil, non-separator elements to detect array/object involvement.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -132,7 +132,7 @@ func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
 			// both objects → recurse
 			if recObj, recOk := rv.(*ObjectVal); recOk {
 				if existObj, existOk := existing.(*ObjectVal); existOk {
-					result.values[k] = MergeUnresolved(recObj, existObj)
+					result.set(k, MergeUnresolved(recObj, existObj))
 					continue
 				}
 			}
@@ -142,14 +142,13 @@ func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
 		}
 		result.set(k, rv)
 	}
-	// 3. Receiver's own priorValues take precedence (in case the same key was
-	//    already a prior on both sides — receiver's history wins).
+	// 3. Receiver's own priorValues take precedence over any priors propagated
+	//    from fallback. This preserves the receiver's full self-reference
+	//    history across iterated WithFallback calls — including priors that
+	//    were installed by an earlier merge where the receiver itself was a
+	//    merged result and a key came from that earlier fallback.
 	for k, v := range receiver.priorValues {
-		// Only override if receiver actually had this key (otherwise the
-		// fallback's prior is the relevant history).
-		if _, hasOwn := receiver.values[k]; hasOwn {
-			result.priorValues[k] = v
-		}
+		result.priorValues[k] = v
 	}
 	return result
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -83,6 +83,77 @@ func (o *ObjectVal) Set(key string, v Val) { o.set(key, v) }
 // GetVal returns the value for key (exported).
 func (o *ObjectVal) GetVal(key string) (Val, bool) { return o.Get(key) }
 
+// SetPrior records a "prior value" for key (used by E12 WithFallback to
+// propagate fallback values as priors for self-reference lookback in phase 2).
+func (o *ObjectVal) SetPrior(key string, v Val) {
+	o.priorValues[key] = v
+}
+
+// GetPrior returns the prior value associated with key, if any.
+func (o *ObjectVal) GetPrior(key string) (Val, bool) {
+	v, ok := o.priorValues[key]
+	return v, ok
+}
+
+// MergeUnresolved performs the E12 WithFallback merge of two unresolved trees.
+// Receiver's keys win; on non-object collision (or when receiver is non-object),
+// the fallback's value is recorded as a prior on the result for cross-layer
+// self-reference lookback in phase 2. Both-object collisions recurse.
+//
+// This is a binary primitive. The caller (Config.WithFallback) is responsible
+// for the "composition barrier" semantic (HOCON.md L1485) when chaining
+// multiple fallbacks: once a non-object value has barred merging at a path,
+// subsequent fallback objects at that path must not contribute. Config
+// tracks barred paths externally and refrains from calling MergeUnresolved
+// recursively into a barred subtree.
+func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
+	if receiver == nil {
+		return fallback
+	}
+	if fallback == nil {
+		return receiver
+	}
+	result := newObjectVal()
+	// 1. Seed with fallback keys (so receiver-only / new fallback-only keys
+	//    co-exist).
+	for _, k := range fallback.Keys() {
+		v, _ := fallback.Get(k)
+		result.set(k, v)
+	}
+	// Carry fallback's priorValues.
+	for k, v := range fallback.priorValues {
+		result.priorValues[k] = v
+	}
+	// 2. Apply receiver: receiver wins; on non-object collision capture
+	//    fallback's value (existing) as prior for cross-layer self-ref lookback.
+	for _, k := range receiver.Keys() {
+		rv, _ := receiver.Get(k)
+		if existing, hasExisting := result.values[k]; hasExisting {
+			// both objects → recurse
+			if recObj, recOk := rv.(*ObjectVal); recOk {
+				if existObj, existOk := existing.(*ObjectVal); existOk {
+					result.values[k] = MergeUnresolved(recObj, existObj)
+					continue
+				}
+			}
+			// non-object collision: receiver wins; capture fallback's
+			// value (existing) as prior for cross-layer self-ref lookback.
+			result.priorValues[k] = existing
+		}
+		result.set(k, rv)
+	}
+	// 3. Receiver's own priorValues take precedence (in case the same key was
+	//    already a prior on both sides — receiver's history wins).
+	for k, v := range receiver.priorValues {
+		// Only override if receiver actually had this key (otherwise the
+		// fallback's prior is the relevant history).
+		if _, hasOwn := receiver.values[k]; hasOwn {
+			result.priorValues[k] = v
+		}
+	}
+	return result
+}
+
 // deepMerge merges src into dst (dst values take precedence for non-objects).
 func deepMerge(dst, src *ObjectVal) *ObjectVal {
 	result := newObjectVal()

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -98,14 +98,15 @@ func (o *ObjectVal) GetPrior(key string) (Val, bool) {
 // MergeUnresolved performs the E12 WithFallback merge of two unresolved trees.
 // Receiver's keys win; on non-object collision (or when receiver is non-object),
 // the fallback's value is recorded as a prior on the result for cross-layer
-// self-reference lookback in phase 2. Both-object collisions recurse.
+// self-reference lookback in phase 2. Both-object collisions recurse — unless
+// a composition barrier is active at the key.
 //
-// This is a binary primitive. The caller (Config.WithFallback) is responsible
-// for the "composition barrier" semantic (HOCON.md L1485) when chaining
-// multiple fallbacks: once a non-object value has barred merging at a path,
-// subsequent fallback objects at that path must not contribute. Config
-// tracks barred paths externally and refrains from calling MergeUnresolved
-// recursively into a barred subtree.
+// Composition barrier (HOCON.md §Object Merge L1485, dr10): when the receiver
+// has a non-object priorValues[k] from an earlier merge layer (e.g. the
+// scalar in `obj.WithFallback(scalar).WithFallback(otherObj)`), the recursion
+// into both-object collision is suppressed at that key and the fallback's
+// object is discarded.  The barrier is signalled by receiver.priorValues[k]
+// being non-object — no external bookkeeping required from callers.
 func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
 	if receiver == nil {
 		return fallback

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -670,7 +670,25 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 	// S13c: env-var list expansion — when '[]' suffix is present, delegate to
 	// resolveEnvList. This branch runs BEFORE scalar env fallback (S13c.5: when
 	// listSuffix=true, the bare scalar env var must NOT be consulted as fallback).
+	//
+	// E12: also gated on UseSystemEnvironment. When env access is disabled,
+	// the list substitution behaves like any other unresolved substitution:
+	// leave the placeholder if lenient; required-substitution error otherwise.
 	if s.listSuffix {
+		if !r.opts.UseSystemEnvironment {
+			if n.Optional {
+				return nil, nil // optional ${?X[]} → drop the field
+			}
+			if r.lenient {
+				return s, nil // leave placeholder for re-resolution
+			}
+			return nil, &ResolveError{
+				Message: fmt.Sprintf("required env-var list ${%s[]} cannot be resolved (UseSystemEnvironment=false)", strings.Join(segStrs, ".")),
+				Path:    strings.Join(segStrs, "."),
+				Line:    n.Line(),
+				Col:     n.Col(),
+			}
+		}
 		return r.resolveEnvList(s, segStrs, n)
 	}
 
@@ -704,8 +722,10 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		return nil, nil // field will be dropped
 	}
 	if r.lenient {
-		// In lenient mode (child resolver for includes), leave unresolved
-		// substitutions as placeholders for the parent resolver to handle.
+		// In lenient mode (include child resolver OR AllowUnresolved=true in
+		// a top-level ResolveTree call), leave unresolved substitutions as
+		// placeholders for the caller to handle (re-resolve after WithFallback,
+		// or surface NotResolved via getter).
 		return s, nil
 	}
 	return nil, &ResolveError{Message: "unresolved substitution", Path: key, Line: n.Line(), Col: n.Col()}
@@ -807,6 +827,12 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string, line,
 		resolved = append(resolved, rv)
 	}
 
+	// Lenient guard (E12 § "s10 × AllowUnresolved"): if any operand could not be
+	// resolved (the lenient path returned the placeholder unchanged), defer the
+	// entire concat as a concatPlaceholder. The deferred placeholder carries a
+	// mix of fully-resolved values (scalars/objects/arrays) and residual sub-
+	// placeholders; a subsequent ResolveTree call will re-pass each through
+	// resolveVal — safe because resolveVal is idempotent for concrete values.
 	// In lenient (AllowUnresolved) mode, if any resolved element is still a
 	// placeholder, defer the whole concat rather than error or produce a broken
 	// string. The placeholder will be resolved by a subsequent ResolveTree call

--- a/internal/resolver/resolver_phase_split_test.go
+++ b/internal/resolver/resolver_phase_split_test.go
@@ -9,6 +9,7 @@
 package resolver
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -71,6 +72,65 @@ func TestResolveTree_AllowUnresolvedKeepsPlaceholder(t *testing.T) {
 	v, _ := res.Root.Get("a")
 	if _, ok := v.(*substPlaceholder); !ok {
 		t.Fatalf("expected placeholder under allowUnresolved, got %T", v)
+	}
+}
+
+func TestResolveTree_UseSystemEnvironmentFalse_BlocksEnvListSubst(t *testing.T) {
+	ast, err := parser.Parse(`a = ${LISTVAR[]}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	// Strict mode: required env list with no env access → ResolveError.
+	_, err = ResolveTree(tree, Options{UseSystemEnvironment: false})
+	if err == nil {
+		t.Fatal("expected ResolveError for required ${LISTVAR[]} with UseSystemEnvironment=false")
+	}
+	var re *ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *ResolveError, got %T", err)
+	}
+}
+
+func TestResolveTree_UseSystemEnvironmentFalse_LenientKeepsEnvListPlaceholder(t *testing.T) {
+	ast, err := parser.Parse(`a = ${LISTVAR[]}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	// Lenient mode: leave the env-list substitution as a placeholder.
+	res, err := ResolveTree(tree, Options{UseSystemEnvironment: false, AllowUnresolved: true})
+	if err != nil {
+		t.Fatalf("ResolveTree: %v", err)
+	}
+	v, _ := res.Root.Get("a")
+	if _, ok := v.(*substPlaceholder); !ok {
+		t.Fatalf("expected placeholder under UseSystemEnvironment=false+AllowUnresolved, got %T", v)
+	}
+}
+
+func TestResolveTree_UseSystemEnvironmentFalse_OptionalEnvListDropsField(t *testing.T) {
+	ast, err := parser.Parse(`a = ${?LISTVAR[]}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	// Optional env list under UseSystemEnvironment=false → field is dropped.
+	res, err := ResolveTree(tree, Options{UseSystemEnvironment: false})
+	if err != nil {
+		t.Fatalf("ResolveTree: %v", err)
+	}
+	if _, ok := res.Root.Get("a"); ok {
+		t.Fatal("expected optional env-list field to be dropped with UseSystemEnvironment=false")
 	}
 }
 

--- a/internal/resolver/resolver_phase_split_test.go
+++ b/internal/resolver/resolver_phase_split_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+import (
+	"testing"
+
+	"github.com/o3co/go.hocon/internal/parser"
+)
+
+func TestBuildTree_LeavesSubstitutionPlaceholders(t *testing.T) {
+	ast, err := parser.Parse("a = ${b}\nb = 1")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	v, ok := tree.Get("a")
+	if !ok {
+		t.Fatalf("expected key a, got none")
+	}
+	if _, isSubst := v.(*substPlaceholder); !isSubst {
+		t.Fatalf("expected substPlaceholder for a, got %T", v)
+	}
+}
+
+func TestResolveTree_ResolvesPlaceholders(t *testing.T) {
+	ast, err := parser.Parse("a = ${b}\nb = 1")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	res, err := ResolveTree(tree, Options{})
+	if err != nil {
+		t.Fatalf("ResolveTree: %v", err)
+	}
+	v, ok := res.Root.Get("a")
+	if !ok {
+		t.Fatalf("expected a in resolved tree")
+	}
+	sv, ok := v.(*ScalarVal)
+	if !ok || sv.Raw != "1" {
+		t.Fatalf("expected a=1, got %#v", v)
+	}
+}
+
+func TestResolveTree_AllowUnresolvedKeepsPlaceholder(t *testing.T) {
+	ast, err := parser.Parse(`a = ${missing}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	res, err := ResolveTree(tree, Options{AllowUnresolved: true, UseSystemEnvironment: false})
+	if err != nil {
+		t.Fatalf("ResolveTree(allowUnresolved): %v", err)
+	}
+	v, _ := res.Root.Get("a")
+	if _, ok := v.(*substPlaceholder); !ok {
+		t.Fatalf("expected placeholder under allowUnresolved, got %T", v)
+	}
+}
+
+func TestContainsPlaceholders(t *testing.T) {
+	ast, err := parser.Parse("a = ${b}\nb = 1")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tree, err := BuildTree(ast, Options{})
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	if !ContainsPlaceholders(tree) {
+		t.Fatal("expected ContainsPlaceholders to return true for unresolved tree")
+	}
+	res, err := ResolveTree(tree, Options{})
+	if err != nil {
+		t.Fatalf("ResolveTree: %v", err)
+	}
+	if ContainsPlaceholders(res.Root) {
+		t.Fatal("expected ContainsPlaceholders to return false for resolved tree")
+	}
+}

--- a/internal/yamlscenario/scenario.go
+++ b/internal/yamlscenario/scenario.go
@@ -1,0 +1,68 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Package yamlscenario defines the Go-side types for the cross-impl E12
+// scenario YAML schema (testdata/hocon/deferred-resolution/*.yaml).
+//
+// Schema reference:
+//
+//	testdata/hocon/deferred-resolution/README.md
+package yamlscenario
+
+// Scenario is the top-level YAML document.
+type Scenario struct {
+	Description   string            `yaml:"description"`
+	Xref          []string          `yaml:"xref,omitempty"`
+	LightbendSkip bool              `yaml:"lightbendSkip,omitempty"`
+	Sources       map[string]Source `yaml:"sources"`
+	Build         []Step            `yaml:"build"`
+	Expect        Expect            `yaml:"expect"`
+}
+
+type Source struct {
+	ParseString       string         `yaml:"parseString,omitempty"`
+	ParseOptions      *ParseOpts     `yaml:"parseOptions,omitempty"`
+	FromMap           map[string]any `yaml:"fromMap,omitempty"`
+	OriginDescription string         `yaml:"originDescription,omitempty"`
+}
+
+type ParseOpts struct {
+	ResolveSubstitutions *bool  `yaml:"resolveSubstitutions,omitempty"`
+	OriginDescription    string `yaml:"originDescription,omitempty"`
+}
+
+type Step struct {
+	Op                   string `yaml:"op"`
+	Source               string `yaml:"source,omitempty"` // for `take`, `resolveWith`
+	This                 string `yaml:"this,omitempty"`
+	Other                string `yaml:"other,omitempty"`  // for `withFallback`
+	Path                 string `yaml:"path,omitempty"`   // for `extract`
+	AllowUnresolved      *bool  `yaml:"allowUnresolved,omitempty"`
+	UseSystemEnvironment *bool  `yaml:"useSystemEnvironment,omitempty"`
+	As                   string `yaml:"as"`
+}
+
+type Expect struct {
+	Outcome       string         `yaml:"outcome"`
+	JSON          string         `yaml:"json,omitempty"`
+	IsResolved    *bool          `yaml:"isResolved,omitempty"`
+	Getter        []GetterAssert `yaml:"getter,omitempty"`
+	ErrorAt       *int           `yaml:"errorAt,omitempty"`
+	ErrorCategory string         `yaml:"errorCategory,omitempty"`
+	ErrorContains string         `yaml:"errorContains,omitempty"`
+}
+
+type GetterAssert struct {
+	Path         string         `yaml:"path"`
+	ExpectString *string        `yaml:"expectString,omitempty"`
+	ExpectInt    *int64         `yaml:"expectInt,omitempty"`
+	ExpectBool   *bool          `yaml:"expectBool,omitempty"`
+	ExpectObject map[string]any `yaml:"expectObject,omitempty"`
+	ExpectArray  []any          `yaml:"expectArray,omitempty"`
+	ExpectError  string         `yaml:"expectError,omitempty"` // e.g. "NotResolved"
+}

--- a/internal/yamlscenario/scenario.go
+++ b/internal/yamlscenario/scenario.go
@@ -40,8 +40,8 @@ type Step struct {
 	Op                   string `yaml:"op"`
 	Source               string `yaml:"source,omitempty"` // for `take`, `resolveWith`
 	This                 string `yaml:"this,omitempty"`
-	Other                string `yaml:"other,omitempty"`  // for `withFallback`
-	Path                 string `yaml:"path,omitempty"`   // for `extract`
+	Other                string `yaml:"other,omitempty"` // for `withFallback`
+	Path                 string `yaml:"path,omitempty"`  // for `extract`
 	AllowUnresolved      *bool  `yaml:"allowUnresolved,omitempty"`
 	UseSystemEnvironment *bool  `yaml:"useSystemEnvironment,omitempty"`
 	As                   string `yaml:"as"`

--- a/option.go
+++ b/option.go
@@ -43,12 +43,15 @@ func (o Option[T]) OrElse(def T) T {
 }
 
 // ParseOptions controls parse-phase behaviour.  Construct via DefaultParseOptions()
-// and chain WithX() methods.  The zero-value literal ParseOptions{} is NOT a
-// valid invocation — it would contradict Lightbend defaults (ResolveSubstitutions
-// must default to true).  Per E12 § "Options encoding per language".
+// and chain WithX() methods.  As an ergonomic safety net, the zero-value literal
+// ParseOptions{} is interpreted as DefaultParseOptions() at the public API
+// boundary (silently substituted with Lightbend defaults) — preserves callers
+// from accidentally inverting ResolveSubstitutions=false / OriginDescription="".
+// Per E12 § "Options encoding per language".
 type ParseOptions struct {
 	resolveSubstitutions bool
 	originDescription    string
+	initialized          bool // false for zero-value; treated as DefaultParseOptions() by callers
 }
 
 // DefaultParseOptions returns ParseOptions with Lightbend-equivalent defaults:
@@ -57,6 +60,7 @@ func DefaultParseOptions() ParseOptions {
 	return ParseOptions{
 		resolveSubstitutions: true,
 		originDescription:    "",
+		initialized:          true,
 	}
 }
 
@@ -71,20 +75,27 @@ func (o ParseOptions) OriginDescription() string { return o.originDescription }
 // WithResolveSubstitutions returns a copy with ResolveSubstitutions set to v.
 func (o ParseOptions) WithResolveSubstitutions(v bool) ParseOptions {
 	o.resolveSubstitutions = v
+	o.initialized = true
 	return o
 }
 
 // WithOriginDescription returns a copy with OriginDescription set to s.
 func (o ParseOptions) WithOriginDescription(s string) ParseOptions {
 	o.originDescription = s
+	o.initialized = true
 	return o
 }
 
 // ResolveOptions controls resolve-phase behaviour.  Construct via
-// DefaultResolveOptions() and chain WithX() methods.
+// DefaultResolveOptions() and chain WithX() methods.  As an ergonomic safety
+// net, the zero-value literal ResolveOptions{} is interpreted as
+// DefaultResolveOptions() at the public API boundary (silently substituted
+// with Lightbend defaults) — preserves callers from accidentally disabling
+// UseSystemEnvironment.  Per E12 § "Options encoding per language".
 type ResolveOptions struct {
 	useSystemEnvironment bool
 	allowUnresolved      bool
+	initialized          bool // false for zero-value; treated as DefaultResolveOptions() by callers
 }
 
 // DefaultResolveOptions returns ResolveOptions with Lightbend-equivalent
@@ -93,6 +104,7 @@ func DefaultResolveOptions() ResolveOptions {
 	return ResolveOptions{
 		useSystemEnvironment: true,
 		allowUnresolved:      false,
+		initialized:          true,
 	}
 }
 
@@ -108,11 +120,13 @@ func (o ResolveOptions) AllowUnresolved() bool { return o.allowUnresolved }
 // WithUseSystemEnvironment returns a copy with UseSystemEnvironment set to v.
 func (o ResolveOptions) WithUseSystemEnvironment(v bool) ResolveOptions {
 	o.useSystemEnvironment = v
+	o.initialized = true
 	return o
 }
 
 // WithAllowUnresolved returns a copy with AllowUnresolved set to v.
 func (o ResolveOptions) WithAllowUnresolved(v bool) ResolveOptions {
 	o.allowUnresolved = v
+	o.initialized = true
 	return o
 }

--- a/option.go
+++ b/option.go
@@ -41,3 +41,78 @@ func (o Option[T]) OrElse(def T) T {
 	}
 	return def
 }
+
+// ParseOptions controls parse-phase behaviour.  Construct via DefaultParseOptions()
+// and chain WithX() methods.  The zero-value literal ParseOptions{} is NOT a
+// valid invocation — it would contradict Lightbend defaults (ResolveSubstitutions
+// must default to true).  Per E12 § "Options encoding per language".
+type ParseOptions struct {
+	resolveSubstitutions bool
+	originDescription    string
+}
+
+// DefaultParseOptions returns ParseOptions with Lightbend-equivalent defaults:
+// ResolveSubstitutions=true, OriginDescription="".
+func DefaultParseOptions() ParseOptions {
+	return ParseOptions{
+		resolveSubstitutions: true,
+		originDescription:    "",
+	}
+}
+
+// ResolveSubstitutions reports whether the parser must run resolve phase 2
+// (substitution evaluation) before returning a Config.  Default: true.
+func (o ParseOptions) ResolveSubstitutions() bool { return o.resolveSubstitutions }
+
+// OriginDescription returns the user-visible source name used in error
+// messages when no file path is available.  Default: "".
+func (o ParseOptions) OriginDescription() string { return o.originDescription }
+
+// WithResolveSubstitutions returns a copy with ResolveSubstitutions set to v.
+func (o ParseOptions) WithResolveSubstitutions(v bool) ParseOptions {
+	o.resolveSubstitutions = v
+	return o
+}
+
+// WithOriginDescription returns a copy with OriginDescription set to s.
+func (o ParseOptions) WithOriginDescription(s string) ParseOptions {
+	o.originDescription = s
+	return o
+}
+
+// ResolveOptions controls resolve-phase behaviour.  Construct via
+// DefaultResolveOptions() and chain WithX() methods.
+type ResolveOptions struct {
+	useSystemEnvironment bool
+	allowUnresolved      bool
+}
+
+// DefaultResolveOptions returns ResolveOptions with Lightbend-equivalent
+// defaults: UseSystemEnvironment=true, AllowUnresolved=false.
+func DefaultResolveOptions() ResolveOptions {
+	return ResolveOptions{
+		useSystemEnvironment: true,
+		allowUnresolved:      false,
+	}
+}
+
+// UseSystemEnvironment reports whether resolve consults process environment
+// for substitution paths not satisfied within the config tree.  Default: true.
+func (o ResolveOptions) UseSystemEnvironment() bool { return o.useSystemEnvironment }
+
+// AllowUnresolved reports whether resolve leaves required-but-unsatisfied
+// substitutions as placeholders (true) or returns ResolveError (false).
+// Default: false.
+func (o ResolveOptions) AllowUnresolved() bool { return o.allowUnresolved }
+
+// WithUseSystemEnvironment returns a copy with UseSystemEnvironment set to v.
+func (o ResolveOptions) WithUseSystemEnvironment(v bool) ResolveOptions {
+	o.useSystemEnvironment = v
+	return o
+}
+
+// WithAllowUnresolved returns a copy with AllowUnresolved set to v.
+func (o ResolveOptions) WithAllowUnresolved(v bool) ResolveOptions {
+	o.allowUnresolved = v
+	return o
+}

--- a/option_test.go
+++ b/option_test.go
@@ -42,3 +42,76 @@ func TestOrElse(t *testing.T) {
 		t.Fatal("None.OrElse should return default")
 	}
 }
+
+func TestDefaultParseOptions(t *testing.T) {
+	opts := hocon.DefaultParseOptions()
+	if !opts.ResolveSubstitutions() {
+		t.Fatal("DefaultParseOptions: ResolveSubstitutions must default to true")
+	}
+	if opts.OriginDescription() != "" {
+		t.Fatalf("DefaultParseOptions: OriginDescription must default empty, got %q", opts.OriginDescription())
+	}
+}
+
+func TestParseOptions_WithResolveSubstitutions(t *testing.T) {
+	o1 := hocon.DefaultParseOptions()
+	o2 := o1.WithResolveSubstitutions(false)
+	if o1.ResolveSubstitutions() != true {
+		t.Fatal("WithResolveSubstitutions must not mutate receiver")
+	}
+	if o2.ResolveSubstitutions() != false {
+		t.Fatal("WithResolveSubstitutions(false) must produce ResolveSubstitutions=false")
+	}
+}
+
+func TestParseOptions_WithOriginDescription(t *testing.T) {
+	o := hocon.DefaultParseOptions().WithOriginDescription("inline-config")
+	if o.OriginDescription() != "inline-config" {
+		t.Fatalf("expected origin 'inline-config', got %q", o.OriginDescription())
+	}
+}
+
+func TestParseOptions_Chainable(t *testing.T) {
+	o := hocon.DefaultParseOptions().
+		WithResolveSubstitutions(false).
+		WithOriginDescription("inline")
+	if o.ResolveSubstitutions() != false {
+		t.Fatal("chained WithResolveSubstitutions")
+	}
+	if o.OriginDescription() != "inline" {
+		t.Fatal("chained WithOriginDescription")
+	}
+}
+
+func TestDefaultResolveOptions(t *testing.T) {
+	opts := hocon.DefaultResolveOptions()
+	if !opts.UseSystemEnvironment() {
+		t.Fatal("DefaultResolveOptions: UseSystemEnvironment must default true")
+	}
+	if opts.AllowUnresolved() {
+		t.Fatal("DefaultResolveOptions: AllowUnresolved must default false")
+	}
+}
+
+func TestResolveOptions_With(t *testing.T) {
+	o := hocon.DefaultResolveOptions().
+		WithUseSystemEnvironment(false).
+		WithAllowUnresolved(true)
+	if o.UseSystemEnvironment() != false {
+		t.Fatal("WithUseSystemEnvironment")
+	}
+	if o.AllowUnresolved() != true {
+		t.Fatal("WithAllowUnresolved")
+	}
+}
+
+func TestResolveOptions_NonMutating(t *testing.T) {
+	o1 := hocon.DefaultResolveOptions()
+	o2 := o1.WithAllowUnresolved(true)
+	if o1.AllowUnresolved() != false {
+		t.Fatal("WithAllowUnresolved must not mutate receiver")
+	}
+	if o2.AllowUnresolved() != true {
+		t.Fatal("WithAllowUnresolved must produce true")
+	}
+}

--- a/option_test.go
+++ b/option_test.go
@@ -115,3 +115,39 @@ func TestResolveOptions_NonMutating(t *testing.T) {
 		t.Fatal("WithAllowUnresolved must produce true")
 	}
 }
+
+func TestParseOptions_ZeroValue_TreatedAsDefaults(t *testing.T) {
+	// ParseOptions{} zero-value at the API boundary is silently substituted
+	// with DefaultParseOptions() (Lightbend defaults). Verify by parsing a
+	// config that contains a substitution — under ResolveSubstitutions=false
+	// (zero-value if we hadn't substituted) the result would be unresolved;
+	// under the substituted default (true) the result is resolved.
+	c, err := hocon.ParseStringWithOptions(`a = 1`, hocon.ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseStringWithOptions: %v", err)
+	}
+	if !c.IsResolved() {
+		t.Fatal("ParseOptions{} zero-value must be treated as DefaultParseOptions() (ResolveSubstitutions=true)")
+	}
+	if c.GetInt("a") != 1 {
+		t.Fatalf("a=%d, want 1", c.GetInt("a"))
+	}
+}
+
+func TestResolveOptions_ZeroValue_TreatedAsDefaults(t *testing.T) {
+	// ResolveOptions{} zero-value would mean UseSystemEnvironment=false
+	// AllowUnresolved=false. Verify substitution: env-fallback works
+	// because UseSystemEnvironment becomes true (substituted default).
+	t.Setenv("TEST_E12_ZERO_VALUE", "from-env")
+	c, _ := hocon.ParseStringWithOptions(
+		`a = ${TEST_E12_ZERO_VALUE}`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	r, err := c.Resolve(hocon.ResolveOptions{}) // zero-value
+	if err != nil {
+		t.Fatalf("Resolve(zero-value ResolveOptions): %v (substitute must enable env)", err)
+	}
+	if r.GetString("a") != "from-env" {
+		t.Fatalf("a=%q, want 'from-env' (env should be enabled under substituted defaults)", r.GetString("a"))
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -113,6 +113,22 @@ func ResetPackageRegistry() {
 	globalRegistry.m = make(map[pkgKey][]byte)
 }
 
+// UnregisterPackage removes a previously registered package binding.
+// No-op if the (identifier, file) pair is not registered.
+// Primarily for test isolation; prefer ResetPackageRegistry when clearing
+// all registrations.
+func UnregisterPackage(identifier, file string) {
+	globalRegistry.unregister(identifier, file)
+}
+
+// unregister removes a single (identifier, file) entry from the registry.
+func (r *pkgRegistry) unregister(identifier, file string) {
+	key := pkgKey{identifier: identifier, file: file}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.m, key)
+}
+
 // lookup looks up a (identifier, file) pair in the global registry.
 // Returns (content, nil) on success, (nil, error) on miss.
 func (r *pkgRegistry) lookup(identifier, file string) ([]byte, error) {

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -322,28 +322,12 @@ func TestSpec_S13_12_OptionalUndefinedInArrayElementSkipped(t *testing.T) {
 
 // ── S13.15: foo : ${?bar}${?baz} skipped only when BOTH undefined ─────────────
 
-// TestSpec_S13_15_BothUndefined_Pin pins the current (non-conformant) behaviour
-// where `foo = ${?bar}${?baz}` creates a field with value "" even when both
-// substitutions are undefined. Spec HOCON.md L640 requires the field to be omitted.
-func TestSpec_S13_15_BothUndefined_Pin(t *testing.T) {
-	// pin: see #78 — field is created with empty string instead of being omitted
-	_ = specIssueS13_15_BothUndef
-	cfg := mustParseCfg(t, "foo = ${?bar}${?baz}")
-	opt := cfg.GetStringOption("foo")
-	if !opt.IsSome() {
-		t.Error("[pin] expected Some (current impl creates field with \"\"), got None")
-		return
-	}
-	v, _ := opt.Get()
-	if v != "" {
-		t.Errorf("[pin] expected current value %q, got %q", "", v)
-	}
-}
-
-// TestSpec_S13_15_BothUndefined_Spec is the spec-correct assertion:
+// TestSpec_S13_15_BothUndefined_Spec verifies the spec-correct behaviour:
 // field must not be created when both substitutions are undefined.
+// Fixed in T14 (dr28 scenario): resolveConcat now returns nil when all
+// operands resolve to nil, so the field is omitted. Closes #78.
 func TestSpec_S13_15_BothUndefined_Spec(t *testing.T) {
-	t.Skipf("[skip] spec violation per S13.15 — field created with empty string when both substs undefined; see #%d", specIssueS13_15_BothUndef)
+	_ = specIssueS13_15_BothUndef
 	cfg := mustParseCfg(t, "foo = ${?bar}${?baz}")
 	if cfg.GetStringOption("foo").IsSome() {
 		t.Error("field foo must not exist when both ${?bar} and ${?baz} are undefined")

--- a/testdata/hocon/deferred-resolution/README.md
+++ b/testdata/hocon/deferred-resolution/README.md
@@ -1,0 +1,187 @@
+# deferred-resolution/ — E12 conformance fixtures
+
+This fixture group covers [E12](../../../../docs/extra-spec-conventions.md#e12)
+(deferred substitution resolution — Lightbend-aligned `parse / withFallback /
+resolve()` lifecycle).
+
+**External origin**: [o3co/go.hocon#99](https://github.com/o3co/go.hocon/issues/99)
+**Spec tracking**: [o3co/xx.hocon#37](https://github.com/o3co/xx.hocon/issues/37)
+**Design doc**: [`.claude/superpowers/specs/2026-05-21-e12-deferred-resolution-design.md`](../../../../.claude/superpowers/specs/2026-05-21-e12-deferred-resolution-design.md)
+
+## Why YAML and not `.conf`?
+
+Existing fixture groups are single `.conf` files: load → parse+resolve → JSON.
+E12 fixtures must express **multi-step scenarios** (parse layer A, fromMap layer
+B, `withFallback` chain, then `resolve()` with options), which is structural
+information that a single `.conf` cannot encode.
+
+Each fixture is a YAML file describing the scenario. The Java generator
+(`generate/src/main/java/DeferredResolutionRunner.java`) runs the scenario
+through Lightbend `com.typesafe.config` and emits the expected outcome to
+`expected/hocon/deferred-resolution/<name>-expected.{json,error}`. Per-impl
+conformance tests read the same YAML and exercise their own public API.
+
+## Scenario YAML schema
+
+```yaml
+# REQUIRED — one-line summary
+description: <free text>
+
+# OPTIONAL — cross-reference issues / specs
+xref: [go.hocon#99, S13a, S10]
+
+# REQUIRED — input sources (atoms), declared by id.
+# Sources are pure: each is either `parseString` (with optional parseOptions)
+# OR `fromMap`. Derivation (extract subconfig, resolve, etc.) happens in `build`.
+sources:
+  <id>:
+    # exactly one of the following per source:
+    parseString: |              # HOCON text to parse
+      a = ${b}
+      b = 1
+    parseOptions:               # OPTIONAL, only valid alongside parseString
+      resolveSubstitutions: false
+      originDescription: "scenario dr01 receiver"
+    # OR
+    fromMap:                    # plain-key map for hocon.FromMap
+      KEY1: "value1"
+      KEY2: 42
+      NESTED:
+        inner: true
+    originDescription: "..."    # OPTIONAL for fromMap
+
+# REQUIRED — explicit step sequence producing the final Config under test.
+# The artifact named `result` (or the last step's output, if unnamed) is what
+# `expect` is asserted against.
+#
+# In all `op` records below, `this` / `other` / `source` arguments may reference
+# either a source-id (from `sources`) or a previously-built named artifact (`as`
+# from an earlier build step). Resolution is by name; sources and built
+# artifacts share one namespace.
+build:
+  - { op: take,          source: <id>,           as: <name> }
+  - { op: withFallback,  this: <name>,  other: <id-or-name>,  as: <name> }
+  - { op: extract,       this: <name>,  path: <dotted.path>,  as: <name> }
+  - { op: resolveWith,   this: <name>,  source: <id-or-name>, allowUnresolved: false, useSystemEnvironment: false, as: <name> }
+  - { op: resolve,       this: <name>,  allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+# REQUIRED — expected outcome of the final artifact (or the named artifact)
+expect:
+  outcome: success | error      # required
+
+  # When outcome=success:
+  json: |-                      # OPTIONAL canonical JSON (whitespace-normalised before compare)
+    { "a": 1, "b": 1 }
+  isResolved: true | false      # OPTIONAL
+
+  # When outcome=success, additional per-path assertions on the final Config:
+  getter:                       # OPTIONAL list
+    - { path: "a",         expectInt:    1 }
+    - { path: "name",      expectString: "alice" }
+    - { path: "missing",   expectError:  NotResolved }
+    - { path: "obj.child", expectObject: { x: 1, y: 2 } }
+    - { path: "list",      expectArray:  [1, 2, 3] }
+
+  # When outcome=error:
+  errorAt: <step-index>         # OPTIONAL; which build step is expected to throw (0-based)
+  errorCategory:                # REQUIRED — see "Error category mapping" below
+    ParseError | ResolveError | NotResolved | TypeError | CycleError
+  errorContains: <substring>    # OPTIONAL substring match against error message
+```
+
+### `op` reference
+
+| Op              | Args (other than `as`)                                        | Semantics                                                                                                |
+| --------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `take`          | `source: <id>`                                                | Make `<id>`'s source-artifact available under `as`.                                                      |
+| `extract`       | `this: <name>, path: <dotted.path>`                           | `this.getConfig(path)` — extract a subconfig as a new artifact. Used to promote a nested object into its own layer (e.g. dr01's `variables` subtree). |
+| `withFallback`  | `this: <name>, other: <id-or-name>`                           | `this.WithFallback(other)`. `other` may reference a source-id OR a previously-built named artifact.      |
+| `resolve`       | `this: <name>, allowUnresolved?, useSystemEnvironment?`       | `this.Resolve(ResolveOptions{...})`. Boolean options use spec defaults if omitted.                       |
+| `resolveWith`   | `this: <name>, source: <id-or-name>, allowUnresolved?, useSystemEnvironment?` | `this.ResolveWith(source, ResolveOptions{...})`. Source must be resolved (otherwise expect=error).       |
+
+### Error category mapping
+
+Cross-impl categories. Per-impl test runners map their concrete error to one of these.
+
+| Category       | Lightbend exception                          | go.hocon                       | ts.hocon                | rs.hocon                            |
+| -------------- | -------------------------------------------- | ------------------------------ | ----------------------- | ----------------------------------- |
+| `ParseError`   | `ConfigException.Parse`                      | `parser.Error`                 | `ParseError`            | `HoconError::Parse(_)`              |
+| `ResolveError` | `ConfigException.UnresolvedSubstitution`     | `resolver.Error` / `ResolveError` | `ResolveError`       | `HoconError::Resolve(_)`            |
+| `NotResolved`  | `ConfigException.NotResolved`                | `ErrNotResolved`               | `NotResolvedError`      | `ConfigError::NotResolved`          |
+| `TypeError`    | `ConfigException.WrongType`                  | (per impl)                     | `WrongTypeError`        | `HoconError::WrongType`             |
+| `CycleError`   | `ConfigException.UnresolvedSubstitution` (Lightbend doesn't distinguish) | `resolver.Error` w/ cycle marker | `CycleError`     | `ResolveError::Cycle`               |
+
+## Per-impl test runner contract
+
+Per-impl conformance tests do:
+
+1. **Read scenario YAML**.
+2. **Resolve sources** in declaration order:
+   - `parseString` → impl's `ParseStringWithOptions` (or equivalent) with `ResolveSubstitutions: false` UNLESS `parseOptions.resolveSubstitutions = true` is set explicitly.
+   - `fromMap` → impl's `FromMap`.
+   - `extract` → after the referenced artifact is available, extract its subconfig at `path` (impl's `getConfig`-equivalent).
+3. **Execute `build` steps** in order, maintaining a name→artifact map.
+4. **Validate `expect`**:
+   - For `outcome: success`: the final artifact (named `result` if present, else the last step's output) must succeed all `getter` assertions and (if `json` provided) JSON-equal the expected.
+   - For `outcome: error`: the build step at index `errorAt` (or any step, if `errorAt` omitted) must throw an error mapped to `errorCategory`. `errorContains` is substring-matched against the error message.
+
+## Generator behaviour (DeferredResolutionRunner)
+
+The Java generator runs each `.yaml` through Lightbend Java and:
+
+- For `outcome: success` scenarios where the resulting Config is **resolved** (`isResolved=true`): emits `<name>-expected.json` (canonical sorted-key JSON) AND `<name>-expected.txt` (`isResolved` flag + getter assertion records). The `.json` file is Lightbend ground truth — per-impl tests JSON-compare against it.
+- For `outcome: success` scenarios where the resulting Config is **unresolved** (`isResolved=false`, expected when `AllowUnresolved=true` and substitutions remain): emits `<name>-expected.unresolved-render.txt` (Lightbend's raw render — contains non-JSON substitution placeholder literals like `${b}`, hence the distinct extension) AND `<name>-expected.txt`. Per-impl tests rely on the `.txt` getter records, NOT the raw render.
+- For `outcome: error` scenarios: emits `<name>-expected.error` plain text with `Category: <cat>\nAt: <step>\nMessage: <first-line>\n`.
+- For `lightbendSkip: true` scenarios: emits `<name>-expected.skip` with the YAML's `description` as rationale. No other expected file is produced for skipped scenarios.
+
+Mismatches between scenario YAML expectations and Lightbend's actual output (`expect.json` differs from rendered JSON, `expect.errorCategory` differs from Lightbend's exception class, `expect.errorAt` differs from actual step index, `expect.errorContains` substring missing from Lightbend's message, or `expect.isResolved` differs) are **hard failures** — the runner emits `<name>-expected.UNEXPECTED` and the build reports an error. This treats Lightbend as the cross-impl ground truth.
+
+## Fixture index
+
+See [design doc § "Fixture inventory"](../../../../.claude/superpowers/specs/2026-05-21-e12-deferred-resolution-design.md#fixture-inventory-30-scenarios) for the full table.
+
+| ID | File | Outcome | Brief |
+|---|---|---|---|
+| dr01 | `dr01-basic-fallback.yaml` | success | Issue #99 example |
+| dr02 | `dr02-frommap-only-fallback.yaml` | success | FromMap-only fallback |
+| dr03 | `dr03-multi-layer-fallback.yaml` | success | 3+ fallback layers |
+| dr04 | `dr04-self-ref-optional-with-fallback.yaml` | success | `a=${?a} extra` + fallback `a=base` |
+| dr05 | `dr05-required-self-ref-with-fallback-prior.yaml` | success | Required self-ref resolves via fallback prior |
+| dr06 | `dr06-required-self-ref-no-fallback.yaml` | error | Required self-ref no prior → CycleError (Lightbend treats as cycle since substitution looks back at the value it defines) |
+| dr07 | `dr07-allow-unresolved-partial.yaml` | success | AllowUnresolved=true partial; getter assertions |
+| dr08 | `dr08-no-system-env.yaml` | error | UseSystemEnvironment=false; env-only sub → ResolveError |
+| dr09 | `dr09-getter-on-unresolved.yaml` | success | AllowUnresolved=true; specific getter → NotResolved |
+| dr10 | `dr10-non-object-override.yaml` | success | `obj.WithFallback(num).WithFallback(otherObj)` ignores otherObj |
+| dr11a | `dr11a-resolve-with-source-keys-absent.yaml` | success | ResolveWith: source keys NOT in result |
+| dr11b | `dr11b-resolve-with-unresolved-source.yaml` | error | ResolveWith with unresolved source → NotResolved |
+| dr12 | `dr12-origin-preserved.yaml` | error | Resolve error message includes source position |
+| dr13 | `dr13-type-error-under-allow-unresolved.yaml` | error | Type error fires under AllowUnresolved=true |
+| dr14 | `dr14-deferred-concat-placeholder.yaml` | success | Fully-unresolved concat survives as placeholder; getter → NotResolved |
+| dr15 | `dr15-include-deferred.yaml` | success | Include expanded at parse; `${...}` deferred |
+| dr16 | `dr16-frommap-nested-coercion.yaml` | success | FromMap with scalars / lists / nested maps |
+| dr17 | `dr17-e11-package-include-deferred.yaml` | success | E11 `include package(...)` + deferred. **n/a for Lightbend** (skipped). |
+| dr18 | `dr18-cross-layer-cycle.yaml` | error | Receiver `a=${b}`, fallback `b=${a}` → CycleError |
+| dr19 | `dr19-resolve-idempotent.yaml` | success | `c.Resolve().Resolve()` equivalent (programmatic-only; see notes) |
+| dr20 | `dr20-transitive-single-source.yaml` | success | `a=${b}; b=${c}; c=1` → `a=1` |
+| dr21 | `dr21-transitive-cross-layer.yaml` | success | Transitive subst across 3 layers |
+| dr22 | `dr22-hidden-single-source.yaml` | success | `foo=${nonexist}; foo=42` → `{foo:42}` (hidden not evaluated) |
+| dr23 | `dr23-hidden-across-layers.yaml` | success | Receiver `foo=42`, fallback `foo=${nonexist}` → `{foo:42}` |
+| dr24 | `dr24-optional-standalone-undef.yaml` | success | `a = ${?x}` (x undef) → field omitted |
+| dr25 | `dr25-optional-string-concat-undef.yaml` | success | `a = ${?x} "tail"` (x undef) → `a = " tail"` |
+| dr26 | `dr26-optional-array-concat-undef.yaml` | success | `a = ${?x} [1,2]` (x undef) → `a = [1,2]` |
+| dr27 | `dr27-optional-object-merge-undef.yaml` | success | `a = ${?x} { k=1 }` (x undef) → `a = {k:1}` |
+| dr28 | `dr28-optional-multi-all-undef.yaml` | success | `a = ${?x}${?y}` (both undef) → field omitted |
+| dr29 | `dr29-empty-config-edges.yaml` | success | `Empty().Resolve()`, `c.WithFallback(Empty())`, `Empty().WithFallback(c)` |
+| dr30 | `dr30-object-merge-barrier.yaml` | success | Receiver-non-object blocks fallback-object |
+
+## Per-impl override notes
+
+- **dr17** (E11 package include): NOT applicable to Lightbend (Lightbend has no `package(...)` qualifier). Java generator skips. Per-impl tests run.
+- **dr19** (idempotency): the assertion "`c.Resolve()` twice yields equivalent Config" is not expressible in scenario YAML (no "compare two builds" op in v1). Per-impl tests verify programmatically. The YAML for dr19 just records the spec assertion as `description`; `expect` is single-resolve outcome.
+- **dr12** (origin preservation): the assertion is that the error message contains source-position info (file:line:col). Lightbend formats positions differently from our impls. Generator emits `errorContains` with a Lightbend-format substring; per-impl tests check their format's analogue.
+
+## See also
+
+- [docs/extra-spec-conventions.md § E12](../../../../docs/extra-spec-conventions.md#e12)
+- [docs/fixture-conventions.md § Scenario YAML fixtures (E12)](../../../../docs/fixture-conventions.md#scenario-yaml-fixtures-e12)
+- [Design doc](../../../../.claude/superpowers/specs/2026-05-21-e12-deferred-resolution-design.md)

--- a/testdata/hocon/deferred-resolution/dr01-basic-fallback.yaml
+++ b/testdata/hocon/deferred-resolution/dr01-basic-fallback.yaml
@@ -1,0 +1,50 @@
+# dr01 — Basic fallback (issue #99 example)
+#
+# A caller parses HOCON containing two substitutions, then layers in a runtime
+# fallback (CI_RUN_NUMBER from FromMap) and a promoted-subtree fallback
+# (`variables`), then resolves. Verifies the canonical Lightbend lifecycle works
+# end-to-end for the externally-requested use case.
+
+description: Issue #99 example — parse with substitution, layer FromMap fallback, layer promoted subtree fallback, resolve.
+xref: [go.hocon#99]
+
+sources:
+  receiver:
+    parseString: |
+      version = ${shortversion}-${CI_RUN_NUMBER}
+      variables { shortversion = "1.2.3" }
+    parseOptions:
+      resolveSubstitutions: false
+
+  runtime:
+    fromMap:
+      CI_RUN_NUMBER: "42"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: extract, this: r0, path: variables, as: vars }
+  - { op: withFallback, this: r0, other: runtime, as: r1 }
+  - { op: withFallback, this: r1, other: vars, as: r2 }
+  - { op: resolve, this: r2, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  # All keys from all merged fallback layers appear in the result of
+  # WithFallback (only ResolveWith would suppress source keys — see dr11a).
+  # The runtime fallback contributes `CI_RUN_NUMBER`; the extracted `vars`
+  # contributes `shortversion`. The receiver contributes `variables` and
+  # `version`. After resolve, `version` is substituted.
+  json: |-
+    {
+      "CI_RUN_NUMBER": "42",
+      "shortversion": "1.2.3",
+      "variables": {
+        "shortversion": "1.2.3"
+      },
+      "version": "1.2.3-42"
+    }
+  getter:
+    - { path: "version", expectString: "1.2.3-42" }
+    - { path: "variables.shortversion", expectString: "1.2.3" }
+    - { path: "CI_RUN_NUMBER", expectString: "42" }

--- a/testdata/hocon/deferred-resolution/dr02-frommap-only-fallback.yaml
+++ b/testdata/hocon/deferred-resolution/dr02-frommap-only-fallback.yaml
@@ -1,0 +1,41 @@
+# dr02 — FromMap-only fallback
+#
+# Receiver contains a substitution ${KEY}. A FromMap fallback provides the
+# value for KEY. After WithFallback + resolve the substitution is satisfied.
+# Demonstrates that FromMap is a first-class fallback source with no parseString.
+#
+# xref: E12-frommap, go.hocon#99
+
+description: Receiver substitution ${KEY} resolved via FromMap-only fallback layer.
+xref: [go.hocon#99, E12-frommap]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${KEY}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    fromMap:
+      KEY: "v"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  # WithFallback merges the fallback's keys into the result; `KEY` therefore
+  # appears at top level alongside the receiver's `a`. Use ResolveWith if you
+  # want the source's keys suppressed — see dr11a.
+  json: |-
+    {
+      "KEY": "v",
+      "a": "v"
+    }
+  getter:
+    - { path: "a", expectString: "v" }
+    - { path: "KEY", expectString: "v" }

--- a/testdata/hocon/deferred-resolution/dr03-multi-layer-fallback.yaml
+++ b/testdata/hocon/deferred-resolution/dr03-multi-layer-fallback.yaml
@@ -1,0 +1,51 @@
+# dr03 — Multi-layer fallback (3 layers, each contributing a unique key)
+#
+# Three fallback layers are composed via WithFallback; each layer contributes
+# one key that the others do not define. After a single top-level resolve(),
+# all three keys must be visible in the final Config.
+#
+# Demonstrates that WithFallback chains correctly accumulate distinct keys
+# and that substitutions across layers resolve when the target key lives in
+# a different fallback position.
+#
+# xref: E12-multi-layer, go.hocon#99
+
+description: Three fallback layers each contributing a distinct key; all visible after resolve.
+xref: [go.hocon#99, E12-multi-layer]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${va}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb1:
+    fromMap:
+      va: "alpha"
+      b: "beta"
+
+  fb2:
+    fromMap:
+      c: "gamma"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb1, as: r1 }
+  - { op: withFallback, this: r1, other: fb2, as: r2 }
+  - { op: resolve, this: r2, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": "alpha",
+      "b": "beta",
+      "c": "gamma",
+      "va": "alpha"
+    }
+  getter:
+    - { path: "a", expectString: "alpha" }
+    - { path: "b", expectString: "beta" }
+    - { path: "c", expectString: "gamma" }

--- a/testdata/hocon/deferred-resolution/dr04-self-ref-optional-with-fallback.yaml
+++ b/testdata/hocon/deferred-resolution/dr04-self-ref-optional-with-fallback.yaml
@@ -1,0 +1,43 @@
+# dr04 — Optional self-reference with fallback prior (s13a × WithFallback)
+#
+# Receiver: `a = ${?a} extra`  (optional self-reference)
+# Fallback:  `a = base`
+#
+# After WithFallback, the fallback's `a = "base"` becomes the lookback prior
+# for the receiver's optional self-ref. Resolve → `a = "base extra"`.
+#
+# Covers s13a edge case #1 (design doc § "s13a × WithFallback"):
+#   "After merge + resolve: a = 'base extra'"
+#
+# xref: S13a, S13a-merge-extension, E12
+
+description: Optional self-reference `a = ${?a} extra` with fallback `a = base` → resolves to "base extra".
+xref: [S13a, S13a-merge-extension, E12]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?a} extra
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    parseString: |
+      a = base
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": "base extra"
+    }
+  getter:
+    - { path: "a", expectString: "base extra" }

--- a/testdata/hocon/deferred-resolution/dr05-required-self-ref-with-fallback-prior.yaml
+++ b/testdata/hocon/deferred-resolution/dr05-required-self-ref-with-fallback-prior.yaml
@@ -1,0 +1,46 @@
+# dr05 — Required self-reference with fallback prior → succeeds (s13a × WithFallback)
+#
+# Receiver: `a = ${a} extra`  (required self-reference, NOT optional)
+# Fallback:  `a = base`
+#
+# After WithFallback, the fallback's `a = "base"` supplies the lookback prior
+# for the required self-ref. Resolve MUST succeed → `a = "base extra"`.
+#
+# Covers s13a edge case #3 (design doc § "s13a × WithFallback"):
+#   "Required self-ref resolves successfully because the fallback layer supplies
+#   the prior value."
+#
+# Contrast with dr06 where no fallback exists → ResolveError.
+#
+# xref: S13a, S13a-merge-extension, E12
+
+description: Required self-reference `a = ${a} extra` with fallback `a = base` → resolves to "base extra".
+xref: [S13a, S13a-merge-extension, E12]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${a} extra
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    parseString: |
+      a = base
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": "base extra"
+    }
+  getter:
+    - { path: "a", expectString: "base extra" }

--- a/testdata/hocon/deferred-resolution/dr06-required-self-ref-no-fallback.yaml
+++ b/testdata/hocon/deferred-resolution/dr06-required-self-ref-no-fallback.yaml
@@ -1,0 +1,32 @@
+# dr06 — Required self-reference, no fallback prior → ResolveError
+#
+# `${a}` (required, not optional `${?a}`) in the definition of `a` looks at the
+# prior value of `a`. If there is no prior — neither earlier in the same source
+# nor in any fallback layer — resolve MUST raise ResolveError per S13a.
+#
+# Template for error scenarios.
+
+description: Required self-reference with no prior value (neither same-source nor fallback) → CycleError.
+xref: [S13a, S13a-merge-extension]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${a} extra
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+# Lightbend reports `${a} = ${a}`-with-no-prior as a cycle (the substitution
+# would have to look back at the very value it's defining). Per spec § s13a
+# this is the correct cross-impl category. Impls that don't distinguish cycles
+# from generic unresolved errors MAY surface this as ResolveError; per-impl
+# override lists can map accordingly. The fixture pins the more-specific
+# Lightbend-faithful category.
+expect:
+  outcome: error
+  errorAt: 1
+  errorCategory: CycleError

--- a/testdata/hocon/deferred-resolution/dr07-allow-unresolved-partial.yaml
+++ b/testdata/hocon/deferred-resolution/dr07-allow-unresolved-partial.yaml
@@ -1,0 +1,33 @@
+# dr07 — AllowUnresolved=true partial resolution + getter assertions
+#
+# When AllowUnresolved=true, resolve() does NOT error on substitutions that
+# can't be resolved. Resolvable paths complete normally; unresolved paths
+# survive as placeholders. Getters on resolved paths return the value; getters
+# on unresolved paths raise NotResolved.
+#
+# Per spec § "Required substitution under AllowUnresolved=true": IsResolved
+# returns false because at least one substitution remained.
+
+description: AllowUnresolved=true allows partial resolution; specific path getters demonstrate the mix.
+xref: [E12-resolve-options]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${avail}
+      b = ${unavail}
+      avail = "hello"
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: true, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: false
+  getter:
+    - { path: "a", expectString: "hello" }
+    - { path: "avail", expectString: "hello" }
+    - { path: "b", expectError: NotResolved }

--- a/testdata/hocon/deferred-resolution/dr08-no-system-env.yaml
+++ b/testdata/hocon/deferred-resolution/dr08-no-system-env.yaml
@@ -1,0 +1,32 @@
+# dr08 — UseSystemEnvironment=false; env-only substitution → ResolveError
+#
+# Receiver references a substitution whose name is deliberately chosen to be
+# absent from any HOCON key in the test config (__HOCON_DR08_NONEXISTENT__).
+# Normally, Resolve() would fall back to the OS environment. With
+# UseSystemEnvironment=false the env lookup is suppressed, and the
+# substitution cannot be resolved → ResolveError.
+#
+# The substitution name uses a prefix that is extremely unlikely to collide
+# with a real environment variable on any CI platform.
+#
+# xref: E12-resolve-options, E12-use-system-environment
+
+description: Substitution ${__HOCON_DR08_NONEXISTENT__} with UseSystemEnvironment=false → ResolveError.
+xref: [E12-resolve-options, E12-use-system-environment]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${__HOCON_DR08_NONEXISTENT__}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: error
+  errorAt: 1
+  errorCategory: ResolveError
+  errorContains: "__HOCON_DR08_NONEXISTENT__"

--- a/testdata/hocon/deferred-resolution/dr09-getter-on-unresolved.yaml
+++ b/testdata/hocon/deferred-resolution/dr09-getter-on-unresolved.yaml
@@ -1,0 +1,36 @@
+# dr09 — Getter on unresolved path under AllowUnresolved=true
+#
+# AllowUnresolved=true allows Resolve() to succeed even if some substitutions
+# remain. The resolved path returns its value normally; the unresolved path
+# raises NotResolved when accessed via a getter.
+#
+# Emphasises the getter-level contract: AllowUnresolved does NOT make getters
+# lenient. Only the Resolve() call itself becomes non-erroring.
+#
+# Per spec § "Getters on unresolved Config":
+#   "AllowUnresolved=true does NOT make getters lenient — it only makes
+#   Resolve() itself non-erroring."
+#
+# xref: E12-resolve-options, E12-getter-unresolved
+
+description: AllowUnresolved=true; getter on resolved path returns value, getter on unresolved path → NotResolved.
+xref: [E12-resolve-options, E12-getter-unresolved]
+
+sources:
+  receiver:
+    parseString: |
+      found = "present"
+      missing = ${__HOCON_DR09_ABSENT__}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: true, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: false
+  getter:
+    - { path: "found", expectString: "present" }
+    - { path: "missing", expectError: NotResolved }

--- a/testdata/hocon/deferred-resolution/dr10-non-object-override.yaml
+++ b/testdata/hocon/deferred-resolution/dr10-non-object-override.yaml
@@ -1,0 +1,57 @@
+# dr10 — Non-object value blocks fallback object merge (Composition barrier)
+#
+# Per spec § "Composition":
+#   "Non-object values do not merge:
+#    obj.WithFallback(nonObj).WithFallback(otherObj) ignores otherObj."
+#
+# Scenario:
+#   receiver  = { a = { x = 1 } }           (a is an object)
+#   fallback1 = { a = "scalar" }             (a is a non-object scalar — barrier)
+#   fallback2 = { a = { y = 2 } }           (a is an object — blocked by fallback1)
+#
+# Receiver's `a = { x = 1 }` wins at path `a`. Fallback1's `a = "scalar"` is
+# non-object and interposes between receiver and fallback2. Fallback2's
+# `a = { y = 2 }` MUST NOT contribute `y` because the barrier (scalar at position
+# 2) prevents the merge. Result: `{ a: { x: 1 } }`.
+#
+# xref: E12-composition, HOCON.md-L1485
+
+description: Non-object scalar in fallback1 blocks fallback2 object from merging into receiver object at same path.
+xref: [E12-composition]
+
+sources:
+  receiver:
+    parseString: |
+      a = { x = 1 }
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb1:
+    parseString: |
+      a = "scalar"
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb2:
+    parseString: |
+      a = { y = 2 }
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb1, as: r1 }
+  - { op: withFallback, this: r1, other: fb2, as: r2 }
+  - { op: resolve, this: r2, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": {
+        "x": 1
+      }
+    }
+  getter:
+    - { path: "a.x", expectInt: 1 }

--- a/testdata/hocon/deferred-resolution/dr11a-resolve-with-source-keys-absent.yaml
+++ b/testdata/hocon/deferred-resolution/dr11a-resolve-with-source-keys-absent.yaml
@@ -1,0 +1,44 @@
+# dr11a — ResolveWith: source keys are NOT present in the result
+#
+# Per spec § "ResolveWith semantic":
+#   "Substitutions in receiver are looked up in source, but source's keys are
+#   NOT merged into the result. Differs from WithFallback(source).Resolve()
+#   because the latter includes source's keys in the resulting Config."
+#
+# Receiver: `r = ${value}` (one substitution, no `value` key of its own)
+# Source:   `{ value = "found" }` (already resolved)
+#
+# After ResolveWith(source):
+#   - `r` resolves to "found"
+#   - `value` key MUST NOT appear in the result (source's keys stay out)
+#
+# xref: E12-resolve-with, E12-resolve-with-precondition
+
+description: ResolveWith resolves receiver substitution from source, but source keys do not appear in result.
+xref: [E12-resolve-with, E12-resolve-with-precondition]
+
+sources:
+  receiver:
+    parseString: |
+      r = ${value}
+    parseOptions:
+      resolveSubstitutions: false
+
+  src:
+    parseString: |
+      value = "found"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: take, source: src, as: s0 }
+  - { op: resolveWith, this: r0, source: s0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "r": "found"
+    }
+  getter:
+    - { path: "r", expectString: "found" }

--- a/testdata/hocon/deferred-resolution/dr11b-resolve-with-unresolved-source.yaml
+++ b/testdata/hocon/deferred-resolution/dr11b-resolve-with-unresolved-source.yaml
@@ -1,0 +1,40 @@
+# dr11b — ResolveWith with unresolved source → NotResolved error
+#
+# Per spec § "Precondition on ResolveWith source": source MUST be resolved (or
+# substitution-free). If source is unresolved, ResolveWith MUST raise
+# NotResolved BEFORE attempting to resolve the receiver.
+
+description: ResolveWith with an unresolved source config raises NotResolved (MUST per E12 precondition).
+xref: [E12-resolve-with-precondition]
+
+# Intentional Lightbend divergence. Lightbend's resolveWith does NOT precondition-
+# check the source; it attempts resolution which then fails with
+# ConfigException.UnresolvedSubstitution (ResolveError). The E12 spec is
+# deliberately stricter: it requires a precondition check that raises NotResolved
+# BEFORE the receiver is touched, to make the error surface clearly identify the
+# user's mistake (passing an unresolved source). Per-impl tests assert the
+# NotResolved category; the Lightbend generator skips this scenario.
+lightbendSkip: true
+
+sources:
+  receiver:
+    parseString: |
+      r = ${value}
+    parseOptions:
+      resolveSubstitutions: false
+
+  bad-source:
+    parseString: |
+      value = ${still-unresolved}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: take, source: bad-source, as: s0 }
+  - { op: resolveWith, this: r0, source: s0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: error
+  errorAt: 2
+  errorCategory: NotResolved

--- a/testdata/hocon/deferred-resolution/dr12-origin-preserved.yaml
+++ b/testdata/hocon/deferred-resolution/dr12-origin-preserved.yaml
@@ -1,0 +1,45 @@
+# dr12 — Origin preserved in resolve error message
+#
+# Source is parsed with an explicit originDescription so that error messages
+# include a human-readable source name. The config contains an unresolvable
+# required substitution `${missing}` at path `bad`.
+#
+# When resolve(allowUnresolved=false) fails, the error message MUST reference
+# either the path (`bad`) or the originDescription ("scenario-dr12-input.conf")
+# so callers can locate the problem.
+#
+# Per spec § "Origin preservation":
+#   "Error messages MUST include the relevant Origin."
+#
+# Per README § "Per-impl override notes — dr12":
+#   Lightbend formats positions differently; generator emits errorContains
+#   with a Lightbend-format substring; per-impl tests check their format.
+#
+# xref: E12-origin, go.hocon#99 (acceptance criterion: useful source position in errors)
+
+description: Resolve error on ${missing} at path `bad` must include origin info (path or source name) in message.
+xref: [E12-origin, go.hocon#99]
+
+sources:
+  receiver:
+    parseString: |
+      bad = ${missing}
+    parseOptions:
+      resolveSubstitutions: false
+      originDescription: "scenario-dr12-input.conf"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: error
+  errorAt: 1
+  errorCategory: ResolveError
+  # Match the originDescription substring. Lightbend's message format is
+  # `<origin>: <line>: Could not resolve substitution to a value: ${missing}`.
+  # Other impls may include the path `bad` and/or the substitution `${missing}`
+  # in addition to or instead of the origin; per-impl tests assert on the
+  # impl's actual format. The cross-impl invariant is: the message contains
+  # SOME origin information (origin name OR path OR substitution target).
+  errorContains: "scenario-dr12-input.conf"

--- a/testdata/hocon/deferred-resolution/dr13-type-error-under-allow-unresolved.yaml
+++ b/testdata/hocon/deferred-resolution/dr13-type-error-under-allow-unresolved.yaml
@@ -1,0 +1,43 @@
+# dr13 — Type error fires even under AllowUnresolved=true (s10 × AllowUnresolved)
+#
+# `a = "p" [1,2]` is a string-then-array concatenation. This is a type-
+# incompatible concatenation per S10 (concat type-check).
+#
+# Per spec § "s10 × AllowUnresolved":
+#   "AllowUnresolved defers *missing-value* errors, not *type* errors.
+#   A type error is structurally invalid regardless of resolution status."
+#
+# The error is expected at parse time (the concatenation is syntactically
+# malformed from the type system's perspective). Lightbend raises
+# ConfigException.Parse for this at parse time.
+#
+# Per-impl note: if an impl raises this error at resolve-time under
+# AllowUnresolved=true rather than at parse time, the errorAt index may be 1
+# (resolve step). The YAML marks errorAt as omitted (any step) to accommodate
+# both behaviours.
+#
+# xref: S10, E12-allow-unresolved, E12-type-error
+
+description: Type-incompatible concat `"p" [1,2]` raises TypeError even at parse time (before resolve).
+xref: [S10, E12-allow-unresolved]
+
+sources:
+  receiver:
+    parseString: |
+      a = "p" [1,2]
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: true, useSystemEnvironment: false, as: result }
+
+# Lightbend fires the type check during parseString (before any resolve()
+# call), surfacing as ConfigException.WrongType (TypeError). Impls that defer
+# the type check to resolve time may surface it at step 1 (resolve) instead;
+# both are spec-compliant per § "s10 × AllowUnresolved" ("structurally
+# invalid regardless of resolution status"). errorAt is omitted to allow
+# both placements.
+expect:
+  outcome: error
+  errorCategory: TypeError

--- a/testdata/hocon/deferred-resolution/dr14-deferred-concat-placeholder.yaml
+++ b/testdata/hocon/deferred-resolution/dr14-deferred-concat-placeholder.yaml
@@ -1,0 +1,34 @@
+# dr14 — Deferred concat placeholder survives under AllowUnresolved=true
+#
+# `a = ${x} ${y}` where both ${x} and ${y} are undefined. With
+# AllowUnresolved=true, Resolve() MUST NOT error — it leaves `a` as a concat
+# placeholder with both operands unresolved.
+#
+# Per spec § "s10 × AllowUnresolved":
+#   "All operands unresolved: no type-check; concat remains as concat-placeholder.
+#   Getter on this path → NotResolved."
+#
+# The getter on `a` MUST raise NotResolved, demonstrating that the concat
+# placeholder is retained and getters still enforce resolution status.
+#
+# xref: S10, E12-allow-unresolved, E12-getter-unresolved
+
+description: Fully-unresolved concat `${x} ${y}` (both undef) survives as placeholder under AllowUnresolved=true; getter → NotResolved.
+xref: [S10, E12-allow-unresolved, E12-getter-unresolved]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${x} ${y}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: true, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: false
+  getter:
+    - { path: "a", expectError: NotResolved }

--- a/testdata/hocon/deferred-resolution/dr15-include-deferred.yaml
+++ b/testdata/hocon/deferred-resolution/dr15-include-deferred.yaml
@@ -1,0 +1,53 @@
+# dr15 — Literal data accessible without error; substitution deferred until resolve
+#
+# Per spec § "E11 × parse phase" (OQ-9):
+#   "Includes are resolved at parse phase, NOT deferred. UnresolvedConfig has
+#   includes already expanded; only ${...} substitutions are deferred."
+#
+# This fixture verifies the boundary: after parseString with
+# resolveSubstitutions=false, literal values are accessible (no NotResolved
+# error) while substitution paths remain unresolved.
+#
+# After resolve with AllowUnresolved=false + FromMap fallback providing KEY,
+# both `lit` and `sub` are accessible. Demonstrates that parse-phase
+# expansion (literal data) and resolve-phase expansion (substitutions) are
+# correctly separated.
+#
+# Note: include-file scenarios are not expressible in scenario YAML (no file
+# system access from the YAML runner). The include-phase guarantee is covered
+# by per-impl tests; this YAML covers the literal-vs-substitution boundary.
+#
+# xref: E11, E12-include-timing, OQ-9
+
+description: Literal field accessible before resolve; substitution deferred; both accessible after resolve with fallback.
+xref: [E11, E12-include-timing]
+
+sources:
+  receiver:
+    parseString: |
+      lit = "value"
+      sub = ${KEY}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    fromMap:
+      KEY: "resolved"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "KEY": "resolved",
+      "lit": "value",
+      "sub": "resolved"
+    }
+  getter:
+    - { path: "lit", expectString: "value" }
+    - { path: "sub", expectString: "resolved" }

--- a/testdata/hocon/deferred-resolution/dr16-frommap-nested-coercion.yaml
+++ b/testdata/hocon/deferred-resolution/dr16-frommap-nested-coercion.yaml
@@ -1,0 +1,56 @@
+# dr16 — FromMap type coercion: bool, int, float, string, list, nested map, null
+#
+# Verifies that FromMap correctly coerces all HOCON scalar types, lists,
+# nested maps, and null from in-memory values.
+#
+# Per spec § "Value factories — Type coercion table":
+#   - null  → HOCON null
+#   - bool  → HOCON boolean
+#   - int   → HOCON number (integral)
+#   - float → HOCON number (non-integral)
+#   - string → HOCON string
+#   - list  → HOCON array
+#   - nested map → HOCON object
+#
+# xref: E12-frommap, E12-frommap-coercion
+
+description: FromMap with all scalar types, list, nested map, and null — verify coercion correctness.
+xref: [E12-frommap, E12-frommap-coercion]
+
+sources:
+  fm:
+    fromMap:
+      flag: true
+      count: 42
+      ratio: 3.14
+      label: "hello"
+      items: [1, 2, 3]
+      nested:
+        inner: "deep"
+      nothing: null
+
+build:
+  - { op: take, source: fm, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "count": 42,
+      "flag": true,
+      "items": [1, 2, 3],
+      "label": "hello",
+      "nested": {
+        "inner": "deep"
+      },
+      "nothing": null,
+      "ratio": 3.14
+    }
+  getter:
+    - { path: "flag",         expectString: "true" }
+    - { path: "count",        expectInt:    42 }
+    - { path: "label",        expectString: "hello" }
+    - { path: "nested.inner", expectString: "deep" }
+    - { path: "items",        expectArray:  [1, 2, 3] }

--- a/testdata/hocon/deferred-resolution/dr17-e11-package-include-deferred.yaml
+++ b/testdata/hocon/deferred-resolution/dr17-e11-package-include-deferred.yaml
@@ -1,0 +1,64 @@
+# dr17 — E11 `include package(...)` + deferred substitution (Lightbend-skip)
+#
+# `include package("<id>", "<file>")` is an xx.hocon E11 extension. Lightbend
+# has no `package(...)` include qualifier; this scenario is not applicable to
+# the Java generator.
+#
+# Per spec § "E11 × parse phase":
+#   "E11 package(...) resolver runs at parse time. A parse-only result has all
+#   include directives including package(...) fully expanded. Substitutions
+#   inside an included file are deferred along with the outer substitutions."
+#
+# The Java generator SKIPS this scenario (lightbendSkip: true). Per-impl
+# conformance tests run it against their own implementation using the package
+# registry API defined by E11.
+#
+# Since YAML-based runners cannot register a package resolver, per-impl tests
+# for dr17 are necessarily programmatic. This YAML documents the scenario
+# semantics and serves as the canonical spec-level record.
+#
+# Scenario intent:
+#   Source string includes `include package("test-pkg", "ref.conf")`.
+#   The referenced content defines `value = ${EXTERNAL}`.
+#   After parse (with resolveSubstitutions=false), the include is expanded.
+#   Resolve with a FromMap fallback providing EXTERNAL → value is accessible.
+#
+# xref: E11, E12-include-timing, E12-e11-cross-ref
+
+lightbendSkip: true
+
+description: >
+  E11 package include expanded at parse phase; substitution inside included content
+  deferred until resolve. Not applicable to Lightbend (no package() qualifier).
+  Per-impl tests only.
+xref: [E11, E12-include-timing]
+
+sources:
+  receiver:
+    parseString: |
+      outer = "top"
+      inner = ${EXTERNAL}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    fromMap:
+      EXTERNAL: "injected"
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "EXTERNAL": "injected",
+      "inner": "injected",
+      "outer": "top"
+    }
+  getter:
+    - { path: "outer", expectString: "top" }
+    - { path: "inner", expectString: "injected" }

--- a/testdata/hocon/deferred-resolution/dr18-cross-layer-cycle.yaml
+++ b/testdata/hocon/deferred-resolution/dr18-cross-layer-cycle.yaml
@@ -1,0 +1,46 @@
+# dr18 — Cross-layer substitution cycle → CycleError
+#
+# Receiver: `a = ${b}`
+# Fallback:  `b = ${a}`
+#
+# After WithFallback, the merged tree contains a cycle: a → b → a.
+# Resolve MUST detect this and raise CycleError (or the closest impl
+# equivalent).
+#
+# Per spec § "Cross-layer cycle detection":
+#   "After WithFallback, resolving the merged tree must detect the a → b → a
+#   cycle and raise ResolveError (CycleError). The cycle-detection algorithm
+#   is impl-internal; the conformance requirement is that emerging-on-merge
+#   cycles are detected."
+#
+# Note: Lightbend raises ConfigException.UnresolvedSubstitution for cycles
+# (no dedicated CycleError distinction). Per-impl runners map their concrete
+# error to the CycleError category.
+#
+# xref: E12-cycle-detection
+
+description: Receiver `a = ${b}`, fallback `b = ${a}` — cross-layer cycle detected at resolve → CycleError.
+xref: [E12-cycle-detection]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${b}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    parseString: |
+      b = ${a}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: error
+  errorAt: 2
+  errorCategory: CycleError

--- a/testdata/hocon/deferred-resolution/dr19-resolve-idempotent.yaml
+++ b/testdata/hocon/deferred-resolution/dr19-resolve-idempotent.yaml
@@ -1,0 +1,47 @@
+# dr19 — Resolve is idempotent (programmatic assertion; YAML records single resolve)
+#
+# Per spec § "Idempotency of Resolve":
+#   "Resolve on an already-resolved Config is a no-op that returns an equivalent
+#   Config (either the same instance or a copy with identical value tree).
+#   Matches Lightbend's documented resolve() behaviour: 'Resolving an already-
+#   resolved config is a harmless no-op'."
+#
+# The full assertion (c.Resolve().Resolve() == c.Resolve()) is not expressible
+# in scenario YAML v1 because there is no "compare two builds" op. Per-impl
+# tests verify the idempotency property programmatically.
+#
+# This YAML records the spec assertion at the single-resolve level and serves
+# as the canonical spec-level fixture for the scenario. The result of one
+# resolve is the expected state; the programmatic double-resolve verification
+# is per-impl only.
+#
+# xref: E12-idempotency
+
+description: >
+  Resolve is idempotent (c.Resolve().Resolve() == c.Resolve()). YAML records
+  single-resolve outcome only; per-impl tests verify double-resolve programmatically.
+xref: [E12-idempotency]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${b}
+      b = 7
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": 7,
+      "b": 7
+    }
+  getter:
+    - { path: "a", expectInt: 7 }
+    - { path: "b", expectInt: 7 }

--- a/testdata/hocon/deferred-resolution/dr20-transitive-single-source.yaml
+++ b/testdata/hocon/deferred-resolution/dr20-transitive-single-source.yaml
@@ -1,0 +1,44 @@
+# dr20 — Transitive substitution within a single source
+#
+# `a = ${b}; b = ${c}; c = 1` — substitution is two hops deep. Resolve MUST
+# follow transitive references: `a` → `b` → `c` → `1`, yielding `a = 1`.
+#
+# Per spec § "Transitive substitution resolution":
+#   "Resolve does not stop at one level of indirection. Resolving ${a} where
+#   a = ${b} and b = ${c} and c = 1 MUST yield 1 (not leave ${b} unresolved)."
+#
+# Per spec § "Single-pass resolution over fallback stack":
+#   "One top-level operation does NOT mean one tree walk. Substitution resolution
+#   is transitive and lazy within that one operation."
+#
+# xref: E12-transitive, E12-single-pass
+
+description: Transitive substitution `a = ${b}; b = ${c}; c = 1` in single source → `a = 1, b = 1, c = 1`.
+xref: [E12-transitive, E12-single-pass]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${b}
+      b = ${c}
+      c = 1
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  getter:
+    - { path: "a", expectInt: 1 }
+    - { path: "b", expectInt: 1 }
+    - { path: "c", expectInt: 1 }

--- a/testdata/hocon/deferred-resolution/dr21-transitive-cross-layer.yaml
+++ b/testdata/hocon/deferred-resolution/dr21-transitive-cross-layer.yaml
@@ -1,0 +1,56 @@
+# dr21 — Transitive substitution across three fallback layers
+#
+# Receiver: `a = ${b}`        (a references b, defined in fb1)
+# fb1:      `b = ${c}`        (b references c, defined in fb2)
+# fb2:      `c = 1`           (c is the concrete value)
+#
+# After composing three layers and resolving once at the top, the transitive
+# chain `a → b → c → 1` must resolve completely → `a = 1, b = 1, c = 1`.
+#
+# Per spec § "Transitive substitution resolution" and § "Single-pass resolution":
+#   The single top-level Resolve() operation walks the merged tree transitively.
+#   Substitutions in any layer resolve against the full merged stack.
+#
+# xref: E12-transitive, E12-multi-layer, E12-single-pass
+
+description: Transitive substitution `a = ${b}` (fb1) `b = ${c}` (fb2) `c = 1` across 3 layers → all resolve to 1.
+xref: [E12-transitive, E12-multi-layer, E12-single-pass]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${b}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb1:
+    parseString: |
+      b = ${c}
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb2:
+    parseString: |
+      c = 1
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb1, as: r1 }
+  - { op: withFallback, this: r1, other: fb2, as: r2 }
+  - { op: resolve, this: r2, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  getter:
+    - { path: "a", expectInt: 1 }
+    - { path: "b", expectInt: 1 }
+    - { path: "c", expectInt: 1 }

--- a/testdata/hocon/deferred-resolution/dr22-hidden-single-source.yaml
+++ b/testdata/hocon/deferred-resolution/dr22-hidden-single-source.yaml
@@ -1,0 +1,45 @@
+# dr22 — Hidden substitution not evaluated within a single source
+#
+# ```hocon
+# foo = ${nonexist}
+# foo = 42
+# ```
+#
+# The first `foo = ${nonexist}` is overridden by the second `foo = 42`.
+# The overridden definition (with its substitution placeholder) is dropped
+# from the resolution tree and MUST NOT be evaluated.
+#
+# Per spec § "Hidden substitutions are not evaluated":
+#   "HOCON.md §Substitutions L670–L703: substitutions in overridden values
+#   are discarded before resolution. This MUST resolve to {foo: 42} without
+#   error."
+#
+# Resolve with allowUnresolved=false MUST succeed and yield `{foo: 42}`.
+# `nonexist` being absent does NOT cause a ResolveError.
+#
+# xref: E12-hidden-subst, HOCON.md-L670
+
+description: Overridden `foo = ${nonexist}` is hidden by later `foo = 42`; hidden substitution not evaluated → succeeds.
+xref: [E12-hidden-subst]
+
+sources:
+  receiver:
+    parseString: |
+      foo = ${nonexist}
+      foo = 42
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "foo": 42
+    }
+  getter:
+    - { path: "foo", expectInt: 42 }

--- a/testdata/hocon/deferred-resolution/dr23-hidden-across-layers.yaml
+++ b/testdata/hocon/deferred-resolution/dr23-hidden-across-layers.yaml
@@ -1,0 +1,47 @@
+# dr23 — Hidden substitution dropped when receiver wins across fallback layers
+#
+# Receiver: `{ foo = 42 }`          (foo is a concrete int)
+# Fallback:  `{ foo = ${nonexist} }` (foo is an unresolvable substitution)
+#
+# After WithFallback, the receiver's `foo = 42` wins (receiver has priority).
+# The fallback's `foo = ${nonexist}` is a hidden/overridden value and MUST NOT
+# be evaluated. Resolve MUST succeed with `{foo: 42}`.
+#
+# Per spec § "Hidden substitutions are not evaluated":
+#   "The same rule applies across fallback layers. A.WithFallback(B) produces a
+#   merged tree where A's keys win. B.WithFallback(A): B's foo wins, A's sub
+#   is dropped — no error."
+#   Here receiver = A (wins), fallback = B (dropped).
+#
+# xref: E12-hidden-subst, HOCON.md-L670
+
+description: Receiver `foo = 42` wins over fallback `foo = ${nonexist}`; fallback substitution dropped → succeeds.
+xref: [E12-hidden-subst]
+
+sources:
+  receiver:
+    parseString: |
+      foo = 42
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    parseString: |
+      foo = ${nonexist}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "foo": 42
+    }
+  getter:
+    - { path: "foo", expectInt: 42 }

--- a/testdata/hocon/deferred-resolution/dr24-optional-standalone-undef.yaml
+++ b/testdata/hocon/deferred-resolution/dr24-optional-standalone-undef.yaml
@@ -1,0 +1,32 @@
+# dr24 — Optional standalone substitution undefined → field omitted
+#
+# `a = ${?x}` where x is undefined. The field `a` MUST be omitted from the
+# resulting object — it does NOT appear as null or empty string.
+#
+# Per spec § "Optional substitution materialisation in concat contexts":
+#   "Standalone field value: Field is omitted from parent object.
+#   Example: `a = ${?x}` (x undef) → {} (no `a` key)"
+#
+# Per HOCON.md §Substitutions L626–L645.
+#
+# xref: E12-optional-subst, HOCON.md-L626
+
+description: Optional standalone `a = ${?x}` (x undefined) → field `a` omitted from result; expected JSON `{}`.
+xref: [E12-optional-subst]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?x}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {}

--- a/testdata/hocon/deferred-resolution/dr25-optional-string-concat-undef.yaml
+++ b/testdata/hocon/deferred-resolution/dr25-optional-string-concat-undef.yaml
@@ -1,0 +1,39 @@
+# dr25 — Optional substitution in string concat (undefined) → empty string contribution
+#
+# `a = ${?x} "tail"` where x is undefined. The undefined ${?x} materialises
+# as an empty string in string-concat context. The leading space between
+# ${?x} and "tail" is preserved per HOCON whitespace-in-concat rules.
+# Result: `a = " tail"` (space + tail).
+#
+# Per spec § "Optional substitution materialisation in concat contexts":
+#   "String concat: Empty string.
+#   Example: `a = ${?x} 'tail'` → a = ' tail' (leading space preserved)"
+#
+# Per HOCON.md §Concatenation L387–L441 (whitespace between concat elements
+# is preserved as a literal space character when the optional sub collapses).
+#
+# xref: E12-optional-subst, HOCON.md-L387
+
+description: Optional string concat `a = ${?x} "tail"` (x undef) → `a = " tail"` (leading space preserved).
+xref: [E12-optional-subst]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?x} "tail"
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": " tail"
+    }
+  getter:
+    - { path: "a", expectString: " tail" }

--- a/testdata/hocon/deferred-resolution/dr26-optional-array-concat-undef.yaml
+++ b/testdata/hocon/deferred-resolution/dr26-optional-array-concat-undef.yaml
@@ -1,0 +1,37 @@
+# dr26 — Optional substitution in array concat (undefined) → empty array contribution
+#
+# `a = ${?x} [1,2]` where x is undefined. The undefined ${?x} materialises
+# as an empty array in array-concat context (no elements contributed).
+# Result: `a = [1, 2]`.
+#
+# Per spec § "Optional substitution materialisation in concat contexts":
+#   "Array concat: Empty array (no elements contributed).
+#   Example: `a = ${?x} [1,2]` (x undef) → a = [1,2]"
+#
+# Per HOCON.md §Concatenation L387–L441.
+#
+# xref: E12-optional-subst, HOCON.md-L387
+
+description: Optional array concat `a = ${?x} [1,2]` (x undef) → `a = [1,2]`.
+xref: [E12-optional-subst]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?x} [1,2]
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": [1, 2]
+    }
+  getter:
+    - { path: "a", expectArray: [1, 2] }

--- a/testdata/hocon/deferred-resolution/dr27-optional-object-merge-undef.yaml
+++ b/testdata/hocon/deferred-resolution/dr27-optional-object-merge-undef.yaml
@@ -1,0 +1,39 @@
+# dr27 — Optional substitution in object merge (undefined) → empty object contribution
+#
+# `a = ${?x} { k = 1 }` where x is undefined. The undefined ${?x} materialises
+# as an empty object in object-merge context (no keys contributed).
+# Result: `a = { k = 1 }`.
+#
+# Per spec § "Optional substitution materialisation in concat contexts":
+#   "Object merge: Empty object (no keys contributed).
+#   Example: `a = ${?x} { k = 1 }` (x undef) → a = {k:1}"
+#
+# Per HOCON.md §Concatenation L387–L441.
+#
+# xref: E12-optional-subst, HOCON.md-L387
+
+description: "Optional object merge `a = ${?x} { k = 1 }` (x undef) resolves to a = {k: 1}."
+xref: [E12-optional-subst]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?x} { k = 1 }
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": {
+        "k": 1
+      }
+    }
+  getter:
+    - { path: "a.k", expectInt: 1 }

--- a/testdata/hocon/deferred-resolution/dr28-optional-multi-all-undef.yaml
+++ b/testdata/hocon/deferred-resolution/dr28-optional-multi-all-undef.yaml
@@ -1,0 +1,33 @@
+# dr28 — Multiple optional substitutions, all undefined → field omitted
+#
+# `a = ${?x}${?y}` where both x and y are undefined. The entire value
+# consists only of undefined optional substitutions. Per HOCON materialisation
+# rules, when all operands collapse to empty and the result is an empty string,
+# the field itself is omitted (same rule as standalone undefined optional).
+#
+# Per spec § "Optional substitution materialisation in concat contexts":
+#   "String concat (multiple optional, all undef): Empty string; if entire
+#   value is empty, field is omitted.
+#   Example: `a = ${?x}${?y}` (both undef) → {} (no `a` key)"
+#
+# xref: E12-optional-subst, HOCON.md-L626
+
+description: "a = ${?x}${?y} — both undefined — field `a` omitted; expected JSON {}."
+xref: [E12-optional-subst]
+
+sources:
+  receiver:
+    parseString: |
+      a = ${?x}${?y}
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: resolve, this: r0, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {}

--- a/testdata/hocon/deferred-resolution/dr29-empty-config-edges.yaml
+++ b/testdata/hocon/deferred-resolution/dr29-empty-config-edges.yaml
@@ -1,0 +1,51 @@
+# dr29 — Empty Config edge cases
+#
+# This YAML covers one directly expressible edge:
+#   `{ a = 1 }.WithFallback(Empty()) → { a: 1 }`
+#
+# The other two edges are not expressible in scenario YAML v1 (no "compare two
+# builds" op and Empty().Resolve() produces an empty JSON object that is
+# trivially expressible but uninteresting without comparing to a second build):
+#
+#   (a) Empty().Resolve() → {} (empty resolved Config; no error)
+#   (b) Empty().WithFallback(c) → equivalent to c (receiver is empty, fallback
+#       supplies all keys)
+#
+# Per-impl tests cover edges (a) and (b) programmatically. This YAML documents
+# the scenario family and verifies the WithFallback(Empty()) no-op case.
+#
+# Per spec § "Value factories":
+#   "Empty(o) is equivalent to FromMap({}, o). Impls MAY implement one in terms
+#   of the other."
+#
+# xref: E12-empty, E12-frommap
+
+description: >
+  `{ a = 1 }.WithFallback(Empty())` → `{a: 1}`. Other edges (Empty().Resolve(),
+  Empty().WithFallback(c)) verified programmatically per-impl.
+xref: [E12-empty, E12-frommap]
+
+sources:
+  receiver:
+    parseString: |
+      a = 1
+    parseOptions:
+      resolveSubstitutions: false
+
+  empty:
+    fromMap: {}
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: empty, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": 1
+    }
+  getter:
+    - { path: "a", expectInt: 1 }

--- a/testdata/hocon/deferred-resolution/dr30-object-merge-barrier.yaml
+++ b/testdata/hocon/deferred-resolution/dr30-object-merge-barrier.yaml
@@ -1,0 +1,48 @@
+# dr30 — Receiver non-object scalar blocks fallback object merge
+#
+# Receiver: `{ a = 42 }`        (a is a scalar integer — non-object)
+# Fallback:  `{ a = { k = 1 } }` (a is an object)
+#
+# Per HOCON object-merge semantics (HOCON.md L1485) and spec § "Composition":
+#   "Non-object values do not merge."
+# The receiver's `a = 42` is a non-object scalar. The fallback's `a = { k = 1 }`
+# is an object. Object merge does NOT happen here because the receiver value
+# is not an object. Receiver wins. Result: `{ a: 42 }`.
+#
+# This is the symmetric counterpart to dr10 (where the barrier was in the
+# middle of the fallback chain). Here the barrier is in the receiver itself.
+#
+# Expected: `{a: 42}` — NOT `{a: {k:1}}` or a merged form.
+#
+# xref: E12-composition, HOCON.md-L1485
+
+description: "Receiver `a = 42` (scalar) wins over fallback `a = { k = 1 }` (object); no merge. Result: a = 42."
+xref: [E12-composition]
+
+sources:
+  receiver:
+    parseString: |
+      a = 42
+    parseOptions:
+      resolveSubstitutions: false
+
+  fb:
+    parseString: |
+      a = { k = 1 }
+    parseOptions:
+      resolveSubstitutions: false
+
+build:
+  - { op: take, source: receiver, as: r0 }
+  - { op: withFallback, this: r0, other: fb, as: r1 }
+  - { op: resolve, this: r1, allowUnresolved: false, useSystemEnvironment: false, as: result }
+
+expect:
+  outcome: success
+  isResolved: true
+  json: |-
+    {
+      "a": 42
+    }
+  getter:
+    - { path: "a", expectInt: 42 }

--- a/value_factory.go
+++ b/value_factory.go
@@ -1,0 +1,135 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/o3co/go.hocon/internal/resolver"
+)
+
+// FromMap constructs a Config from an in-memory map.  Keys are treated as
+// plain keys (NOT path expressions — `"a.b": 1` produces a top-level key
+// literally named "a.b", not nested `a.b`).  Values are coerced per the
+// spec table (E12 § "Value factories").
+//
+// originDescription provides the source name for error messages when no
+// file path is associated; "" means "use default".
+//
+// Returns ErrNotResolved is never; substitutions are not parsed from FromMap
+// input.  Type-coercion errors return a fmt.Errorf wrapping the bad path.
+func FromMap(values map[string]any, originDescription string) (*Config, error) {
+	obj, err := coerceMap(values)
+	if err != nil {
+		return nil, err
+	}
+	return &Config{
+		root:              obj,
+		resolved:          true,
+		originDescription: originDescription,
+	}, nil
+}
+
+// Empty returns a Config with no keys.  Equivalent to FromMap(nil, origin).
+func Empty(originDescription string) *Config {
+	return &Config{
+		root:              resolver.NewObjectVal(),
+		resolved:          true,
+		originDescription: originDescription,
+	}
+}
+
+func coerceMap(in map[string]any) (*resolver.ObjectVal, error) {
+	obj := resolver.NewObjectVal()
+	// Sorted key iteration so cross-impl JSON output is stable.
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v, err := coerceValue(in[k])
+		if err != nil {
+			return nil, fmt.Errorf("FromMap: key %q: %w", k, err)
+		}
+		obj.Set(k, v)
+	}
+	return obj, nil
+}
+
+func coerceValue(v any) (resolver.Val, error) {
+	if v == nil {
+		return &resolver.ScalarVal{Raw: "null", Type: resolver.ScalarNull}, nil
+	}
+	switch x := v.(type) {
+	case bool:
+		raw := "false"
+		if x {
+			raw = "true"
+		}
+		return &resolver.ScalarVal{Raw: raw, Type: resolver.ScalarBoolean}, nil
+	case string:
+		return &resolver.ScalarVal{Raw: x, Type: resolver.ScalarString}, nil
+	case int:
+		return &resolver.ScalarVal{Raw: strconv.FormatInt(int64(x), 10), Type: resolver.ScalarNumber}, nil
+	case int8:
+		return &resolver.ScalarVal{Raw: strconv.FormatInt(int64(x), 10), Type: resolver.ScalarNumber}, nil
+	case int16:
+		return &resolver.ScalarVal{Raw: strconv.FormatInt(int64(x), 10), Type: resolver.ScalarNumber}, nil
+	case int32:
+		return &resolver.ScalarVal{Raw: strconv.FormatInt(int64(x), 10), Type: resolver.ScalarNumber}, nil
+	case int64:
+		return &resolver.ScalarVal{Raw: strconv.FormatInt(x, 10), Type: resolver.ScalarNumber}, nil
+	case uint:
+		return uintToVal(uint64(x))
+	case uint8:
+		return &resolver.ScalarVal{Raw: strconv.FormatUint(uint64(x), 10), Type: resolver.ScalarNumber}, nil
+	case uint16:
+		return &resolver.ScalarVal{Raw: strconv.FormatUint(uint64(x), 10), Type: resolver.ScalarNumber}, nil
+	case uint32:
+		return &resolver.ScalarVal{Raw: strconv.FormatUint(uint64(x), 10), Type: resolver.ScalarNumber}, nil
+	case uint64:
+		return uintToVal(x)
+	case float32:
+		return floatToVal(float64(x))
+	case float64:
+		return floatToVal(x)
+	case []any:
+		arr := &resolver.ArrayVal{}
+		for i, e := range x {
+			ev, err := coerceValue(e)
+			if err != nil {
+				return nil, fmt.Errorf("element[%d]: %w", i, err)
+			}
+			arr.Elements = append(arr.Elements, ev)
+		}
+		return arr, nil
+	case map[string]any:
+		return coerceMap(x)
+	}
+	return nil, fmt.Errorf("unsupported value type %T", v)
+}
+
+func uintToVal(u uint64) (resolver.Val, error) {
+	if u > math.MaxInt64 {
+		return nil, fmt.Errorf("uint64 value %d exceeds int64.Max (HOCON numbers fit int64)", u)
+	}
+	return &resolver.ScalarVal{Raw: strconv.FormatUint(u, 10), Type: resolver.ScalarNumber}, nil
+}
+
+func floatToVal(f float64) (resolver.Val, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil, fmt.Errorf("float value %v is not finite (NaN/Inf not representable in HOCON)", f)
+	}
+	// Use FormatFloat with -1 precision for round-tripable representation.
+	return &resolver.ScalarVal{Raw: strconv.FormatFloat(f, 'g', -1, 64), Type: resolver.ScalarNumber}, nil
+}


### PR DESCRIPTION
## Summary

Implements xx.hocon E12 (deferred substitution resolution) in go.hocon. Closes #99.

Adds the Lightbend-aligned `parse → withFallback → resolve()` lifecycle requested by @cgordon. Existing `ParseString` / `ParseFile` behaviour is unchanged (still parse-and-resolve in one call); the new API surface is purely additive.

**New entry points:** `ParseStringWithOptions`, `ParseFileWithOptions`, `FromMap`, `Empty`.
**New methods on `*Config`:** `Resolve`, `ResolveWith`, `IsResolved`. `WithFallback` extended to accept unresolved operands.
**New types:** `ParseOptions`, `ResolveOptions` (both builder-style with `DefaultX()` factories + chainable `WithX()` setters).
**New errors:** `ErrNotResolved` sentinel.

All 30 cross-impl scenario fixtures (`testdata/hocon/deferred-resolution/dr01-dr30`, 28 driven directly + dr12/dr17 covered programmatically) pass against Lightbend ground truth.

**Cross-spec amendments** (already merged into xx.hocon spec):
- S13a × WithFallback: self-reference lookback walks across fallback layers.
- S10 × AllowUnresolved: type-incompatible concat errors fire even under `AllowUnresolved=true`.
- Hidden substitutions in overridden values are not evaluated (HOCON.md L670-703).

**Bundled fix:** S13.15 multi-optional-undef concat materialisation — `a = ${?x}${?y}` (both undef) now correctly omits the field per HOCON.md L640 (was producing `{"a":""}`). The dr28 fixture surfaced the divergence. Closes #78.

**Multi-agent-review findings addressed in commit 4773163:**
- C1 (convergent — Claude + Codex): ResolveWith now filters recursively by receiver's pre-merge tree shape (previously kept only top-level receiver keys → source's nested keys leaked under shared top-level keys).
- I1: `lookup` / `lookupSoft` short-circuit `isUnresolvedPlaceholder` on `c.resolved=true` — eliminates per-getter subtree walk for the dominant resolved-Config path.
- I3: `ParseError` / `ResolveError` gain `OriginDescription` field surfaced in `Error()` when `FilePath` is empty; `ParseOptions.OriginDescription` now flows end-to-end into error messages.

**Out of scope (filed separately):** I2 — `ResetPackageRegistry` lacks the `//go:build testing` tag the E11 CHANGELOG claims (pre-existing).

**Release target:** v1.4.0 (minor — purely additive public API).

## Test plan

- [x] `go test ./... -count=1 -race` — all 6 packages green
- [x] `go vet ./...` clean
- [x] `make testdata` re-fetches `deferred-resolution/` from xx.hocon (Makefile updated)
- [x] Layer-1 programmatic tests in `deferred_resolution_test.go` (~35 tests)
- [x] Layer-2 YAML scenario runner in `deferred_resolution_fixture_test.go` (28/30 scenarios; dr17 + dr12 covered programmatically)
- [x] `/multi-agent-review` clean post-fix (Claude + Codex, both green after 4773163)

## Spec references

- xx.hocon E12 entry: [docs/extra-spec-conventions.md § E12](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md#e12)
- Design doc copy: `docs/proposals/E12-deferred-resolution-design.md`
- External origin: #99 (@cgordon)
- Spec tracking: o3co/xx.hocon#37 (merged)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)