### PR TITLE
fix(parser): accept comma separator after newline — closes #104

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -192,12 +192,16 @@ func (p *parser) parseObjectFields(braced bool) (*ObjectNode, error) {
 	return obj, nil
 }
 
-// skipSeparator consumes an optional comma or newline separator.
+// skipSeparator consumes an optional comma surrounded by optional newlines.
+// HOCON accepts a comma after newline(s) following a completed field/element
+// (e.g. `a: 1\n,\nb: 2`), so newlines must be consumed before and after the
+// optional comma — not only after (closes #104).
 func (p *parser) skipSeparator() {
+	p.skipNewlines()
 	if p.current.Type == lexer.TokenComma {
 		p.advance()
+		p.skipNewlines()
 	}
-	p.skipNewlines()
 }
 
 // onlyClosingParens reports whether `s` is a non-empty string consisting

--- a/issue104_test.go
+++ b/issue104_test.go
@@ -1,0 +1,64 @@
+package hocon_test
+
+import (
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+func TestIssue104CommaAfterNewlineInArray(t *testing.T) {
+	input := `steps: [
+  {
+    name: first
+  }
+  ,{
+    name: second
+  }
+]`
+	cfg, err := hocon.ParseString(input)
+	if err != nil {
+		t.Fatalf("expected to parse, got error: %v", err)
+	}
+	steps := cfg.GetConfigSlice("steps")
+	if got := len(steps); got != 2 {
+		t.Fatalf("expected 2 steps, got %d", got)
+	}
+	if got := steps[0].GetString("name"); got != "first" {
+		t.Errorf("expected steps[0].name=first, got %q", got)
+	}
+	if got := steps[1].GetString("name"); got != "second" {
+		t.Errorf("expected steps[1].name=second, got %q", got)
+	}
+}
+
+func TestIssue104CommaOnOwnLineInObject(t *testing.T) {
+	input := `settings {
+  first: true
+  ,
+  second: true
+}`
+	cfg, err := hocon.ParseString(input)
+	if err != nil {
+		t.Fatalf("expected to parse, got error: %v", err)
+	}
+	if !cfg.GetBool("settings.first") {
+		t.Errorf("expected settings.first=true")
+	}
+	if !cfg.GetBool("settings.second") {
+		t.Errorf("expected settings.second=true")
+	}
+}
+
+func TestIssue104LeadingCommaStillRejected(t *testing.T) {
+	_, err := hocon.ParseString(`,a: 1`)
+	if err == nil {
+		t.Errorf("expected leading comma to be rejected")
+	}
+}
+
+func TestIssue104RepeatedCommaStillRejected(t *testing.T) {
+	_, err := hocon.ParseString(`a: 1,, b: 2`)
+	if err == nil {
+		t.Errorf("expected repeated commas to be rejected")
+	}
+}

--- a/issue104_test.go
+++ b/issue104_test.go
@@ -62,3 +62,53 @@ func TestIssue104RepeatedCommaStillRejected(t *testing.T) {
 		t.Errorf("expected repeated commas to be rejected")
 	}
 }
+
+// Additional coverage from multi-agent review: pin the "comma surrounded by
+// optional newlines" contract in array position too, and the multi-newline
+// case. Array-position negative cases also live in parser_test's S5.4/S5.5
+// spec suite; pinning here as well guards against future suite restructures.
+
+func TestIssue104CommaOnOwnLineInArray(t *testing.T) {
+	input := `a: [1
+,
+2
+,
+3]`
+	cfg, err := hocon.ParseString(input)
+	if err != nil {
+		t.Fatalf("expected to parse, got error: %v", err)
+	}
+	got := cfg.GetIntSlice("a")
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("expected [1,2,3], got %v", got)
+	}
+}
+
+func TestIssue104MultipleNewlinesBeforeComma(t *testing.T) {
+	input := `a: 1
+
+
+,
+b: 2`
+	cfg, err := hocon.ParseString(input)
+	if err != nil {
+		t.Fatalf("expected to parse, got error: %v", err)
+	}
+	if cfg.GetInt("a") != 1 || cfg.GetInt("b") != 2 {
+		t.Errorf("expected a=1,b=2, got a=%d,b=%d", cfg.GetInt("a"), cfg.GetInt("b"))
+	}
+}
+
+func TestIssue104LeadingCommaInArrayStillRejected(t *testing.T) {
+	_, err := hocon.ParseString(`a: [,1,2]`)
+	if err == nil {
+		t.Errorf("expected leading comma in array to be rejected")
+	}
+}
+
+func TestIssue104RepeatedCommaInArrayStillRejected(t *testing.T) {
+	_, err := hocon.ParseString(`a: [1,,2]`)
+	if err == nil {
+		t.Errorf("expected repeated commas in array to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

cgordon (Lightbend porter) reported that `go.hocon` rejects valid HOCON when a comma appears at the start of the next line after a completed field/element. Lightbend (1.4.6) accepts the pattern; go.hocon rejected it as a parser oversight.

```hocon
steps: [
  { name: first }
  ,{ name: second }
]
```

Pre-fix: `parse error at line 5, col 3: unexpected token 10` (TokenComma).

## Fix

`internal/parser/parser.go:195-205` — `skipSeparator()` now consumes newlines on **both** sides of the optional comma rather than only after, so any mixture of `\n,\n` / `,\n` / `\n,` / `,` / `\n` is accepted as a separator. Preserves rejection of leading commas (`,a: 1`) and repeated commas (`a: 1,, b: 2`) since those never have a completed field upstream of `skipSeparator`.

## Per project policy

- Spec-compliance bug fix (1.x library implementing the external HOCON spec). Non-breaking — only accepts more inputs, never less.
- Multi-agent review: Claude (Important = test gaps, addressed) + Codex (PASS). No convergence.

## Test plan

- [x] 8 regression tests in `issue104_test.go` covering: cgordon's primary array+object repros, comma-on-own-line in array, multiple newlines before comma, leading/repeated comma negative pins for both object and array positions
- [x] Full suite `go test ./...` green (with `make testdata` for Lightbend fixtures)
- [x] `golangci-lint run` clean (0 issues)
- [x] Multi-agent review pass: Codex green, Claude Important items addressed in follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)