### PR TITLE
release(v1.4.0): finalize CHANGELOG — E11 + E12 + comma-after-newline fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **E11 — `include package("<id>", "<file>")` qualifier** (xx.hocon [#33](https://github.com/o3co/xx.hocon/issues/33), [#36](https://github.com/o3co/xx.hocon/pull/36)). A new include qualifier with **service-locator semantics** — looks up `.conf` files registered under a stable name via a global registry. **Not a Java classpath equivalent** (no auto-discovery, no auto `reference.conf` merge, no transitive auto-resolution). Closest analog: JVM `ServiceLoader` / JNDI. New public surface:
-  - `include package("github.com/myorg/pkg", "reference.conf")` syntax — two-arg form mandatory; one-arg + missing-comma rejected at parse time.
-  - `RegisterPackage(identifier, file, content string) error` — global registry, parallel to `database/sql.Register`. Idempotent byte-equal re-registration allowed; different-content collision returns `*PackageCollisionError`. Call from a config-providing package's `init()` after `//go:embed`.
-  - `*RegistrationError` — input validation failures at registration time (empty identifier, file constraint violations including Windows-style `C:/` paths and trailing slash).
-  - `PackageLookup func(id, file string) (string, error)` parser option — overrides the global registry for test injection / custom resolution; correctly propagated to child resolvers across nested include chains.
-  - `ResetPackageRegistry()` — exported behind `//go:build testing` build tag (hidden from production builds). Use for test isolation.
-  - `IncludeNode.PkgID` / `IncludeNode.PkgFile` — new AST fields populated when the include qualifier is `package(...)`.
-  - `ResolveError.Cause` field + `Unwrap()` method — package lookup errors are now `errors.Is`/`errors.As`-discoverable.
-  - File argument validated **after HOCON string unescaping**: rejects empty, absolute, `..`, `./`, backslash, consecutive `/`, Windows drive prefix, trailing slash.
-  - Cycle detection: length-prefixed `"package:N:id:file"` cycle key integrated with existing include-cycle detection.
-  - `include required(package(...))` — registry miss is unconditional hard error regardless of `Required` flag state (per E11 decision 7).
-
 ## [1.4.0] - 2026-05-21
+
+### Added — E11 `include package("<id>", "<file>")` qualifier
+
+xx.hocon [#33](https://github.com/o3co/xx.hocon/issues/33), [#36](https://github.com/o3co/xx.hocon/pull/36). A new include qualifier with **service-locator semantics** — looks up `.conf` files registered under a stable name via a global registry. **Not a Java classpath equivalent** (no auto-discovery, no auto `reference.conf` merge, no transitive auto-resolution). Closest analog: JVM `ServiceLoader` / JNDI. New public surface:
+
+- `include package("github.com/myorg/pkg", "reference.conf")` syntax — two-arg form mandatory; one-arg + missing-comma rejected at parse time.
+- `RegisterPackage(identifier, file, content string) error` — global registry, parallel to `database/sql.Register`. Idempotent byte-equal re-registration allowed; different-content collision returns `*PackageCollisionError`. Call from a config-providing package's `init()` after `//go:embed`.
+- `*RegistrationError` — input validation failures at registration time (empty identifier, file constraint violations including Windows-style `C:/` paths and trailing slash).
+- `PackageLookup func(id, file string) (string, error)` parser option — overrides the global registry for test injection / custom resolution; correctly propagated to child resolvers across nested include chains.
+- `ResetPackageRegistry()` — exported behind `//go:build testing` build tag (hidden from production builds). Use for test isolation.
+- `IncludeNode.PkgID` / `IncludeNode.PkgFile` — new AST fields populated when the include qualifier is `package(...)`.
+- `ResolveError.Cause` field + `Unwrap()` method — package lookup errors are now `errors.Is`/`errors.As`-discoverable.
+- File argument validated **after HOCON string unescaping**: rejects empty, absolute, `..`, `./`, backslash, consecutive `/`, Windows drive prefix, trailing slash.
+- Cycle detection: length-prefixed `"package:N:id:file"` cycle key integrated with existing include-cycle detection.
+- `include required(package(...))` — registry miss is unconditional hard error regardless of `Required` flag state (per E11 decision 7).
 
 ### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/go.hocon/issues/99))
 
@@ -87,6 +88,7 @@ fused `ParseString`; only relevant when using the deferred-resolution lifecycle)
   both `x` and `y` undefined now correctly omits the field (was producing
   `{"a":""}` empty string).  Per HOCON.md L640.  Bundled with E12 since
   the dr28 fixture surfaced the spec divergence.
+- **parser: accept comma separator after newline** (closes [#104](https://github.com/o3co/go.hocon/issues/104), [@cgordon](https://github.com/cgordon) report). `skipSeparator()` previously consumed only `comma → newlines`, rejecting valid HOCON like `a: 1\n,\nb: 2` with `unexpected token 10`. Lightbend (1.4.6) accepts the pattern. Fix: consume newlines on both sides of the optional comma. Preserves rejection of leading commas (`,a: 1`) and repeated commas (`a: 1,, b: 2`).
 
 **Spec source:** [xx.hocon#37](https://github.com/o3co/xx.hocon/issues/37) /
 E12 in `docs/extra-spec-conventions.md`.


### PR DESCRIPTION
## Summary

Release prep for v1.4.0. CHANGELOG only.

- Move E11 entry from `[Unreleased]` into `[1.4.0]` (it was waiting for the cut)
- Add `### Fixed` entry for #104 (comma-after-newline parser fix, cgordon-reported)
- Leave `[Unreleased]` empty for the next cycle

go.hocon has no explicit version file (Go modules use git tags) — just CHANGELOG + tag.

Part of v1.4.0 cross-impl cut alongside ts.hocon and rs.hocon release branches.

## Test plan

- [x] No code change — CHANGELOG only
- [ ] CI green