### PR TITLE
fix(resolver): include override semantics + self-ref through include (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Include ordering / self-referential append through include** ([#106](https://github.com/o3co/go.hocon/issues/106)). When an `include` directive appeared after an existing key in the parent file, the parent's value was incorrectly kept instead of being overridden by the included file's value. Lightbend Config treats included content as if it had been written inline at the include position; `go.hocon` now matches that semantics. Self-referential appends like `steps = ${steps} [{ name = child }]` placed inside an included file now resolve against the parent's prior value, matching Lightbend. Reported by [@cgordon](https://github.com/cgordon).
+
+### Changed — resolver
+
+- **Lenient self-referential substitution defer (E12 `AllowUnresolved`)**. Under `Resolve(opts.WithAllowUnresolved(true))`, a required self-referential `${k}` with no prior value used to error; it now defers the placeholder so a subsequent merge supplying a prior can complete resolution. This is required by the include-ordering fix above (the include child resolver runs in lenient mode); user-visible behaviour change is limited to `AllowUnresolved=true`, where the error is replaced by an unresolved placeholder.
+
 ## [1.4.0] - 2026-05-21
 
 ### Added — E11 `include package("<id>", "<file>")` qualifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Include ordering / self-referential append through include** ([#106](https://github.com/o3co/go.hocon/issues/106)). When an `include` directive appeared after an existing key in the parent file, the parent's value was incorrectly kept instead of being overridden by the included file's value. Lightbend Config treats included content as if it had been written inline at the include position; `go.hocon` now matches that semantics. Self-referential appends like `steps = ${steps} [{ name = child }]` placed inside an included file now resolve against the parent's prior value, matching Lightbend. Reported by [@cgordon](https://github.com/cgordon).
+- **Include ordering / self-referential append through include** ([#106](https://github.com/o3co/go.hocon/issues/106)). When an `include` directive appeared after an existing key in the parent file, the parent's value was incorrectly kept instead of being overridden by the included file's value. Lightbend Config treats included content as if it had been written inline at the include position; `go.hocon` now matches those semantics. Self-referential appends like `steps = ${steps} [{ name = child }]` placed inside an included file now resolve against the parent's prior value, matching Lightbend. Reported by [@cgordon](https://github.com/cgordon).
 
 ### Changed — resolver
 

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -435,7 +435,7 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					// dup-key chain (what an inline-equivalent reader would
 					// see). Otherwise the parent's existing value becomes the
 					// prior.
-					var prior Val = existing
+					prior := existing
 					if inclPrior, hasInclPrior := included.priorValues[k]; hasInclPrior {
 						prior = inclPrior
 					}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -414,10 +414,49 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 			if err != nil {
 				return nil, err
 			}
-			merged := deepMerge(obj, included)
-			// preserve obj's original keys order, then add new ones
-			for _, k := range merged.keys {
-				obj.set(k, merged.values[k])
+			// Apply the included object's fields as if they had been written
+			// inline at the include's position: included assignments override
+			// earlier parent assignments, and for non-object collisions the
+			// parent's prior value is recorded so a self-referential ${k}
+			// inside the include resolves to the parent's value (#106).
+			for _, k := range included.keys {
+				iv := included.values[k]
+				if existing, exists := obj.Get(k); exists {
+					if eo, eok := existing.(*ObjectVal); eok {
+						if io, iok := iv.(*ObjectVal); iok {
+							// both objects → deep merge with included on top
+							obj.set(k, deepMerge(io, eo))
+							continue
+						}
+					}
+					// Non-object override: prior value for self-reference lookback.
+					// If included carries its own prior chain for k, that prior
+					// is the immediately-prior value within the include's own
+					// dup-key chain (what an inline-equivalent reader would
+					// see). Otherwise the parent's existing value becomes the
+					// prior.
+					var prior Val = existing
+					if inclPrior, hasInclPrior := included.priorValues[k]; hasInclPrior {
+						prior = inclPrior
+					}
+					// Write r.priorValues ONLY at top of the current resolver's
+					// scope. When the include is nested (pathPrefix != []), `k`
+					// is just a leaf name and would collide with an unrelated
+					// top-level key of the same name; see setPath L1239-1247
+					// for the same rule applied to regular field overwrite.
+					if len(pathPrefix) == 0 {
+						r.priorValues[segmentsToKey([]string{k})] = prior
+					}
+					obj.priorValues[k] = prior
+				} else if inclPrior, hasInclPrior := included.priorValues[k]; hasInclPrior {
+					// No collision in parent, but include's own dup-key chain
+					// produced a prior. Preserve it (with the same scope rule).
+					if len(pathPrefix) == 0 {
+						r.priorValues[segmentsToKey([]string{k})] = inclPrior
+					}
+					obj.priorValues[k] = inclPrior
+				}
+				obj.set(k, iv)
 			}
 			continue
 		}
@@ -707,6 +746,15 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 			// that would produce "foofoo" for `a = ${?a}foo` with no prior `a`.
 			if n.Optional {
 				return nil, nil
+			}
+			// Lenient mode: defer the placeholder so a later resolution pass
+			// (with prior values supplied by a parent or fallback) can complete
+			// it. Used by include resolution (#106): the included file's own
+			// `${k}` against a parent-only `k` reaches this branch because the
+			// child resolver has no prior; the parent's include-merge step
+			// installs the prior and a subsequent ResolveTree pass succeeds.
+			if r.lenient {
+				return s, nil
 			}
 			return nil, &ResolveError{Message: "unresolved self-referential substitution", Path: key, Line: n.Line(), Col: n.Col()}
 		}

--- a/issue106_test.go
+++ b/issue106_test.go
@@ -1,0 +1,252 @@
+package hocon_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// TestIssue106_IncludeScalarOverridesParent verifies that when an include
+// appears after a key already assigned in the parent, the included assignment
+// overrides the parent — matching Lightbend's "as if inlined at include
+// position" semantics.
+//
+// Reported by cgordon (go.hocon#106).
+func TestIssue106_IncludeScalarOverridesParent(t *testing.T) {
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(childFile, []byte("a = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("a = 1\ninclude \"%s\"\n", slashChild)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetInt64("a"); got != 2 {
+		t.Errorf("a=%d, want 2 (include must override parent's earlier assignment)", got)
+	}
+}
+
+// TestIssue106_ParentScalarOverridesInclude verifies the reverse direction:
+// when a parent assignment appears AFTER an include, the parent's assignment
+// wins. This is the simple "last write wins" rule and should already work,
+// but we pin it as a regression test alongside the include-override fix.
+func TestIssue106_ParentScalarOverridesInclude(t *testing.T) {
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(childFile, []byte("a = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 5\n", slashChild)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetInt64("a"); got != 5 {
+		t.Errorf("a=%d, want 5 (parent assignment after include must win)", got)
+	}
+}
+
+// TestIssue106_SelfRefAppendThroughInclude verifies that an included file may
+// reference the parent's value of a key via self-substitution (`${k}`) and
+// append to it. Lightbend resolves this as if the include's body appeared
+// inline; go.hocon previously failed with "unresolved self-referential
+// substitution" because the include merge did not record the parent's value
+// as a priorValue for the include's assignment.
+//
+// Reported by cgordon (go.hocon#106).
+func TestIssue106_SelfRefAppendThroughInclude(t *testing.T) {
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(childFile, []byte(`steps = ${steps} [
+  { name = child }
+]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	parentSrc := fmt.Sprintf(`steps = [
+  { name = base }
+]
+
+include "%s"
+`, slashChild)
+	if err := os.WriteFile(mainFile, []byte(parentSrc), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	steps := cfg.GetConfigSlice("steps")
+	if got := len(steps); got != 2 {
+		t.Fatalf("expected 2 steps (base + child), got %d", got)
+	}
+	if got := steps[0].GetString("name"); got != "base" {
+		t.Errorf("steps[0].name=%q, want base", got)
+	}
+	if got := steps[1].GetString("name"); got != "child" {
+		t.Errorf("steps[1].name=%q, want child", got)
+	}
+}
+
+// TestIssue106_ControlSameFileAppend pins the existing same-file
+// self-referential append behavior so the fix for the include path does not
+// regress it.
+func TestIssue106_ControlSameFileAppend(t *testing.T) {
+	cfg, err := hocon.ParseString(`steps = [
+  { name = base }
+]
+
+steps = ${steps} [
+  { name = child }
+]
+`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	steps := cfg.GetConfigSlice("steps")
+	if got := len(steps); got != 2 {
+		t.Fatalf("expected 2 steps, got %d", got)
+	}
+}
+
+// TestIssue106_NestedIncludePriorDoesNotLeakTopLevel pins the
+// multi-agent-review finding (Claude + Codex convergence): when a nested
+// include overrides a key inside a wrapper object, the parent's prior must
+// NOT leak into the resolver-wide priorValues map under the same leaf name.
+// Otherwise an unrelated top-level self-referential substitution with the
+// same leaf key would incorrectly find the nested prior. Mirrors the
+// S13a13 TestS13a13_NestedPriorDoesNotCollideWithTopLevel scenario for the
+// include path.
+func TestIssue106_NestedIncludePriorDoesNotLeakTopLevel(t *testing.T) {
+	dir := t.TempDir()
+	leafFile := filepath.Join(dir, "leaf.conf")
+	if err := os.WriteFile(leafFile, []byte("a = innerB\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "p.conf")
+	slashLeaf := strings.ReplaceAll(leafFile, "\\", "/")
+	src := fmt.Sprintf(`nested {
+  a = innerA
+  include "%s"
+}
+a = ${?a}suffix
+`, slashLeaf)
+	if err := os.WriteFile(mainFile, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("nested.a"); got != "innerB" {
+		t.Errorf("nested.a=%q, want innerB (include override)", got)
+	}
+	if got := cfg.GetString("a"); got != "suffix" {
+		t.Errorf("a=%q, want \"suffix\" (top-level ${?a} has no prior; nested include must not leak)", got)
+	}
+}
+
+// TestIssue106_SequentialIncludesOverrideParent verifies that two consecutive
+// includes each correctly override the parent's value. Each include's
+// prior-capture must use the previous include's value (not the parent's
+// original value) so the chain reads like inline assignments.
+func TestIssue106_SequentialIncludesOverrideParent(t *testing.T) {
+	dir := t.TempDir()
+	c1 := filepath.Join(dir, "c1.conf")
+	c2 := filepath.Join(dir, "c2.conf")
+	if err := os.WriteFile(c1, []byte("a = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(c2, []byte("a = 3\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashC1 := strings.ReplaceAll(c1, "\\", "/")
+	slashC2 := strings.ReplaceAll(c2, "\\", "/")
+	src := fmt.Sprintf("a = 1\ninclude \"%s\"\ninclude \"%s\"\n", slashC1, slashC2)
+	if err := os.WriteFile(mainFile, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetInt64("a"); got != 3 {
+		t.Errorf("a=%d, want 3 (last include wins)", got)
+	}
+}
+
+// TestIssue106_LenientSelfRefDeferredPlaceholder pins the lenient-mode change
+// to resolveSubst: a required self-referential substitution with no prior
+// value used to error, but under lenient mode (AllowUnresolved=true) it now
+// defers the placeholder so a subsequent ResolveTree pass (with a prior
+// supplied externally) can complete it. Used by the include path; this test
+// keeps the AllowUnresolved code path honest.
+func TestIssue106_LenientSelfRefDeferredPlaceholder(t *testing.T) {
+	// Parse without resolution, then resolve in lenient (AllowUnresolved) mode.
+	// `a = ${a} "suffix"` is a required self-ref against itself; under lenient
+	// mode we expect the placeholder to remain (no error). A subsequent merge
+	// supplying a prior `a` should let it complete.
+	cfg, err := hocon.ParseStringWithOptions(`a = ${a} "suffix"`,
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := cfg.Resolve(hocon.DefaultResolveOptions().WithAllowUnresolved(true))
+	if err != nil {
+		t.Fatalf("Resolve(AllowUnresolved=true): %v", err)
+	}
+	if resolved.IsResolved() {
+		t.Error("expected IsResolved()=false because self-ref had no prior; resolver should defer the placeholder")
+	}
+}
+
+// TestIssue106_NestedObjectsDeepMerge verifies that the include-merge fix
+// does not break the "both-object collision deep-merges" rule. Parent and
+// include each contribute disjoint sub-keys under the same parent key; the
+// merge must union them.
+func TestIssue106_NestedObjectsDeepMerge(t *testing.T) {
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(childFile, []byte(`server { port = 8080 }`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf(`server { host = "localhost" }
+include "%s"
+`, slashChild)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("server.host"); got != "localhost" {
+		t.Errorf("server.host=%q, want localhost", got)
+	}
+	if got := cfg.GetInt64("server.port"); got != 8080 {
+		t.Errorf("server.port=%d, want 8080", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#106](https://github.com/o3co/go.hocon/issues/106). Two related include-resolution bugs reported by @cgordon:

1. **Include ordering**: a key set in the parent file should be overridden by an include that appears after it. Previously the parent's earlier value won.
2. **Self-ref through include**: `steps = ${steps} [...]` inside an included file should resolve `${steps}` against the parent's value. Previously errored with "unresolved self-referential substitution".

Both now match Lightbend Config's "as if pasted inline at the include position" semantics.

## Changes

- `internal/resolver/resolver.go` — replace `deepMerge(obj, included)` (parent-wins) in the include branch with a per-key apply loop that mirrors the regular duplicate-key path: deep-merge on both-object collision, otherwise included wins and the parent's existing value is captured as a prior for self-reference lookback. r.priorValues write is gated on `len(pathPrefix)==0` per the [setPath L1239-1247 rule](https://github.com/o3co/go.hocon/blob/develop/internal/resolver/resolver.go#L1239) so nested includes don't leak priors into the resolver-wide top-level scope.
- `internal/resolver/resolver.go` — lenient self-ref defer: under lenient mode (E12 `AllowUnresolved=true` or include child resolver), a required self-ref with no prior now returns the placeholder instead of erroring. Required so the include child resolver's phase 2 doesn't pre-fail on `${k}` against parent-only `k`.
- `issue106_test.go` — 8 tests pinning the reported cases, controls (parent-after-include, same-file append), and the multi-agent-review regression scenarios (nested include must not leak, sequential includes chain priors, lenient self-ref defer).
- `CHANGELOG.md` — Unreleased `Fixed` and `Changed` entries.

## Multi-agent review

Reviewed by Claude + Codex; both flagged the same nested-include leak risk in the initial fix (r.priorValues with bare leaf key). Convergence applied per CLAUDE.md "Multi-reviewer convergence" rule — must-fix. Gated on `len(pathPrefix)==0` + new regression test `TestIssue106_NestedIncludePriorDoesNotLeakTopLevel`.

## Test plan

- [x] `go test ./...` — all packages PASS (including S13a13 nested-prior tests and lightbend conformance)
- [x] `go test -run TestIssue106 -v` — 8 PASS (3 control + 5 fix-scenario)
- [ ] Maintainer: verify CI green
- [ ] Maintainer: confirm no regression in #99 (E12) deferred-resolution tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)