### PR TITLE
fix(resolver): empty/comment-only included files contribute empty (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Lenient self-referential substitution defer (E12 `AllowUnresolved`)**. Under `Resolve(opts.WithAllowUnresolved(true))`, a required self-referential `${k}` with no prior value used to error; it now defers the placeholder so a subsequent merge supplying a prior can complete resolution. This is required by the include-ordering fix above (the include child resolver runs in lenient mode); user-visible behaviour change is limited to `AllowUnresolved=true`, where the error is replaced by an unresolved placeholder.
 
+### Changed — include path
+
+- **Empty / comment-only / whitespace-only included files contribute an empty config** ([#105](https://github.com/o3co/go.hocon/issues/105), Lightbend compatibility). Previously, `include "empty.conf"` (or comment-only / whitespace-only / BOM-only content) errored with `empty file is not a valid HOCON document (HOCON.md L130)`. This blocked the common optional-override-file pattern. The carve-out is **narrow** — applies only to the file-include code path; top-level empty parses (`ParseString("")`, `ParseFile` on an empty file as the root) still error per S3.1. Reported by [@cgordon](https://github.com/cgordon).
+
 ## [1.4.0] - 2026-05-21
 
 ### Added — E11 `include package("<id>", "<file>")` qualifier

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -790,6 +790,12 @@ func (l *Lexer) readNumber(line, col int) Token {
 	return Token{Type: tt, Value: string(l.src[startPos:lastValidEnd]), Line: line, Col: startCol}
 }
 
+// IsHoconWhitespace reports whether r is a HOCON whitespace character.
+// Exported wrapper around isHoconWhitespace so other internal packages
+// (e.g. the resolver's empty-include probe at #105) can ask the same
+// question without re-encoding the spec definition.
+func IsHoconWhitespace(r rune) bool { return isHoconWhitespace(r) }
+
 // isHoconWhitespace reports whether r is a HOCON whitespace character per
 // HOCON.md §Whitespace (L165-184). The set is:
 //

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/o3co/go.hocon/internal/lexer"
 	"github.com/o3co/go.hocon/internal/parser"
@@ -1445,12 +1446,61 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 		return propsToObjectVal(properties.Parse(string(data))), nil
 	}
 
+	// Lightbend-compat carve-out for #105: an empty or comment-only include
+	// file contributes nothing instead of erroring with "empty file is not a
+	// valid HOCON document". Top-level empty parses (ParseString("")) remain
+	// invalid per spec S3.1 (HOCON.md L130); this carve-out applies ONLY to
+	// the include path so the common optional-override-file pattern works.
+	if isEmptyOrCommentOnlyHocon(data) {
+		return newObjectVal(), nil
+	}
+
 	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
 		return nil, err
 	}
 
 	return obj, nil
+}
+
+// isEmptyOrCommentOnlyHocon reports whether the given HOCON source has no
+// semantic content — i.e. only HOCON whitespace (per the lexer's full
+// definition — including NBSP, Unicode Zs, U+2028/U+2029, BOM, etc.) and
+// the two HOCON line-comment forms (# and //). Block comments are NOT a
+// HOCON syntax; if `/* ... */` appears, it falls through and the parser
+// produces its proper error. Used by loadIncludeFile to short-circuit the
+// S3.1 empty-document rejection for included files (Lightbend-compat for
+// #105).
+func isEmptyOrCommentOnlyHocon(data []byte) bool {
+	s := string(data)
+	for i := 0; i < len(s); {
+		// Decode one rune so we treat all HOCON whitespace (NBSP, U+2028,
+		// U+FEFF, etc. — multi-byte under UTF-8) consistently with the lexer.
+		r, size := utf8.DecodeRuneInString(s[i:])
+		// HOCON whitespace (per lexer.isHoconWhitespace) covers newlines too;
+		// also covers BOM at any position, not just the leading byte.
+		if lexer.IsHoconWhitespace(r) || r == '\n' {
+			i += size
+			continue
+		}
+		if r == '#' {
+			// # line comment — skip until newline or EOF.
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		if r == '/' && i+1 < len(s) && s[i+1] == '/' {
+			// // line comment — skip until newline or EOF.
+			i += 2
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // parseAndResolve parses raw HOCON/JSON data and resolves it into an ObjectVal.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1477,9 +1477,10 @@ func isEmptyOrCommentOnlyHocon(data []byte) bool {
 		// Decode one rune so we treat all HOCON whitespace (NBSP, U+2028,
 		// U+FEFF, etc. — multi-byte under UTF-8) consistently with the lexer.
 		r, size := utf8.DecodeRuneInString(s[i:])
-		// HOCON whitespace (per lexer.isHoconWhitespace) covers newlines too;
-		// also covers BOM at any position, not just the leading byte.
-		if lexer.IsHoconWhitespace(r) || r == '\n' {
+		// HOCON whitespace (per lexer.isHoconWhitespace) covers LF as well as
+		// BOM at any position, not just the leading byte — so a single
+		// IsHoconWhitespace check is sufficient.
+		if lexer.IsHoconWhitespace(r) {
 			i += size
 			continue
 		}

--- a/issue105_test.go
+++ b/issue105_test.go
@@ -103,9 +103,10 @@ func TestIssue105_WhitespaceOnlyIncludeFile(t *testing.T) {
 func TestIssue105_UnicodeWhitespaceOnlyIncludeFile(t *testing.T) {
 	dir := t.TempDir()
 	uwsFile := filepath.Join(dir, "uws.conf")
-	// Build content from Go \u escapes to avoid editor-encoding surprises:
 	// NBSP (U+00A0), en-quad (U+2000), line separator (U+2028), then LF.
-	content := []byte("   \n")
+	// Use explicit \u escapes so the literal is reviewable byte-for-byte
+	// rather than depending on invisible characters surviving copy/paste.
+	content := []byte("\u00A0\u2000\u2028\n")
 	if err := os.WriteFile(uwsFile, content, 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/issue105_test.go
+++ b/issue105_test.go
@@ -1,0 +1,214 @@
+package hocon_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// Issue #105 (cgordon): empty or comment-only included files should
+// contribute an empty config instead of erroring. The narrower scope —
+// include path only — is implemented; top-level empty parses
+// (`ParseString("")`) remain invalid per S3.1 (HOCON.md L130).
+
+func TestIssue105_EmptyIncludeFile(t *testing.T) {
+	dir := t.TempDir()
+	emptyFile := filepath.Join(dir, "empty.conf")
+	if err := os.WriteFile(emptyFile, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashEmpty := strings.ReplaceAll(emptyFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashEmpty)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected empty include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+func TestIssue105_CommentOnlyIncludeFile_Hash(t *testing.T) {
+	dir := t.TempDir()
+	commentFile := filepath.Join(dir, "comments.conf")
+	if err := os.WriteFile(commentFile, []byte("# only a comment\n# another\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashC := strings.ReplaceAll(commentFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashC)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected hash-comment-only include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+func TestIssue105_CommentOnlyIncludeFile_DoubleSlash(t *testing.T) {
+	dir := t.TempDir()
+	commentFile := filepath.Join(dir, "comments.conf")
+	if err := os.WriteFile(commentFile, []byte("// only a comment\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashC := strings.ReplaceAll(commentFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashC)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected //-comment-only include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+func TestIssue105_WhitespaceOnlyIncludeFile(t *testing.T) {
+	dir := t.TempDir()
+	wsFile := filepath.Join(dir, "ws.conf")
+	if err := os.WriteFile(wsFile, []byte("   \n\t\n\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashWs := strings.ReplaceAll(wsFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashWs)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected whitespace-only include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+// TestIssue105_UnicodeWhitespaceOnlyIncludeFile pins the multi-byte
+// whitespace path. HOCON's whitespace set (per HOCON.md §Whitespace) covers
+// NBSP, all Unicode Zs members, U+2028 (line sep), U+2029 (para sep), BOM,
+// etc. An included file containing only these characters must also be
+// treated as empty by the carve-out.
+func TestIssue105_UnicodeWhitespaceOnlyIncludeFile(t *testing.T) {
+	dir := t.TempDir()
+	uwsFile := filepath.Join(dir, "uws.conf")
+	// Build content from Go \u escapes to avoid editor-encoding surprises:
+	// NBSP (U+00A0), en-quad (U+2000), line separator (U+2028), then LF.
+	content := []byte("   \n")
+	if err := os.WriteFile(uwsFile, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashUws := strings.ReplaceAll(uwsFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashUws)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected Unicode-whitespace-only include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+func TestIssue105_BOMOnlyIncludeFile(t *testing.T) {
+	dir := t.TempDir()
+	bomFile := filepath.Join(dir, "bom.conf")
+	// UTF-8 BOM followed by nothing semantic.
+	if err := os.WriteFile(bomFile, []byte{0xEF, 0xBB, 0xBF, '\n'}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashB := strings.ReplaceAll(bomFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashB)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v (expected BOM-only include to be no-op)", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+}
+
+// TestIssue105_BlockCommentInIncludeIsRejected pins the narrow scope: HOCON
+// recognises only `#` and `//` comments. A `/* ... */` block-comment-only
+// include is NOT silently treated as empty; it falls through to the parser
+// which reports the syntax error. This guards against the carve-out
+// becoming a backdoor for masking malformed include files.
+func TestIssue105_BlockCommentInIncludeIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	bcFile := filepath.Join(dir, "block.conf")
+	if err := os.WriteFile(bcFile, []byte("/* multi\nline\ncomment */\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashBc := strings.ReplaceAll(bcFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashBc)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hocon.ParseFile(mainFile); err == nil {
+		t.Error("expected block-comment-only include to error (HOCON only supports # and //)")
+	}
+}
+
+// TestIssue105_TopLevelEmptyStillRejected pins the narrower scope: only
+// the include path treats empty/comment-only as no-op. ParseString of an
+// empty top-level document still errors per S3.1 (HOCON.md L130).
+func TestIssue105_TopLevelEmptyStillRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"empty", ""},
+		{"whitespace", "   \n  "},
+		{"hash-comment", "# only comment\n"},
+		{"slash-comment", "// only comment\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := hocon.ParseString(tc.src); err == nil {
+				t.Errorf("ParseString(%q) succeeded; spec S3.1 requires rejection", tc.src)
+			}
+		})
+	}
+}
+
+// TestIssue105_NonEmptyIncludeStillParses pins the negative direction: a
+// non-empty include that has actual content must still be parsed normally
+// (regression guard for the emptiness probe).
+func TestIssue105_NonEmptyIncludeStillParses(t *testing.T) {
+	dir := t.TempDir()
+	cFile := filepath.Join(dir, "c.conf")
+	if err := os.WriteFile(cFile, []byte("# leading comment\nb = 2\n# trailing\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashC := strings.ReplaceAll(cFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashC)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := hocon.ParseFile(mainFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetInt64("a"); got != 1 {
+		t.Errorf("a=%d, want 1", got)
+	}
+	if got := cfg.GetInt64("b"); got != 2 {
+		t.Errorf("b=%d, want 2 (non-empty include must still parse)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#105](https://github.com/o3co/go.hocon/issues/105). Lightbend Config treats an empty / whitespace-only / comment-only / BOM-only included file as a no-op. `go.hocon` previously errored with \"empty file is not a valid HOCON document\". This blocks the common pattern:

```hocon
include \"optional-overrides.conf\"
a = 1
```

where `optional-overrides.conf` is intentionally empty or comments-only.

## Scope

**Narrow:** applies only to the file-include code path (`loadIncludeFile`). Top-level empty parses (`ParseString(\"\")`, `ParseFile` on an empty file as the root) continue to error per spec S3.1 (HOCON.md L130). E11 `include package(...)` is unchanged.

## Changes

- `internal/lexer/lexer.go` — export `IsHoconWhitespace` (wrapper around the existing predicate) so the resolver can reuse the spec-conformant whitespace definition.
- `internal/resolver/resolver.go` — add `isEmptyOrCommentOnlyHocon` helper + carve-out in `loadIncludeFile`. Whitespace check delegates to the lexer (full HOCON whitespace set: NBSP, Zs, U+2028/U+2029, BOM, control chars). Comments are HOCON's only two forms (`#` and `//`); `/* ... */` block-comment-only files fall through to the parser so its proper syntax error is reported.
- `issue105_test.go` — 8 scenarios pinned:
  - empty / hash-comment-only / slash-comment-only / whitespace-only / Unicode-whitespace-only / BOM-only includes → no-op
  - block-comment-only include → rejected (not masked)
  - top-level empty / whitespace / comment-only → still rejected (S3.1)
  - non-empty include still parses normally
- `CHANGELOG.md` — Unreleased `Changed — include path` entry.

## Multi-agent review

Reviewed by Claude + Codex; both flagged P2 issues in the initial draft:
1. HOCON whitespace coverage was only ASCII subset — addressed via `lexer.IsHoconWhitespace`.
2. `/* ... */` block-comment carve-out masked non-spec syntax — removed; block-comment-only includes now error correctly.

## Test plan

- [x] `go test -run TestIssue105 -v` — 11 PASS (8 fix scenarios + 4 top-level reject sub-tests)
- [x] `go test ./...` — all packages green (including lightbend conformance)
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)