### PR TITLE
release(v1.4.1): finalize CHANGELOG — cgordon include-resolution bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-22
+
+Bugfix release: two cgordon-reported include-resolution divergences from Lightbend Config. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.
+
 ### Fixed
 
 - **Include ordering / self-referential append through include** ([#106](https://github.com/o3co/go.hocon/issues/106)). When an `include` directive appeared after an existing key in the parent file, the parent's value was incorrectly kept instead of being overridden by the included file's value. Lightbend Config treats included content as if it had been written inline at the include position; `go.hocon` now matches those semantics. Self-referential appends like `steps = ${steps} [{ name = child }]` placed inside an included file now resolve against the parent's prior value, matching Lightbend. Reported by [@cgordon](https://github.com/cgordon).


### PR DESCRIPTION
## Summary

Pure include-path bugfix release. Closes [#106](https://github.com/o3co/go.hocon/issues/106) and [#105](https://github.com/o3co/go.hocon/issues/105) — both Lightbend-divergence bugs reported by @cgordon. No public API changes; safe drop-in upgrade from v1.4.0.

Already merged to develop:
- 80f6d11 #106 include override + self-ref
- 3dfb515 #105 empty/comment-only include

## Release plan

1. Merge this release-prep PR
2. Tag `v1.4.1` from develop tip
3. Release workflow handles Go proxy fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)