### PR TITLE
ci(release): auto-create GitHub Release entry on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,15 +34,20 @@ jobs:
         # from CHANGELOG.md, so the GitHub Release body matches what's
         # already committed and reviewed. Strips the closing version
         # header so the body ends at the previous section's separator.
+        #
+        # Uses `index($0, str) == 1` (prefix match) rather than awk regex
+        # so SemVer build metadata (`+...`) and other regex metacharacters
+        # in version strings can't break or overmatch the section header.
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           awk -v ver="$VERSION" '
-            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
-            flag && /^## \[/ { flag=0 }
+            index($0, "## [" ver "]") == 1 { flag=1; next }
+            flag && index($0, "## [") == 1 { flag=0 }
             flag
           ' CHANGELOG.md > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
-            echo "::warning::No CHANGELOG section found for v${VERSION}; release body will be empty"
+            echo "::error::No CHANGELOG section found for v${VERSION}; aborting release so an empty body doesn't ship"
+            exit 1
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,17 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   proxy-fetch:
     name: Trigger Go module proxy indexing
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
       - name: Fetch via GOPROXY
         run: |
           VERSION="${GITHUB_REF_NAME}"
@@ -23,3 +28,32 @@ jobs:
           VERSION="${GITHUB_REF_NAME}"
           MODULE="github.com/o3co/go.hocon"
           curl -sSf "https://sum.golang.org/lookup/${MODULE}@${VERSION}" || true
+
+      - name: Extract CHANGELOG section for this tag
+        # Pulls the section between `## [VERSION]` and the next `## [`
+        # from CHANGELOG.md, so the GitHub Release body matches what's
+        # already committed and reviewed. Strips the closing version
+        # header so the body ends at the previous section's separator.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
+            flag && /^## \[/ { flag=0 }
+            flag
+          ' CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::warning::No CHANGELOG section found for v${VERSION}; release body will be empty"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: /tmp/release-notes.md
+          # Don't fail the workflow if the release already exists
+          # (covers retroactive `gh release create` runs from this PR
+          # and any future case where the tag's release was created
+          # manually before the workflow ran).
+          fail_on_unmatched_files: false
+          make_latest: true


### PR DESCRIPTION
## Summary

The release workflow previously triggered Go module proxy indexing on tag push but did not create the GitHub Release page entry. v1.4.0 and v1.4.1 were retroactively created manually via `gh release create` after the gap was caught by [@yoshi49535](https://github.com/yoshi49535); this PR closes the gap so v1.5.0+ ship a Release entry automatically.

## Mechanism

1. Add `actions/checkout@v5` step (was missing — needed to read CHANGELOG.md)
2. Parse `CHANGELOG.md`, extract the section between `## [VERSION]` and the next `## [` heading
3. Write to `/tmp/release-notes.md`
4. Run [`softprops/action-gh-release@v2`](https://github.com/softprops/action-gh-release) with the extracted body and `make_latest: true`

## Permissions

Bumped `contents: read` (implicit default) → `contents: write` so the action can create the release.

## Test plan

- [ ] Verify the workflow YAML is valid (`gh workflow view release.yml` after merge)
- [ ] On the next tag push (v1.5.0), confirm the Release entry is auto-created with body matching the CHANGELOG section
- [ ] Verify "Latest" badge moves to the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)