### PR TITLE
release(v1.5.0): finalize CHANGELOG — cross-impl spec compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-23
+
+Cross-impl spec-compliance release with [rs.hocon v1.5.0](https://github.com/o3co/rs.hocon/releases/tag/v1.5.0) and [ts.hocon v1.5.0](https://github.com/o3co/ts.hocon/releases/tag/v1.5.0). Three spec-compliance bugfixes ([#83](https://github.com/o3co/go.hocon/issues/83) S8.6 multi-tail key concat, [#66](https://github.com/o3co/go.hocon/issues/66) S11.8 bool/null literal keys, [#65](https://github.com/o3co/go.hocon/issues/65) S10.8 unquoted space-concat in keys), one resolver fix ([#45](https://github.com/o3co/go.hocon/issues/45) lenient optional substitution through includes), and parser error-path coverage hardening ([#37](https://github.com/o3co/go.hocon/issues/37): 86.4% → 92.0% statement coverage on `internal/parser`). No public API changes; safe drop-in upgrade from v1.4.1.
+
 ### Fixed — S8.6 multi-tail key concat
 
 - **Signed-numeric and chained adjacent-token keys now parse as a single key segment** ([#83](https://github.com/o3co/go.hocon/issues/83)). Follow-up to #65 / #81-followup: the parseKey concat branch was single-shot and only accepted `TokenString` / `TokenBool` / `TokenNull` / `TokenInclude` tails. This rejected signed-numeric chains because go.hocon's `readNumber` produces `TokenInt("-456")` when `-` is immediately followed by digits, so `123-456` arrives as two adjacent `TokenInt` tokens. The fix turns the concat branch into a loop that absorbs adjacent `TokenInt` / `TokenFloat` tails alongside the existing set, so chains like `123-456 = 1` → `{"123-456": 1}`, `123-456abc = 1` → `{"123-456abc": 1}`, and `123-456.foo = 1` → path `["123-456", "foo"]` all converge. Quoted-key gating preserved — `"a.b"-1 = 1` stays rejected so the literal `.` inside the quoted segment is never re-interpreted as a path separator. Cross-impl: ts.hocon and rs.hocon read `123-456` as a single unquoted token via their Option B lexer model, so they handle this naturally; this PR closes go.hocon's Option A divergence.


### PR DESCRIPTION
## Summary

Cross-impl spec-compliance release with rs.hocon v1.5.0 and ts.hocon v1.5.0.

## Contents

- **Fixed** — S8.6 multi-tail key concat: signed-numeric chains like `123-456 = 1` ([#83](https://github.com/o3co/go.hocon/issues/83))
- **Fixed** — S11.8 bool/null literal keys ([#66](https://github.com/o3co/go.hocon/issues/66))
- **Fixed** — S10.8 unquoted space-concat in field keys ([#65](https://github.com/o3co/go.hocon/issues/65))
- **Fixed** — Lenient optional substitution through includes ([#45](https://github.com/o3co/go.hocon/issues/45))
- **Tests** — Parser error-path coverage hardening: 86.4% → 92.0% on `internal/parser` ([#37](https://github.com/o3co/go.hocon/issues/37))

## Diff

- `CHANGELOG.md` — `[Unreleased]` heading carved out, `## [1.5.0] - 2026-05-23` section with cross-impl preamble added above existing entries

No public API changes; safe drop-in upgrade from v1.4.1.

## Test plan

- [x] CHANGELOG entries are the actual merged work since v1.4.1 (verified against `git log v1.4.1..HEAD --oneline`)
- [x] No code changes — pure release prep
- [x] No version file to bump (Go module versioning comes from the tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)