### PR TITLE
fix(resolver): chained self-referential append no longer crashes (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chained self-referential substitution
+
+- **Chained self-referential append no longer crashes the resolver** ([#118](https://github.com/o3co/go.hocon/issues/118)). When a key was self-referentially appended three or more times — either directly (`a = ${a} ["x"]` repeated), through chained `include` directives (each included file appending `branches = ${branches} [...]`), through object value-concat (`obj = ${obj} {key=val}` repeated), or on a nested path (`r.x = ${r.x} [...]` repeated) — the resolver entered infinite recursion and aborted the process with a Go runtime stack overflow. The deferred `Resolve` API path had the same failure mode. The fix folds self-referential `${key}` references in the prior value at save time so the recorded prior is always self-ref-free, restoring Lightbend Config's chain semantics where each `${key}` resolves to the value immediately prior to its current assignment. The nested-path variant previously errored with `circular reference detected`; that case now also resolves correctly. Reported by [@cgordon](https://github.com/cgordon).
+
+### Fixed — lenient optional substitution
+
+- **Optional substitutions in included files now see parent-scope values** ([#45](https://github.com/o3co/go.hocon/issues/45)). Previously, in the lenient resolver pass used by include processing, unresolved optional substitutions (`${?path}`) were dropped immediately, so an included file referencing a parent's value (e.g. `result = ${?parent_val}`) lost the field before the parent's value could be supplied. The fix preserves the placeholder during the lenient pass; the final / strict pass still drops optional substitutions with no value. Found by Copilot review on the include-relativization PR.
+
 ## [1.5.0] - 2026-05-23
 
 Cross-impl spec-compliance release with [rs.hocon v1.5.0](https://github.com/o3co/rs.hocon/releases/tag/v1.5.0) and [ts.hocon v1.5.0](https://github.com/o3co/ts.hocon/releases/tag/v1.5.0). Three spec-compliance bugfixes ([#83](https://github.com/o3co/go.hocon/issues/83) S8.6 multi-tail key concat, [#66](https://github.com/o3co/go.hocon/issues/66) S11.8 bool/null literal keys, [#65](https://github.com/o3co/go.hocon/issues/65) S10.8 unquoted space-concat in keys), one resolver fix ([#45](https://github.com/o3co/go.hocon/issues/45) lenient optional substitution through includes), and parser error-path coverage hardening ([#37](https://github.com/o3co/go.hocon/issues/37): 86.4% → 92.0% statement coverage on `internal/parser`). No public API changes; safe drop-in upgrade from v1.4.1.
@@ -26,10 +34,6 @@ Cross-impl spec-compliance release with [rs.hocon v1.5.0](https://github.com/o3c
 ### Fixed — S10.8 spec compliance
 
 - **Unquoted space-concat in field keys now accepted as a single key** ([#65](https://github.com/o3co/go.hocon/issues/65)). Per HOCON spec L317 ("string value concatenation is allowed in field keys") and L553-560 (`a b c : 42` is equivalent to `"a b c" : 42`), space-separated unquoted tokens before the `:`/`=`/`{`/`+=` separator must merge into a single key. Previously `foo bar = 1` errored with `expected ':', '=' or '{' after key`; now it parses as key `"foo bar"`. The fix extends `parseKey` in `internal/parser/parser.go` with a space-concat continuation branch driven by a new `spaceConcat` flag: when the next key token has `PrecedingSpace`, the first dot-split piece of that token merges into the LAST existing segment with a literal space; any remaining dot-split pieces become new path segments. Quoted+unquoted mixed concat (`"foo bar" baz = 1`) and inline-object shorthand (`a b { x = 1 }`) work transitively. A leading `.` in the spaced-in token keeps path-separator semantics per S11.1 (via the pre-existing leading-dot continuation branch, which takes priority over space-concat): `a .b = 1` → `["a", "b"]`, `a.b .c = 1` → `["a", "b", "c"]`. Cross-impl with [ts.hocon PR #128](https://github.com/o3co/ts.hocon/pull/128) and [rs.hocon PR #115](https://github.com/o3co/rs.hocon/pull/115).
-
-### Fixed — lenient optional substitution
-
-- **Optional substitutions in included files now see parent-scope values** ([#45](https://github.com/o3co/go.hocon/issues/45)). Previously, in the lenient resolver pass used by include processing, unresolved optional substitutions (`${?path}`) were dropped immediately, so an included file referencing a parent's value (e.g. `result = ${?parent_val}`) lost the field before the parent's value could be supplied. The fix preserves the placeholder during the lenient pass; the final / strict pass still drops optional substitutions with no value. Found by Copilot review on the include-relativization PR.
 
 ## [1.4.1] - 2026-05-22
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -503,6 +503,9 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   tests: internal/resolver/resolver_test.go (TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty, TestSpecS13a_13_SelfRefLookback), s13a13_self_ref_lookback_test.go (TestS13a13_SelfRefLookback_Success, TestS13a13_SelfRefLookback_Errors)
   status: ✅ (cleared in Phase 6 cluster #3f, [#68](https://github.com/o3co/go.hocon/issues/68))
 
+  Chain length ≥ 3 (e.g. `a = ${a} [...]` repeated): until v1.5.0 the resolver crashed on top-level / object / include-chain forms and errored on nested-path form. Fixed in v1.5.1 by folding `${key}` references in the saved prior at assignment time so the recorded prior is always self-ref-free. ([#118](https://github.com/o3co/go.hocon/issues/118))
+  tests: internal/resolver/issue118_chained_self_ref_test.go (TestIssue118_FlatArrayChain, TestIssue118_FourStepArrayChain, TestIssue118_ChainedInclude, TestIssue118_ChainedIncludeAllChain, TestIssue118_ObjectChain, TestIssue118_MultiSegmentChain, TestIssue118_SingleSelfRefWithoutPriorErrors)
+
 - **S13a.14** Mutually-referring object fields (`bar.a = ${foo.d}; foo.c = ${bar.b}`) resolve lazily without false cycle — §Self-Referential (L825-834)
   tests: spec_phase5_test.go (TestSpec_S13a_14_MutualRefNoCycle)
   status: ✅

--- a/internal/resolver/foldselfref.go
+++ b/internal/resolver/foldselfref.go
@@ -1,0 +1,76 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver
+
+// containsSelfRef reports whether v contains at least one substPlaceholder
+// whose dotted-path key equals fullKey.
+//
+// Scope: walks concatPlaceholder and substPlaceholder only. Self-references
+// embedded inside ArrayVal elements or ObjectVal fields are out of scope —
+// those represent a separate pattern (e.g. `a = [${a}, 1]`) that #118's fix
+// does not address.
+func containsSelfRef(v Val, fullKey string) bool {
+	switch vv := v.(type) {
+	case *substPlaceholder:
+		return substFullKey(vv) == fullKey
+	case *concatPlaceholder:
+		for _, e := range vv.vals {
+			if containsSelfRef(e, fullKey) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// foldSelfRef returns v with every substPlaceholder whose dotted-path key
+// equals fullKey replaced by replacement. If v contains no such self-ref,
+// v is returned unchanged.
+//
+// Used at prior-save time to break self-referential chains: when an
+// assignment `key = ${key} [...]` is about to overwrite an earlier value,
+// the new prior would itself contain `${key}` and produce infinite recursion
+// during resolution. Substituting the actual prior value for `${key}` in
+// the concat yields a self-ref-free tree that resolveSubst can walk safely.
+//
+// Scope matches containsSelfRef: walks only concat / subst placeholders.
+func foldSelfRef(v Val, fullKey string, replacement Val) Val {
+	switch vv := v.(type) {
+	case *substPlaceholder:
+		if substFullKey(vv) == fullKey {
+			return replacement
+		}
+		return v
+	case *concatPlaceholder:
+		anyChanged := false
+		newVals := make([]Val, len(vv.vals))
+		for i, e := range vv.vals {
+			ne := foldSelfRef(e, fullKey, replacement)
+			newVals[i] = ne
+			if ne != e {
+				anyChanged = true
+			}
+		}
+		if !anyChanged {
+			return v
+		}
+		return &concatPlaceholder{vals: newVals, line: vv.line, col: vv.col}
+	default:
+		return v
+	}
+}
+
+// substFullKey returns the dotted-path key of a substPlaceholder's segments.
+// Segments are already relativized at this point if the placeholder lives
+// inside an included file under a nested pathPrefix.
+func substFullKey(sp *substPlaceholder) string {
+	return segmentsToKey(segTexts(sp.segments))
+}

--- a/internal/resolver/foldselfref.go
+++ b/internal/resolver/foldselfref.go
@@ -8,64 +8,80 @@
 
 package resolver
 
-// containsSelfRef reports whether v contains at least one substPlaceholder
-// whose dotted-path key equals fullKey.
+// foldSelfRef walks v and rewrites every substPlaceholder whose dotted-path
+// key equals fullKey by substituting replacement. The boolean return reports
+// whether at least one such self-reference was found in v (regardless of
+// whether substitution actually occurred).
 //
-// Scope: walks concatPlaceholder and substPlaceholder only. Self-references
+// Pass replacement=nil to perform a presence-only check without rewriting:
+// the returned Val is v unchanged and the boolean still reports correctly.
+// This single-walk API combines what would otherwise be two passes (one to
+// detect, one to rewrite) into one.
+//
+// Scope: walks substPlaceholder / concatPlaceholder only. Self-references
 // embedded inside ArrayVal elements or ObjectVal fields are out of scope —
-// those represent a separate pattern (e.g. `a = [${a}, 1]`) that #118's fix
-// does not address.
-func containsSelfRef(v Val, fullKey string) bool {
+// those represent a separate pattern (e.g. `a = [${a}, 1]`) tracked in #120.
+func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 	switch vv := v.(type) {
 	case *substPlaceholder:
-		return substFullKey(vv) == fullKey
+		if substFullKey(vv) != fullKey {
+			return v, false
+		}
+		if replacement != nil {
+			return replacement, true
+		}
+		return v, true
 	case *concatPlaceholder:
-		for _, e := range vv.vals {
-			if containsSelfRef(e, fullKey) {
-				return true
+		var newVals []Val
+		anyHit := false
+		for i, e := range vv.vals {
+			ne, hit := foldSelfRef(e, fullKey, replacement)
+			if hit {
+				if !anyHit && replacement != nil {
+					// First hit — lazy-init the rewritten slice so the
+					// no-self-ref common path allocates nothing.
+					newVals = make([]Val, len(vv.vals))
+					copy(newVals[:i], vv.vals[:i])
+				}
+				anyHit = true
+			}
+			if newVals != nil {
+				newVals[i] = ne
 			}
 		}
-		return false
+		if !anyHit {
+			return v, false
+		}
+		if replacement == nil {
+			return v, true
+		}
+		return &concatPlaceholder{vals: newVals, line: vv.line, col: vv.col}, true
 	default:
-		return false
+		return v, false
 	}
 }
 
-// foldSelfRef returns v with every substPlaceholder whose dotted-path key
-// equals fullKey replaced by replacement. If v contains no such self-ref,
-// v is returned unchanged.
+// foldOrSkipPrior decides how to save a self-reference-aware prior at one
+// of the three prior-save sites (direct assignment, include-merge non-object
+// override, setPath nested assignment). Cases:
 //
-// Used at prior-save time to break self-referential chains: when an
-// assignment `key = ${key} [...]` is about to overwrite an earlier value,
-// the new prior would itself contain `${key}` and produce infinite recursion
-// during resolution. Substituting the actual prior value for `${key}` in
-// the concat yields a self-ref-free tree that resolveSubst can walk safely.
+//   - prior has no self-ref to fullKey         → save prior as-is  → (prior,  true)
+//   - prior has self-ref AND old != nil        → fold against old  → (folded, true)
+//   - prior has self-ref AND old == nil        → skip save         → (nil,    false)
 //
-// Scope matches containsSelfRef: walks only concat / subst placeholders.
-func foldSelfRef(v Val, fullKey string, replacement Val) Val {
-	switch vv := v.(type) {
-	case *substPlaceholder:
-		if substFullKey(vv) == fullKey {
-			return replacement
-		}
-		return v
-	case *concatPlaceholder:
-		anyChanged := false
-		newVals := make([]Val, len(vv.vals))
-		for i, e := range vv.vals {
-			ne := foldSelfRef(e, fullKey, replacement)
-			newVals[i] = ne
-			if ne != e {
-				anyChanged = true
-			}
-		}
-		if !anyChanged {
-			return v
-		}
-		return &concatPlaceholder{vals: newVals, line: vv.line, col: vv.col}
-	default:
-		return v
+// The skip case (no old prior to fold against) preserves the existing
+// "unresolved self-referential substitution" error path at resolveSubst.
+// Callers must not write to priorValues when the second return value is
+// false; leaving priorValues untouched is what makes the error path fire.
+func foldOrSkipPrior(prior Val, fullKey string, old Val) (Val, bool) {
+	folded, hasSelfRef := foldSelfRef(prior, fullKey, old)
+	if !hasSelfRef {
+		return prior, true
 	}
+	if old == nil {
+		return nil, false
+	}
+	return folded, true
 }
 
 // substFullKey returns the dotted-path key of a substPlaceholder's segments.

--- a/internal/resolver/issue118_chained_self_ref_test.go
+++ b/internal/resolver/issue118_chained_self_ref_test.go
@@ -10,6 +10,7 @@ package resolver_test
 
 import (
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/o3co/go.hocon/internal/parser"
@@ -24,6 +25,20 @@ import (
 // Each test runs in isolation via `go test -run <name>` because a stack
 // overflow in any one scenario terminates the entire test binary, masking
 // later tests.
+
+// TestIssue118_TwoStepChainStillWorks — chain length 2 (the pre-#118 working
+// case) must not regress under the extended save-trigger + fold-at-save logic.
+// Mirrors TestResolver_SelfReference but lives in the #118 suite so the
+// regression-prevention narrative is self-contained.
+func TestIssue118_TwoStepChainStillWorks(t *testing.T) {
+	res := resolve(t, `branches = ["main"]
+branches = ${branches} ["dev"]`)
+	got := getStringSlice(t, res, "branches")
+	want := []string{"main", "dev"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
 
 // TestIssue118_FlatArrayChain — direct 3-step array self-ref. No includes.
 func TestIssue118_FlatArrayChain(t *testing.T) {
@@ -208,32 +223,9 @@ func expectInt(t *testing.T, ov *resolver.ObjectVal, key string, want int) {
 		return
 	}
 	// Numeric scalars are stored as their raw textual form.
-	if sv.Raw != itoa(want) {
+	if sv.Raw != strconv.Itoa(want) {
 		t.Errorf("%s: expected %d, got %s", key, want, sv.Raw)
 	}
-}
-
-func itoa(i int) string {
-	// minimal int-to-string for test assertions
-	if i == 0 {
-		return "0"
-	}
-	neg := i < 0
-	if neg {
-		i = -i
-	}
-	var buf [20]byte
-	p := len(buf)
-	for i > 0 {
-		p--
-		buf[p] = byte('0' + i%10)
-		i /= 10
-	}
-	if neg {
-		p--
-		buf[p] = '-'
-	}
-	return string(buf[p:])
 }
 
 type tryResolveResult struct {

--- a/internal/resolver/issue118_chained_self_ref_test.go
+++ b/internal/resolver/issue118_chained_self_ref_test.go
@@ -162,6 +162,57 @@ r.x = ${r.x} ["c"]`)
 	}
 }
 
+// TestIssue118_NestedObjectScopedChain — nested-object form where the inner
+// field uses `${parent.leaf}` from inside a nested object block:
+//
+//	r {
+//	  x = ["a"]
+//	  x = ${r.x} ["b"]
+//	  x = ${r.x} ["c"]
+//	}
+//
+// The inner resolveObject runs with pathPrefix=[r]; each inner field has
+// Key=[x] (single segment). The substPlaceholder for `${r.x}` carries
+// segments=[r, x] — the fully-qualified path. The original PR-121 fix
+// computed fullKey from the bare leaf key only, missing the self-ref and
+// silently falling through to a "circular reference detected" error
+// instead of resolving the chain. Surfaced by Copilot review on PR #121.
+//
+// Lightbend resolves this to ["a", "b", "c"].
+func TestIssue118_NestedObjectScopedChain(t *testing.T) {
+	res := resolve(t, `r {
+  x = ["a"]
+  x = ${r.x} ["b"]
+  x = ${r.x} ["c"]
+}`)
+	v, ok := res.Root.Get("r")
+	if !ok {
+		t.Fatal("r not found")
+	}
+	rObj, ok := v.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("r: expected ObjectVal, got %T", v)
+	}
+	xv, ok := rObj.Get("x")
+	if !ok {
+		t.Fatal("r.x not found")
+	}
+	arr, ok := xv.(*resolver.ArrayVal)
+	if !ok {
+		t.Fatalf("r.x: expected ArrayVal, got %T", xv)
+	}
+	want := []string{"a", "b", "c"}
+	if len(arr.Elements) != len(want) {
+		t.Fatalf("r.x: expected %d elements, got %d", len(want), len(arr.Elements))
+	}
+	for i, w := range want {
+		sv, ok := arr.Elements[i].(*resolver.ScalarVal)
+		if !ok || sv.Raw != w {
+			t.Errorf("r.x[%d]: expected %q, got %v", i, w, arr.Elements[i])
+		}
+	}
+}
+
 // TestIssue118_SingleSelfRefWithoutPriorErrors — edge case: lone `a = ${a} ["x"]`
 // (no earlier prior assignment) must still produce a clean "unresolved
 // self-referential substitution" error, NOT a crash. Verifies the

--- a/internal/resolver/issue118_chained_self_ref_test.go
+++ b/internal/resolver/issue118_chained_self_ref_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package resolver_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/o3co/go.hocon/internal/parser"
+	"github.com/o3co/go.hocon/internal/resolver"
+)
+
+// Regression suite for issue #118: chained self-referential append (N>=3) crashes
+// the resolver with infinite recursion. Lightbend produces well-defined chain
+// semantics where each ${key} resolves to the value the key had immediately
+// before its current assignment. go.hocon must match.
+//
+// Each test runs in isolation via `go test -run <name>` because a stack
+// overflow in any one scenario terminates the entire test binary, masking
+// later tests.
+
+// TestIssue118_FlatArrayChain — direct 3-step array self-ref. No includes.
+func TestIssue118_FlatArrayChain(t *testing.T) {
+	res := resolve(t, `branches = ["main"]
+branches = ${branches} ["dev"]
+branches = ${branches} ["release"]`)
+	got := getStringSlice(t, res, "branches")
+	want := []string{"main", "dev", "release"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+// TestIssue118_FourStepArrayChain — induction check: chain length 4 still resolves.
+func TestIssue118_FourStepArrayChain(t *testing.T) {
+	res := resolve(t, `a = ["a"]
+a = ${a} ["b"]
+a = ${a} ["c"]
+a = ${a} ["d"]`)
+	got := getStringSlice(t, res, "a")
+	want := []string{"a", "b", "c", "d"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+// TestIssue118_ChainedInclude — 3-file scenario from the original issue report.
+// parent.conf: include common; include child; branches = ${branches} ["release"]
+func TestIssue118_ChainedInclude(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "common.conf"), `branches = ["main"]`)
+	writeFile(t, filepath.Join(dir, "child.conf"), `branches = ${branches} ["dev"]`)
+	res := resolveWithDir(t, `include "common.conf"
+include "child.conf"
+branches = ${branches} ["release"]`, dir)
+	got := getStringSlice(t, res, "branches")
+	want := []string{"main", "dev", "release"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+// TestIssue118_ChainedIncludeAllChain — every include itself appends self-ref.
+// parent: branches = ["root"]; include a; include b
+// a: branches = ${branches} ["x"]
+// b: branches = ${branches} ["y"]
+func TestIssue118_ChainedIncludeAllChain(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.conf"), `branches = ${branches} ["x"]`)
+	writeFile(t, filepath.Join(dir, "b.conf"), `branches = ${branches} ["y"]`)
+	res := resolveWithDir(t, `branches = ["root"]
+include "a.conf"
+include "b.conf"`, dir)
+	got := getStringSlice(t, res, "branches")
+	want := []string{"root", "x", "y"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+// TestIssue118_ObjectChain — 3-step object self-ref (HOCON spec: object-object
+// concat means deep merge). The previous prior-save logic skipped the existing-Object
+// case when val is non-Object (a concat), losing the step-2 prior; this regression
+// test asserts the chain resolves correctly to {a:1, b:2, c:3}.
+func TestIssue118_ObjectChain(t *testing.T) {
+	res := resolve(t, `obj = { a = 1 }
+obj = ${obj} { b = 2 }
+obj = ${obj} { c = 3 }`)
+	v, ok := res.Root.Get("obj")
+	if !ok {
+		t.Fatal("obj not found")
+	}
+	ov, ok := v.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("expected ObjectVal, got %T", v)
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if _, ok := ov.Get(k); !ok {
+			t.Errorf("expected key %q in result, got keys=%v", k, ov.Keys())
+		}
+	}
+	expectInt(t, ov, "a", 1)
+	expectInt(t, ov, "b", 2)
+	expectInt(t, ov, "c", 3)
+}
+
+// TestIssue118_MultiSegmentChain — chain on a nested path (`r.x = ${r.x} [...]` × 3).
+// Before #118 this produced a "circular reference detected" error rather than the
+// stack overflow seen on top-level chains, but the bug class is the same: the
+// per-object priorValues got overwritten with a self-referential concat. Fixed
+// by extending the same fold-at-save logic to setPath.
+func TestIssue118_MultiSegmentChain(t *testing.T) {
+	res := resolve(t, `r.x = ["a"]
+r.x = ${r.x} ["b"]
+r.x = ${r.x} ["c"]`)
+	v, ok := res.Root.Get("r")
+	if !ok {
+		t.Fatal("r not found")
+	}
+	rObj, ok := v.(*resolver.ObjectVal)
+	if !ok {
+		t.Fatalf("r: expected ObjectVal, got %T", v)
+	}
+	xv, ok := rObj.Get("x")
+	if !ok {
+		t.Fatal("r.x not found")
+	}
+	arr, ok := xv.(*resolver.ArrayVal)
+	if !ok {
+		t.Fatalf("r.x: expected ArrayVal, got %T", xv)
+	}
+	want := []string{"a", "b", "c"}
+	if len(arr.Elements) != len(want) {
+		t.Fatalf("r.x: expected %d elements, got %d", len(want), len(arr.Elements))
+	}
+	for i, w := range want {
+		sv, ok := arr.Elements[i].(*resolver.ScalarVal)
+		if !ok || sv.Raw != w {
+			t.Errorf("r.x[%d]: expected %q, got %v", i, w, arr.Elements[i])
+		}
+	}
+}
+
+// TestIssue118_SingleSelfRefWithoutPriorErrors — edge case: lone `a = ${a} ["x"]`
+// (no earlier prior assignment) must still produce a clean "unresolved
+// self-referential substitution" error, NOT a crash. Verifies the
+// skip-save-when-no-old-prior behavior preserves the existing error path.
+func TestIssue118_SingleSelfRefWithoutPriorErrors(t *testing.T) {
+	// Direct call to resolver (not resolve helper) because resolve helper
+	// t.Fatal's on error; we want to verify error is returned.
+	got := tryResolve(t, `a = ${a} ["x"]`)
+	if got.err == nil {
+		t.Fatal("expected resolve error for self-ref with no prior, got nil")
+	}
+}
+
+// ---- helpers ----
+
+func getStringSlice(t *testing.T, res *resolver.Result, key string) []string {
+	t.Helper()
+	v, ok := res.Root.Get(key)
+	if !ok {
+		t.Fatalf("%s not found in result", key)
+	}
+	arr, ok := v.(*resolver.ArrayVal)
+	if !ok {
+		t.Fatalf("%s: expected ArrayVal, got %T", key, v)
+	}
+	out := make([]string, len(arr.Elements))
+	for i, e := range arr.Elements {
+		sv, ok := e.(*resolver.ScalarVal)
+		if !ok {
+			t.Fatalf("%s[%d]: expected ScalarVal, got %T", key, i, e)
+		}
+		out[i] = sv.Raw
+	}
+	return out
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func expectInt(t *testing.T, ov *resolver.ObjectVal, key string, want int) {
+	t.Helper()
+	v, ok := ov.Get(key)
+	if !ok {
+		t.Errorf("key %q not found in object", key)
+		return
+	}
+	sv, ok := v.(*resolver.ScalarVal)
+	if !ok {
+		t.Errorf("%s: expected ScalarVal, got %T", key, v)
+		return
+	}
+	// Numeric scalars are stored as their raw textual form.
+	if sv.Raw != itoa(want) {
+		t.Errorf("%s: expected %d, got %s", key, want, sv.Raw)
+	}
+}
+
+func itoa(i int) string {
+	// minimal int-to-string for test assertions
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	p := len(buf)
+	for i > 0 {
+		p--
+		buf[p] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		p--
+		buf[p] = '-'
+	}
+	return string(buf[p:])
+}
+
+type tryResolveResult struct {
+	res *resolver.Result
+	err error
+}
+
+func tryResolve(t *testing.T, src string) tryResolveResult {
+	t.Helper()
+	ast, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	res, err := resolver.Resolve(ast, resolver.Options{})
+	return tryResolveResult{res: res, err: err}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -450,17 +450,7 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					// the saved value is self-ref-free. Without this, chained
 					// includes (`branches = ${branches} ["x"]` in each file) save
 					// a self-referential concat and resolveSubst loops forever.
-					doSave := true
-					if containsSelfRef(prior, fullKey) {
-						old := obj.priorValues[k]
-						if old != nil {
-							prior = foldSelfRef(prior, fullKey, old)
-						} else {
-							// No old prior to fold against — preserve existing
-							// "unresolved self-ref" error path.
-							doSave = false
-						}
-					}
+					prior, doSave := foldOrSkipPrior(prior, fullKey, obj.priorValues[k])
 					if doSave {
 						// Write r.priorValues ONLY at top of the current resolver's
 						// scope. When the include is nested (pathPrefix != []), `k`
@@ -476,16 +466,10 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					// No collision in parent, but include's own dup-key chain
 					// produced a prior. Preserve it (with the same scope rule).
 					// #118: same fold-or-skip treatment as the collision branch.
-					prior := inclPrior
-					doSave := true
-					if containsSelfRef(prior, fullKey) {
-						old := obj.priorValues[k]
-						if old != nil {
-							prior = foldSelfRef(prior, fullKey, old)
-						} else {
-							doSave = false
-						}
-					}
+					// obj.priorValues[k] may carry an older prior from a prior
+					// include-merge or direct overwrite even though obj.values[k]
+					// is unset (priors survive subsequent shadowing).
+					prior, doSave := foldOrSkipPrior(inclPrior, fullKey, obj.priorValues[k])
 					if doSave {
 						if len(pathPrefix) == 0 {
 							r.priorValues[fullKey] = prior
@@ -550,23 +534,12 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					// silently dropped the object-overwritten-by-concat case (e.g.
 					// `obj = {a:1}; obj = ${obj} {b:2}`) — step 2's `${obj}` had no
 					// prior to resolve against. Save now happens whenever the new
-					// value is not deep-merging with existing.
-					priorToSave := existing
-					doSave := true
-					if containsSelfRef(existing, fullKey) {
-						// existing itself contains `${key}` (chain length >= 3).
-						// Fold against the OLD prior so the saved value is
-						// self-ref-free; otherwise resolveSubst would loop forever
-						// re-resolving the same prior. #118.
-						if old, hasOld := r.priorValues[fullKey]; hasOld {
-							priorToSave = foldSelfRef(existing, fullKey, old)
-						} else {
-							// No old prior to fold against — leave priorValues
-							// unchanged so resolveSubst's existing "unresolved
-							// self-referential substitution" error path fires.
-							doSave = false
-						}
-					}
+					// value is not deep-merging with existing. When existing
+					// itself contains `${key}` (chain length >= 3), fold it
+					// against the OLD prior so the saved value is self-ref-free;
+					// otherwise resolveSubst would loop forever re-resolving the
+					// same prior. See foldOrSkipPrior for the three-way decision.
+					priorToSave, doSave := foldOrSkipPrior(existing, fullKey, r.priorValues[fullKey])
 					if doSave {
 						r.priorValues[fullKey] = priorToSave
 						obj.priorValues[key] = priorToSave // per-object scope for optional-substitution fallback
@@ -1326,15 +1299,8 @@ func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val, fullPath 
 				// existing is being shadowed without merging — save it as prior so
 				// a self-referential `${fullPath}` in val can refer back to it. Mirror
 				// of the top-level direct-assignment logic for nested paths. #118.
-				priorToSave := existing
-				doSave := true
-				if containsSelfRef(existing, fullKey) {
-					if old, hasOld := r.priorValues[fullKey]; hasOld {
-						priorToSave = foldSelfRef(existing, fullKey, old)
-					} else {
-						doSave = false
-					}
-				}
+				// See foldOrSkipPrior for the three-way decision (save / fold / skip).
+				priorToSave, doSave := foldOrSkipPrior(existing, fullKey, r.priorValues[fullKey])
 				if doSave {
 					// Write r.priorValues keyed by the FULL dotted path. The previous
 					// implementation deliberately avoided r.priorValues because it

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -518,7 +518,13 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 		// normal assignment — handle duplicate key merging
 		if len(field.Key) == 1 {
 			key := field.Key[0]
-			fullKey := segmentsToKey([]string{key})
+			// fullKey is the fully-qualified path for self-ref detection and
+			// r.priorValues bookkeeping. Includes pathPrefix so the
+			// nested-object form `r { x = ${r.x} [...] }` (where the inner
+			// resolveObject runs with pathPrefix=[r]) detects self-references
+			// to "r.x" instead of the bare leaf "x". Surfaced by Copilot
+			// review on PR #121.
+			fullKey := segmentsToKey(append(append([]string{}, pathPrefix...), key))
 			if existing, ok := obj.Get(key); ok {
 				merged := false
 				if eo, eok := existing.(*ObjectVal); eok {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -423,6 +423,11 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 			// inside the include resolves to the parent's value (#106).
 			for _, k := range included.keys {
 				iv := included.values[k]
+				// Full path key for self-ref detection: substPlaceholder.segments
+				// are already relativized to pathPrefix+k by relativizeVals at
+				// resolveInclude's end (see L1376-1378), so fold comparisons
+				// must use the same fully-qualified path.
+				fullKey := segmentsToKey(append(append([]string{}, pathPrefix...), k))
 				if existing, exists := obj.Get(k); exists {
 					if eo, eok := existing.(*ObjectVal); eok {
 						if io, iok := iv.(*ObjectVal); iok {
@@ -441,22 +446,52 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					if inclPrior, hasInclPrior := included.priorValues[k]; hasInclPrior {
 						prior = inclPrior
 					}
-					// Write r.priorValues ONLY at top of the current resolver's
-					// scope. When the include is nested (pathPrefix != []), `k`
-					// is just a leaf name and would collide with an unrelated
-					// top-level key of the same name; see setPath L1239-1247
-					// for the same rule applied to regular field overwrite.
-					if len(pathPrefix) == 0 {
-						r.priorValues[segmentsToKey([]string{k})] = prior
+					// #118: fold self-ref in `prior` against the previous prior so
+					// the saved value is self-ref-free. Without this, chained
+					// includes (`branches = ${branches} ["x"]` in each file) save
+					// a self-referential concat and resolveSubst loops forever.
+					doSave := true
+					if containsSelfRef(prior, fullKey) {
+						old := obj.priorValues[k]
+						if old != nil {
+							prior = foldSelfRef(prior, fullKey, old)
+						} else {
+							// No old prior to fold against — preserve existing
+							// "unresolved self-ref" error path.
+							doSave = false
+						}
 					}
-					obj.priorValues[k] = prior
+					if doSave {
+						// Write r.priorValues ONLY at top of the current resolver's
+						// scope. When the include is nested (pathPrefix != []), `k`
+						// is just a leaf name and would collide with an unrelated
+						// top-level key of the same name; see setPath L1239-1247
+						// for the same rule applied to regular field overwrite.
+						if len(pathPrefix) == 0 {
+							r.priorValues[fullKey] = prior
+						}
+						obj.priorValues[k] = prior
+					}
 				} else if inclPrior, hasInclPrior := included.priorValues[k]; hasInclPrior {
 					// No collision in parent, but include's own dup-key chain
 					// produced a prior. Preserve it (with the same scope rule).
-					if len(pathPrefix) == 0 {
-						r.priorValues[segmentsToKey([]string{k})] = inclPrior
+					// #118: same fold-or-skip treatment as the collision branch.
+					prior := inclPrior
+					doSave := true
+					if containsSelfRef(prior, fullKey) {
+						old := obj.priorValues[k]
+						if old != nil {
+							prior = foldSelfRef(prior, fullKey, old)
+						} else {
+							doSave = false
+						}
 					}
-					obj.priorValues[k] = inclPrior
+					if doSave {
+						if len(pathPrefix) == 0 {
+							r.priorValues[fullKey] = prior
+						}
+						obj.priorValues[k] = prior
+					}
 				}
 				obj.set(k, iv)
 			}
@@ -492,28 +527,56 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 				newArr = &ArrayVal{Elements: []Val{val}}
 			}
 			combined := &ArrayVal{Elements: append(existArr.Elements, newArr.Elements...)}
-			r.setPath(obj, field.Key, combined)
+			r.setPath(obj, field.Key, combined, field.Key)
 			continue
 		}
 
 		// normal assignment — handle duplicate key merging
 		if len(field.Key) == 1 {
 			key := field.Key[0]
+			fullKey := segmentsToKey([]string{key})
 			if existing, ok := obj.Get(key); ok {
+				merged := false
 				if eo, eok := existing.(*ObjectVal); eok {
 					if nv, nok := val.(*ObjectVal); nok {
 						val = deepMerge(nv, eo) // new over existing: nv=dst wins
+						merged = true
 					}
-				} else {
-					// non-object overwrite: save prior value for self-referential substitution support
-					r.priorValues[segmentsToKey([]string{key})] = existing
-					obj.priorValues[key] = existing // per-object scope for optional-substitution fallback
+				}
+				if !merged {
+					// existing is being shadowed without merging — save it as prior
+					// so a self-referential `${key}` in val can refer back to it.
+					// Pre-#118 this branch only fired for non-object existing, which
+					// silently dropped the object-overwritten-by-concat case (e.g.
+					// `obj = {a:1}; obj = ${obj} {b:2}`) — step 2's `${obj}` had no
+					// prior to resolve against. Save now happens whenever the new
+					// value is not deep-merging with existing.
+					priorToSave := existing
+					doSave := true
+					if containsSelfRef(existing, fullKey) {
+						// existing itself contains `${key}` (chain length >= 3).
+						// Fold against the OLD prior so the saved value is
+						// self-ref-free; otherwise resolveSubst would loop forever
+						// re-resolving the same prior. #118.
+						if old, hasOld := r.priorValues[fullKey]; hasOld {
+							priorToSave = foldSelfRef(existing, fullKey, old)
+						} else {
+							// No old prior to fold against — leave priorValues
+							// unchanged so resolveSubst's existing "unresolved
+							// self-referential substitution" error path fires.
+							doSave = false
+						}
+					}
+					if doSave {
+						r.priorValues[fullKey] = priorToSave
+						obj.priorValues[key] = priorToSave // per-object scope for optional-substitution fallback
+					}
 				}
 				// non-object: last value wins (fall through to obj.set below)
 			}
 			obj.set(key, val)
 		} else {
-			r.setPath(obj, field.Key, val)
+			r.setPath(obj, field.Key, val, field.Key)
 		}
 	}
 	return obj, nil
@@ -1246,25 +1309,44 @@ func (r *resolver) lookupPathObj(obj *ObjectVal, segments []string) (*ObjectVal,
 	return ov, ok
 }
 
-func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val) {
+func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val, fullPath []string) {
 	if len(segments) == 1 {
 		key := segments[0]
+		fullKey := segmentsToKey(fullPath)
 		// Deep merge if both existing and new values are objects
 		if existing, ok := obj.Get(key); ok {
+			merged := false
 			if eo, eok := existing.(*ObjectVal); eok {
 				if nv, nok := val.(*ObjectVal); nok {
 					val = deepMerge(nv, eo) // new over existing: nv=dst wins
+					merged = true
 				}
-			} else {
-				// non-object overwrite: save prior value for self-referential substitution support.
-				// Store ONLY on the parent object's per-object priorValues so that nested-path
-				// self-ref look-back (resolveSubst isSelfRef → parent.priorValues check) can find it.
-				// Do NOT write r.priorValues here: segments is the bare leaf key (e.g. "a" from
-				// "foo.a"), which would collide with an unrelated top-level "a" key in r.priorValues.
-				// Top-level keys are handled by the len(field.Key)==1 branch in buildObject, which
-				// writes r.priorValues with the correct full key; the parent.priorValues entry alone
-				// is sufficient for nested self-ref look-back (see resolveSubst L508-516).
-				obj.priorValues[key] = existing
+			}
+			if !merged {
+				// existing is being shadowed without merging — save it as prior so
+				// a self-referential `${fullPath}` in val can refer back to it. Mirror
+				// of the top-level direct-assignment logic for nested paths. #118.
+				priorToSave := existing
+				doSave := true
+				if containsSelfRef(existing, fullKey) {
+					if old, hasOld := r.priorValues[fullKey]; hasOld {
+						priorToSave = foldSelfRef(existing, fullKey, old)
+					} else {
+						doSave = false
+					}
+				}
+				if doSave {
+					// Write r.priorValues keyed by the FULL dotted path. The previous
+					// implementation deliberately avoided r.priorValues because it
+					// used the bare leaf key (which would collide with an unrelated
+					// top-level key of the same name). The full-path key has no
+					// collision risk: "foo.a" never matches a top-level "a".
+					// resolveSubst at L685 looks up r.priorValues[key] where key is
+					// already the full dotted path of the placeholder, so the entry
+					// is reachable from the self-ref branch with resolving=true.
+					r.priorValues[fullKey] = priorToSave
+					obj.priorValues[key] = priorToSave
+				}
 			}
 		}
 		obj.set(key, val)
@@ -1278,7 +1360,7 @@ func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val) {
 	if childObj == nil {
 		childObj = newObjectVal()
 	}
-	r.setPath(childObj, segments[1:], val)
+	r.setPath(childObj, segments[1:], val, fullPath)
 	obj.set(segments[0], childObj)
 }
 


### PR DESCRIPTION
## Summary

Closes #118.

Chained self-referential append (`a = ${a} ["x"]` repeated 3+ times — direct, via includes, or with object payload) sent the resolver into infinite recursion and aborted the process with a Go runtime stack overflow. The nested-path variant (`r.x = ${r.x} [...]` × 3) produced "circular reference detected" instead of crashing but still failed to resolve correctly. Reported by @cgordon.

Root cause (verified by instrumented trace, preserved on `debug/issue-118-trace` branch):
- `resolver.priorValues` is a one-deep `map[string]Val`. Each overwrite discards the older prior.
- When the existing being saved is itself a concat containing `${key}` (chain length ≥ 3), the saved prior is self-ref-containing. `resolveSubst`'s self-ref branch then calls `resolveVal(prior)` → re-enters `resolveSubst` with `resolving[key]==true` → looks up the same prior → infinite loop with no progress.
- Two additional holes: the direct-assignment prior save fired only when `existing` was non-Object (silently dropped the existing-Object + val-non-Object case); `setPath` wrote only `obj.priorValues`, not `r.priorValues`, so `resolveSubst`'s re-entry path couldn't find the saved prior for nested chains.

Fix:
- New `foldSelfRef` / `foldOrSkipPrior` helpers in `internal/resolver/foldselfref.go` walk `substPlaceholder` / `concatPlaceholder` trees and substitute `${key}` references with the old prior. By induction, every stored prior becomes self-ref-free.
- Applied at the 3 originating prior-save sites (direct assignment, include-merge non-object override, `setPath` nested assignment).
- `setPath` signature extended to carry `fullPath`; now writes `r.priorValues` keyed by the full dotted path (`"r.x"` etc.) — no collision with bare top-level keys.
- Edge case (`a = ${a} [...]` with no earlier prior): save is skipped to preserve the existing "unresolved self-referential substitution" error path.

Scope intentionally limited: `ArrayVal` / `ObjectVal` interior self-refs (e.g. `a = [${a}, 1]` chained) are tracked separately in #120.

Commits:
1. `fix(resolver): chained self-referential append no longer crashes` — initial helpers + 3 sites + 7 RED-confirmed regression tests
2. `refactor(resolver): address #118 review feedback` — multi-agent-review fixes (helper consolidation `foldOrSkipPrior`, single-walk API, `strconv.Itoa` polish, 2-step baseline test)

Verified:
- 8 new regression tests pass individually and as a suite (`internal/resolver/issue118_chained_self_ref_test.go`)
- `go test ./...` full suite PASS
- `go vet ./...` clean
- `golangci-lint run ./...` 0 issues
- multi-agent-review (Claude + Codex) → 0 Critical, 0 Important, Minor convergence → #120 filed

## Test plan

- [x] All 7 regression scenarios pass individually via `go test -run`
- [x] Combined suite passes (no stack overflow regression)
- [x] Full `go test ./...` clean
- [x] Lint + vet clean
- [x] multi-agent-review issues addressed
- [x] Tracking issue (#120) filed for out-of-scope pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)