### PR TITLE
fix(resolver): preserve priorValues in resolveSubstitutions

### DIFF
--- a/include_child_env_fallback_test.go
+++ b/include_child_env_fallback_test.go
@@ -12,30 +12,48 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/o3co/go.hocon"
 )
 
-// Bug regression suite: env-var fallback (${?ENV_NAME}) inside content reached
-// through an `include` (file or package) was being processed by a child
-// resolver whose Options dropped UseSystemEnvironment, so the substitution
-// could not see the process env. Combined with the lenient-pass placeholder
-// preservation (#45 fix), env-unset turned into "drop the field entirely",
-// erasing the prior assignment that the env override was meant to layer on.
-//
-// The classic operator pattern is "default in source + optional env override":
+// Bug regression suite for #128: the include-child path of resolveSubstitutions
+// constructed a fresh result object and copied obj.values[k] forward but
+// dropped obj.priorValues. For the canonical "default + optional env override"
+// pattern
 //
 //	registry {
 //	  instance-id = "localhost"
 //	  instance-id = ${?REGISTRY_INSTANCE_ID}
 //	}
 //
-// With the bug, env set → ignored (default returned); env unset → field
-// vanishes (silent regression vs. the documented Lightbend semantics where
-// the prior assignment is retained). Both broke real operator-facing
-// reference.conf files shipped via include package(...) (E11).
+// reached through an include (file or package), this stripped the prior chain
+// at the include boundary. When the parent's strict resolve pass then evaluated
+// the still-placeholder ${?…} and the env var was unset, the optional return
+// looked up obj.priorValues[k] in an empty map and dropped the field entirely
+// — silently regressing the documented Lightbend semantics where the prior
+// duplicate-key assignment must be retained.
+//
+// The fix (PR #129) preserves obj.priorValues into result.priorValues in
+// resolveSubstitutions, scoped to inIncludeChild to avoid leaking already-
+// resolved state into later WithFallback / MergeUnresolved composition.
+//
+// These regression tests pin both halves of the bug (env set → applied; env
+// unset → prior retained) on both the file-include and include-package
+// (E11) paths, plus the deferred parse/resolve lifecycle.
+
+// unsetEnvForTest unsets `key` for the duration of the test and restores any
+// prior value via t.Cleanup. Mirrors t.Setenv's auto-restore semantics for the
+// unset case (which testing does not provide a direct helper for).
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	if prev, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() { _ = os.Setenv(key, prev) })
+	}
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+}
 
 // TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv pins: env set →
 // child-included content resolves ${?VAR} against the process environment.
@@ -48,8 +66,7 @@ func TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	parentFile := filepath.Join(dir, "parent.conf")
-	slashChild := strings.ReplaceAll(childFile, "\\", "/")
-	src := fmt.Sprintf(`include "%s"`+"\n", slashChild)
+	src := fmt.Sprintf(`include "%s"`+"\n", filepath.ToSlash(childFile))
 	if err := os.WriteFile(parentFile, []byte(src), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +88,7 @@ func TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
 // the failing-half of the bug: env unset → the prior in-source default
 // assignment must remain, not be erased.
 func TestIncludeFile_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset(t *testing.T) {
-	os.Unsetenv("ICEF_TEST_VAR_UNSET")
+	unsetEnvForTest(t, "ICEF_TEST_VAR_UNSET")
 
 	dir := t.TempDir()
 	childFile := filepath.Join(dir, "child.conf")
@@ -85,8 +102,7 @@ registry {
 		t.Fatal(err)
 	}
 	parentFile := filepath.Join(dir, "parent.conf")
-	slashChild := strings.ReplaceAll(childFile, "\\", "/")
-	src := fmt.Sprintf(`include "%s"`+"\n", slashChild)
+	src := fmt.Sprintf(`include "%s"`+"\n", filepath.ToSlash(childFile))
 	if err := os.WriteFile(parentFile, []byte(src), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -109,6 +125,7 @@ registry {
 // the process environment.
 func TestIncludePackage_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
 	t.Setenv("ICEF_PKG_VAR_SET", "from-pkg-env")
+	t.Cleanup(hocon.ResetPackageRegistry)
 
 	const refContent = `result = ${?ICEF_PKG_VAR_SET}`
 	const pkgID = "github.com/o3co/go.hocon/test/include-env-fallback-set"
@@ -133,7 +150,8 @@ func TestIncludePackage_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
 // pins the failing-half of the bug for the E11 path: env unset → the prior
 // in-source default assignment must remain.
 func TestIncludePackage_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset(t *testing.T) {
-	os.Unsetenv("ICEF_PKG_VAR_UNSET")
+	unsetEnvForTest(t, "ICEF_PKG_VAR_UNSET")
+	t.Cleanup(hocon.ResetPackageRegistry)
 
 	const refContent = `
 registry {
@@ -164,7 +182,8 @@ registry {
 // then explicit Resolve): the include-child prior chain must still surface
 // when the optional env-var fallback evaluates to nothing.
 func TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault(t *testing.T) {
-	os.Unsetenv("ICEF_PKG_VAR_DEFERRED")
+	unsetEnvForTest(t, "ICEF_PKG_VAR_DEFERRED")
+	t.Cleanup(hocon.ResetPackageRegistry)
 
 	const refContent = `
 registry {

--- a/include_child_env_fallback_test.go
+++ b/include_child_env_fallback_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// Bug regression suite: env-var fallback (${?ENV_NAME}) inside content reached
+// through an `include` (file or package) was being processed by a child
+// resolver whose Options dropped UseSystemEnvironment, so the substitution
+// could not see the process env. Combined with the lenient-pass placeholder
+// preservation (#45 fix), env-unset turned into "drop the field entirely",
+// erasing the prior assignment that the env override was meant to layer on.
+//
+// The classic operator pattern is "default in source + optional env override":
+//
+//	registry {
+//	  instance-id = "localhost"
+//	  instance-id = ${?REGISTRY_INSTANCE_ID}
+//	}
+//
+// With the bug, env set → ignored (default returned); env unset → field
+// vanishes (silent regression vs. the documented Lightbend semantics where
+// the prior assignment is retained). Both broke real operator-facing
+// reference.conf files shipped via include package(...) (E11).
+
+// TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv pins: env set →
+// child-included content resolves ${?VAR} against the process environment.
+func TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
+	t.Setenv("ICEF_TEST_VAR_SET", "from-env")
+
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(childFile, []byte(`result = ${?ICEF_TEST_VAR_SET}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parentFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	src := fmt.Sprintf(`include "%s"`+"\n", slashChild)
+	if err := os.WriteFile(parentFile, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(parentFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := cfg.GetStringOption("result").Get()
+	if !ok {
+		t.Fatalf("result missing — env-var fallback must apply through include")
+	}
+	if got != "from-env" {
+		t.Errorf("result=%q, want %q", got, "from-env")
+	}
+}
+
+// TestIncludeFile_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset pins
+// the failing-half of the bug: env unset → the prior in-source default
+// assignment must remain, not be erased.
+func TestIncludeFile_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset(t *testing.T) {
+	os.Unsetenv("ICEF_TEST_VAR_UNSET")
+
+	dir := t.TempDir()
+	childFile := filepath.Join(dir, "child.conf")
+	childContent := `
+registry {
+  instance-id = "localhost"
+  instance-id = ${?ICEF_TEST_VAR_UNSET}
+}
+`
+	if err := os.WriteFile(childFile, []byte(childContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parentFile := filepath.Join(dir, "parent.conf")
+	slashChild := strings.ReplaceAll(childFile, "\\", "/")
+	src := fmt.Sprintf(`include "%s"`+"\n", slashChild)
+	if err := os.WriteFile(parentFile, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := hocon.ParseFile(parentFile)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := cfg.GetStringOption("registry.instance-id").Get()
+	if !ok {
+		t.Fatalf("registry.instance-id missing — prior default must remain when ${?ENV} is unset")
+	}
+	if got != "localhost" {
+		t.Errorf("registry.instance-id=%q, want %q", got, "localhost")
+	}
+}
+
+// TestIncludePackage_OptionalEnvFallback_AppliesSystemEnv pins: env set →
+// content reached via include package(...) (E11) resolves ${?VAR} against
+// the process environment.
+func TestIncludePackage_OptionalEnvFallback_AppliesSystemEnv(t *testing.T) {
+	t.Setenv("ICEF_PKG_VAR_SET", "from-pkg-env")
+
+	const refContent = `result = ${?ICEF_PKG_VAR_SET}`
+	const pkgID = "github.com/o3co/go.hocon/test/include-env-fallback-set"
+	if err := hocon.RegisterPackage(pkgID, "reference.conf", []byte(refContent)); err != nil {
+		t.Fatalf("RegisterPackage: %v", err)
+	}
+
+	cfg, err := hocon.ParseString(fmt.Sprintf(`include package(%q, "reference.conf")`+"\n", pkgID))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := cfg.GetStringOption("result").Get()
+	if !ok {
+		t.Fatalf("result missing — env-var fallback must apply through include package")
+	}
+	if got != "from-pkg-env" {
+		t.Errorf("result=%q, want %q", got, "from-pkg-env")
+	}
+}
+
+// TestIncludePackage_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset
+// pins the failing-half of the bug for the E11 path: env unset → the prior
+// in-source default assignment must remain.
+func TestIncludePackage_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset(t *testing.T) {
+	os.Unsetenv("ICEF_PKG_VAR_UNSET")
+
+	const refContent = `
+registry {
+  instance-id = "localhost"
+  instance-id = ${?ICEF_PKG_VAR_UNSET}
+}
+`
+	const pkgID = "github.com/o3co/go.hocon/test/include-env-fallback-unset"
+	if err := hocon.RegisterPackage(pkgID, "reference.conf", []byte(refContent)); err != nil {
+		t.Fatalf("RegisterPackage: %v", err)
+	}
+
+	cfg, err := hocon.ParseString(fmt.Sprintf(`include package(%q, "reference.conf")`+"\n", pkgID))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := cfg.GetStringOption("registry.instance-id").Get()
+	if !ok {
+		t.Fatalf("registry.instance-id missing — prior default must remain when ${?ENV} is unset")
+	}
+	if got != "localhost" {
+		t.Errorf("registry.instance-id=%q, want %q", got, "localhost")
+	}
+}
+
+// TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault
+// pins the deferred-resolution path (parse with ResolveSubstitutions=false,
+// then explicit Resolve): the include-child prior chain must still surface
+// when the optional env-var fallback evaluates to nothing.
+func TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault(t *testing.T) {
+	os.Unsetenv("ICEF_PKG_VAR_DEFERRED")
+
+	const refContent = `
+registry {
+  instance-id = "localhost"
+  instance-id = ${?ICEF_PKG_VAR_DEFERRED}
+}
+`
+	const pkgID = "github.com/o3co/go.hocon/test/include-env-fallback-deferred"
+	if err := hocon.RegisterPackage(pkgID, "reference.conf", []byte(refContent)); err != nil {
+		t.Fatalf("RegisterPackage: %v", err)
+	}
+
+	cfg, err := hocon.ParseStringWithOptions(
+		fmt.Sprintf(`include package(%q, "reference.conf")`+"\n", pkgID),
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := cfg.Resolve(hocon.DefaultResolveOptions())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	got, ok := resolved.GetStringOption("registry.instance-id").Get()
+	if !ok {
+		t.Fatalf("registry.instance-id missing — prior default must remain when ${?ENV} is unset")
+	}
+	if got != "localhost" {
+		t.Errorf("registry.instance-id=%q, want %q", got, "localhost")
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -672,14 +672,22 @@ func (c *concatPlaceholder) val() {}
 // resolveSubstitutions performs the second pass, replacing placeholders.
 func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*ObjectVal, error) {
 	result := newObjectVal()
-	// Preserve priorValues so a later resolver pass (e.g. parent resolving an
-	// include child's still-placeholder output) can fall back to the prior
-	// in-source assignment when an optional substitution evaluates to nothing.
-	// Without this, the include child's resolveSubstitutions strips
-	// obj.priorValues, and the parent's `${?ENV}` (env unset) silently erases
-	// the `key = "default"` assignment that preceded it.
-	for k, v := range obj.priorValues {
-		result.priorValues[k] = v
+	// Include-child only: preserve priorValues so the parent's later strict
+	// resolve pass can fall back to the prior in-source assignment when an
+	// optional substitution evaluates to nothing. Without this carry, the
+	// include child's resolveSubstitutions strips obj.priorValues across the
+	// include boundary, and the parent's `${?ENV}` (env unset) silently
+	// erases the `key = "default"` assignment that preceded it.
+	//
+	// Scoped to `inIncludeChild` so already-resolved Configs in the top-level
+	// resolve path don't carry stale priorValues forward — that would give
+	// later WithFallback composition (MergeUnresolved) extra prior state from
+	// completed resolutions and risk spurious composition-barrier firing
+	// (Codex review on PR #129).
+	if r.inIncludeChild {
+		for k, v := range obj.priorValues {
+			result.priorValues[k] = v
+		}
 	}
 	for _, k := range obj.Keys() {
 		v, _ := obj.Get(k)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -672,6 +672,15 @@ func (c *concatPlaceholder) val() {}
 // resolveSubstitutions performs the second pass, replacing placeholders.
 func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*ObjectVal, error) {
 	result := newObjectVal()
+	// Preserve priorValues so a later resolver pass (e.g. parent resolving an
+	// include child's still-placeholder output) can fall back to the prior
+	// in-source assignment when an optional substitution evaluates to nothing.
+	// Without this, the include child's resolveSubstitutions strips
+	// obj.priorValues, and the parent's `${?ENV}` (env unset) silently erases
+	// the `key = "default"` assignment that preceded it.
+	for k, v := range obj.priorValues {
+		result.priorValues[k] = v
+	}
 	for _, k := range obj.Keys() {
 		v, _ := obj.Get(k)
 		resolved, err := r.resolveVal(v, root, k)


### PR DESCRIPTION
## Summary

- Fixes #128: include-child `${?ENV}` env-with-default pattern silently erases prior duplicate-key assignment when env var is unset.
- One-liner intent: copy `obj.priorValues` into `result.priorValues` at the top of `resolveSubstitutions`, so the include child's still-placeholder output carries the prior chain into the parent's strict resolve pass.
- 9 LOC behaviour change + 5 pin tests in `include_child_env_fallback_test.go`.

## Why this lands now

dplaasio/oss develop landed PR #67 (HOCON-native config decentralization via `include package(...)` E11) on top of go.hocon v1.4.1. Every per-package `reference.conf` ships `key = "default"; key = ${?ENV_VAR}` — the standard Lightbend env-with-default override pattern. Under v1.4.1–v1.5.2 that pattern is structurally broken through include-package: env unset → key vanishes, env set → silently default-returned (the v1.5.1 #45 fix surfaces env-set correctly through the parent's strict pass, but the env-unset case still drops the prior). dplaasio/e2e's `vcresolver-chain` CI broke as a result.

## Pin coverage

- `TestIncludeFile_OptionalEnvFallback_AppliesSystemEnv` — file include + env set
- `TestIncludeFile_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset` — file include + env unset (was failing)
- `TestIncludePackage_OptionalEnvFallback_AppliesSystemEnv` — include package(...) + env set
- `TestIncludePackage_OptionalEnvFallback_PreservesPriorDefaultWhenEnvUnset` — include package(...) + env unset (was failing)
- `TestIncludePackage_OptionalEnvFallback_DeferredPath_PreservesPriorDefault` — deferred resolve path

## Test plan

- [x] `go test ./...` — all green (pre-existing `TestS13c_SuccessFixtures/ev12c-include-config-defined-wins` fixture-missing failure on develop is unrelated and unaffected by this PR).
- [x] Verified end-to-end with dplaasio/oss `network/pkg/core/...` + `packages/hoconconfig/...` tests (passes against this branch via local `replace`; fails against v1.5.2 with `missing required field "instance-id" / "port"`).

## Cross-impl follow-up

The same code shape — `resolveSubstitutions` / `resolveResObj` producing a fresh result container without carrying `priorValues` — exists in ts.hocon and rs.hocon. Empirical verification on those impls is pending; expect sibling issues / PRs in the cross-impl convergence pattern used by v1.5.0 / v1.5.1.

## Release

Drop-in patch (no public API change). Suggest v1.5.3 once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)