### PR TITLE
feat(tooling): hocon-json conformance adapter for the differential harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 /dist/
+/bin/
 
 # Test artifacts
 *.test

--- a/cmd/hocon-json/main.go
+++ b/cmd/hocon-json/main.go
@@ -47,13 +47,26 @@ func main() {
 	fmt.Println(out)
 }
 
+// errorRecord serializes to {"__error__":{"type":..,"message":..}} with a
+// deterministic field order (a struct, unlike a map, preserves order and lets
+// us check the marshal error).
+type errorRecord struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"__error__"`
+}
+
 func emitError(err error) {
-	rec := map[string]map[string]string{
-		"__error__": {
-			"type":    fmt.Sprintf("%T", err),
-			"message": err.Error(),
-		},
+	var rec errorRecord
+	rec.Error.Type = fmt.Sprintf("%T", err)
+	rec.Error.Message = err.Error()
+	b, mErr := json.Marshal(rec)
+	if mErr != nil {
+		// Last resort: still emit a single-line __error__ object (never a blank
+		// line) so the harness can classify this as an error rather than broken.
+		fmt.Printf("{\"__error__\":{\"type\":%q,\"message\":\"json marshal failed\"}}\n", rec.Error.Type)
+		return
 	}
-	b, _ := json.Marshal(rec)
 	fmt.Println(string(b))
 }

--- a/cmd/hocon-json/main.go
+++ b/cmd/hocon-json/main.go
@@ -1,0 +1,59 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Command hocon-json is the go.hocon adapter for the cross-impl differential
+// harness (xx.hocon/generate). It parses+resolves a HOCON file and prints the
+// resolved tree as canonical JSON to stdout. On any parse/resolve error it
+// prints a single-line {"__error__":{"type":..,"message":..}} record to stdout
+// and exits 3, so the differential driver can compare error-vs-success
+// behaviour uniformly across go/rs/ts and the Lightbend oracle.
+//
+// Usage: hocon-json <conf-file>
+//
+// Environment substitutions resolve against the process environment, so the
+// driver controls hermeticity by clearing/setting the subprocess env.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+const exitError = 3
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: hocon-json <conf-file>")
+		os.Exit(2)
+	}
+	cfg, err := hocon.ParseFile(os.Args[1])
+	if err != nil {
+		emitError(err)
+		os.Exit(exitError)
+	}
+	out, err := cfg.RenderJSONForTest()
+	if err != nil {
+		emitError(err)
+		os.Exit(exitError)
+	}
+	fmt.Println(out)
+}
+
+func emitError(err error) {
+	rec := map[string]map[string]string{
+		"__error__": {
+			"type":    fmt.Sprintf("%T", err),
+			"message": err.Error(),
+		},
+	}
+	b, _ := json.Marshal(rec)
+	fmt.Println(string(b))
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# CLI entrypoints are excluded from coverage: cmd/hocon-json is the dev-tool
+# adapter for xx.hocon's cross-impl differential harness, exercised end-to-end
+# by that harness rather than by Go unit tests.
+ignore:
+  - "cmd/**"

--- a/config.go
+++ b/config.go
@@ -981,13 +981,15 @@ func (c *Config) renderJSON() (string, error) {
 }
 
 // RenderJSONForTest serializes the resolved config tree to canonical JSON
-// (object keys sorted, numbers emitted as their source literal). It errors if
-// the config still holds unresolved substitution placeholders.
+// (object keys sorted, numbers emitted from their stored canonical literal —
+// integers are canonicalized at parse time, so leading zeros / -0 in the
+// source text are not preserved). It errors if the config still holds
+// unresolved substitution placeholders.
 //
 // This is NOT part of the stable public API (the library's contract is
-// parse() + typed getters); the name encodes that it exists only for the
-// cross-impl conformance / differential tooling, mirroring rs.hocon's
-// _render_json_for_test and ts.hocon's _renderJSONForTest.
+// parse() + typed getters) and may change without notice; the name encodes
+// that it exists only for the cross-impl conformance / differential tooling,
+// mirroring rs.hocon's _render_json_for_test and ts.hocon's _renderJSONForTest.
 func (c *Config) RenderJSONForTest() (string, error) {
 	return c.renderJSON()
 }

--- a/config.go
+++ b/config.go
@@ -980,6 +980,18 @@ func (c *Config) renderJSON() (string, error) {
 	return sb.String(), nil
 }
 
+// RenderJSONForTest serializes the resolved config tree to canonical JSON
+// (object keys sorted, numbers emitted as their source literal). It errors if
+// the config still holds unresolved substitution placeholders.
+//
+// This is NOT part of the stable public API (the library's contract is
+// parse() + typed getters); the name encodes that it exists only for the
+// cross-impl conformance / differential tooling, mirroring rs.hocon's
+// _render_json_for_test and ts.hocon's _renderJSONForTest.
+func (c *Config) RenderJSONForTest() (string, error) {
+	return c.renderJSON()
+}
+
 func writeValJSON(sb *strings.Builder, v resolver.Val) error {
 	switch vv := v.(type) {
 	case nil:

--- a/render_json_for_test_test.go
+++ b/render_json_for_test_test.go
@@ -1,0 +1,22 @@
+package hocon_test
+
+import (
+	"testing"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+func TestRenderJSONForTest_Canonical(t *testing.T) {
+	cfg, err := hocon.ParseString("a = 1\nb = \"x\"\nc { d = true }\n")
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	got, err := cfg.RenderJSONForTest()
+	if err != nil {
+		t.Fatalf("RenderJSONForTest: %v", err)
+	}
+	const want = `{"a":1,"b":"x","c":{"d":true}}`
+	if got != want {
+		t.Fatalf("RenderJSONForTest() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `cmd/hocon-json`, the go.hocon adapter for xx.hocon's cross-impl **differential harness** (xx.hocon#49). It parses+resolves a HOCON file and prints the resolved tree as canonical JSON to stdout; on any parse/resolve error it prints a single-line `{"__error__":{"type","message"}}` record and exits 3, so the harness can compare error-vs-success uniformly across go/rs/ts and the Lightbend oracle.

- `cmd/hocon-json/main.go` — the adapter (CLI: `hocon-json <conf-file>`).
- `config.go` — adds `RenderJSONForTest()`, a thin wrapper over the private `renderJSON()`. **Not** part of the stable `parse()`+typed-getters API; the name encodes tooling-only intent, mirroring rs.hocon's `_render_json_for_test` / ts.hocon's `_renderJSONForTest`.

Env substitutions resolve against the process environment (the harness controls hermeticity via the subprocess env).

## Test plan
- [ ] `go build ./cmd/hocon-json && ./hocon-json <some.conf>` → canonical JSON
- [ ] error input → `{"__error__":...}` + exit 3
- [ ] cross-impl: `make differential` in xx.hocon (#49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)