### PR TITLE
fix(parser): S10.5 whitespace + S10.11 numeric lexeme + S10.15 (#132/#133/#83) — cut v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-28
+
+Cross-impl release coordinated to land at v1.6.0 across go.hocon / ts.hocon / rs.hocon. Two string-concat spec fixes from the go.hocon#131–#135 audit, plus an incidental S10.15 spec-compliance fix that fell out of the #132 refactor. No public API changes; safe drop-in upgrade from v1.5.3. (go.hocon#134 — `+=` accumulation across includes — and the go-only #131 / #135 are deferred to follow-ups: #134 needs the multi-agent-review treatment the chained-self-ref machinery already required, and #135 is a Critical include-child eager-vs-deferred resolution change in the same family as #128.)
+
+### Fixed — S10.5 inner whitespace in value concatenation ([#132](https://github.com/o3co/go.hocon/issues/132))
+
+- **Literal whitespace runs between simple values in a string concatenation are now preserved verbatim** (HOCON.md §String value concatenation L332). `parseValue` inserted a single hardcoded `" "` separator between concat pieces, collapsing every multi-space run to one space (`foo   bar` → `"foo bar"`, and `"left"  ${?UNSET}  "right"` → `"left  right"` instead of Lightbend's `"left    right"`). The fix carries the literal `Token.PrecedingWhitespace` run (the lexer field E13 added for key-position whitespace) into the value-position separator. To keep separator identity while preserving the literal run, `ScalarNode` / `ScalarVal` gain a `Separator bool` flag and `isSeparator` now reads the flag instead of detecting a single-space `Raw`. Single-space concatenations are unchanged. Pinned by `TestS10_5_ValueConcatWhitespace` + `TestS10_5_UndefinedOptionalKeepsBothRuns`.
+
+### Fixed — S10.11 numeric lexeme preserved for stringification ([#133](https://github.com/o3co/go.hocon/issues/133))
+
+- **Numbers now stringify "as written in the source file" when concatenated** (HOCON.md L366). `parseSingleValue` canonicalized integer lexemes via `strconv.FormatInt` (`05` → `"5"`, and `00_example` — lexed as `TokenInt("00")` + unquoted `_example` — → `"0_example"`), losing the source spelling. `version = ${major}.${minor}` with `minor = 05` produced `"26.5"` instead of `"26.05"`. The `ScalarNode.Raw` now retains the source lexeme; the numeric accessors (`GetInt64` etc. re-parse `Raw` via `strconv.ParseInt`) still drop leading zeros / negative-zero sign for the standalone value, so this refines — not reverses — the earlier E8/F3 canonicalization. The two E8 unit tests + the octal-like `GetString` test are updated to assert lexeme preservation plus a semantic-accessor check. Pinned by `TestS10_11_NumericLexemePreserved` + `TestS10_11_NumericPrefixUnquotedKeepsLexeme`.
+
+### Fixed — S10.15 quoted whitespace between array substitutions now errors ([#83](https://github.com/o3co/go.hocon/issues/83))
+
+- **`${a} " " ${b}` (a quoted whitespace string between two array substitutions) now raises the spec-required type error** (HOCON.md L442) instead of silently merging the arrays. This fell out of the #132 refactor: the old `isSeparator` matched on `Raw == " "`, which also classified a *quoted* `" "` as a parser separator and stripped it (merging `[1]` and `[2]` into `[1,2]`). With the explicit `Separator` flag, a quoted `" "` correctly carries `Separator=false` and is not stripped, so the array + string + array concat raises the S10.13 type error. The `_Pin` test documenting the merged-array bug was removed and the `_Spec` test un-skipped.
+
 ## [1.5.3] - 2026-05-26
 
 Bugfix release: include-child env-with-default fallback ([#128](https://github.com/o3co/go.hocon/issues/128)), E6 cross-source list-suffix env-fallback ordering ([xx.hocon#22](https://github.com/o3co/xx.hocon/issues/22) + S13c.5), C3 cluster 3h cross-impl resolver bugs ([xx.hocon#27](https://github.com/o3co/xx.hocon/issues/27) — sr15 / sr13), and E13 key-position parsing alignment ([xx.hocon#42](https://github.com/o3co/xx.hocon/issues/42)). No public API changes; safe drop-in upgrade from v1.5.2.

--- a/config_test.go
+++ b/config_test.go
@@ -849,25 +849,20 @@ func TestConfig_DotPrefixedFloat_ToObject(t *testing.T) {
 	}
 }
 
-func TestConfig_GetString_OctalLikeNormalized(t *testing.T) {
-	// E8 BREAKING (xx.hocon#31 / commit dd102e8): leading-zero integers are
-	// canonicalized at value-position in `parser.parseSingleValue`'s
-	// TokenInt case (`strconv.ParseInt` + `FormatInt`) — `0100` parses as
-	// int64 100, and the resulting `ScalarNode.Raw` is `"100"`. GetString
-	// returns ScalarVal.Raw from the resolver, which carries the
-	// normalized form. Pre-E8 this test pinned the raw "0100" preservation;
-	// that surface was retracted with the E8 amendment to match Lightbend's
-	// parseLong behavior. Note: the lexer's `TokenInt.Value` is kept
-	// verbatim (parseKey reads the same token upstream, so normalizing in
-	// the lexer would silently rewrite keys — see PR #97 / commit 0a83805).
-	// Callers that need the original .conf text must read the source
-	// themselves; GetInt64 and JSON serialization are unchanged (still 100).
+func TestConfig_GetString_OctalLikePreservesLexeme(t *testing.T) {
+	// S10.11 (go.hocon#133): a numeric value stringifies "as written in the
+	// source file", so the stored `ScalarNode.Raw` keeps the original lexeme
+	// `"0100"` for GetString / string concatenation. The numeric accessors
+	// re-parse Raw, so GetInt64 still drops the leading zero (100). This
+	// refines the earlier E8/F3 decision that over-canonicalized the stored
+	// lexeme via `strconv.FormatInt`. (The lexer's TokenInt.Value was always
+	// verbatim; parseKey reads it upstream and is unaffected.)
 	cfg := mustParseCfg(t, `val = 0100`)
-	if got := cfg.GetString("val"); got != "100" {
-		t.Errorf("got %q, want %q (E8 leading-zero normalization)", got, "100")
+	if got := cfg.GetString("val"); got != "0100" {
+		t.Errorf("got %q, want %q (S10.11 lexeme preserved)", got, "0100")
 	}
 	if got := cfg.GetInt64("val"); got != 100 {
-		t.Errorf("GetInt64 got %d, want 100", got)
+		t.Errorf("GetInt64 got %d, want 100 (semantic value canonical)", got)
 	}
 }
 

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -52,6 +52,14 @@ type ScalarNode struct {
 	pos
 	Raw       string
 	ValueType string
+	// Separator is true when this scalar was synthesized by the parser as the
+	// whitespace run between two concatenated value tokens (not user-authored).
+	// The resolver's isSeparator uses this flag to decide whether the node
+	// contributes to string concatenation (S10.5) or is stripped for
+	// object/array concatenation (S10.14). Carrying a flag (rather than
+	// detecting a single-space Raw) lets the parser preserve the literal
+	// whitespace run per S10.5 (go.hocon#132) without losing separator identity.
+	Separator bool
 }
 
 func (n *ScalarNode) node() {}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -855,14 +855,24 @@ func (p *parser) parseValue() (Node, error) {
 		p.current.Type != lexer.TokenRBrace &&
 		p.current.Type != lexer.TokenRBracket {
 		// If there was whitespace between the previous value and this token,
-		// insert a space node for proper concatenation.
+		// insert a separator node for proper concatenation. S10.5 (go.hocon#132):
+		// preserve the literal whitespace run verbatim rather than collapsing to
+		// a single space. Capture PrecedingWhitespace BEFORE parseSingleValue
+		// advances the token. Fall back to a single space if the lexer reported
+		// PrecedingSpace but captured no chars (comment-only shape, which cannot
+		// occur mid-value-concat — the loop breaks on newline).
 		hadSpace := p.current.PrecedingSpace
+		precedingWS := p.current.PrecedingWhitespace
 		next, err2 := p.parseSingleValue()
 		if err2 != nil {
 			break
 		}
 		if hadSpace {
-			nodes = append(nodes, &ScalarNode{Raw: " ", ValueType: "string"})
+			sep := precedingWS
+			if sep == "" {
+				sep = " "
+			}
+			nodes = append(nodes, &ScalarNode{Raw: sep, ValueType: "string", Separator: true})
 		}
 		nodes = append(nodes, next)
 	}
@@ -903,15 +913,19 @@ func (p *parser) parseSingleValue() (Node, error) {
 	case lexer.TokenInt:
 		raw := p.current.Value
 		p.advance()
-		parsed, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil {
+		if _, err := strconv.ParseInt(raw, 10, 64); err != nil {
 			return nil, newError(line, col, "invalid int %q", raw)
 		}
-		// E8 (xx.hocon#31): canonicalize leading zeros and negative-zero sign
-		// at value-position only. `parseKey` reads the same TokenInt.Value
-		// upstream, so normalizing in the lexer would silently rewrite keys
-		// (`01 = x` → `1`); keep it confined to the value path.
-		return &ScalarNode{pos: pos{line, col}, Raw: strconv.FormatInt(parsed, 10), ValueType: "number"}, nil
+		// S10.11 (go.hocon#133): preserve the source lexeme so a numeric value
+		// stringifies "as written" when concatenated (`minor = 05` →
+		// `${major}.${minor}` = "26.05", and `00_example` keeps its "00"
+		// prefix). The numeric accessors (GetInt64 etc. at config.go re-parse
+		// Raw via strconv.ParseInt) still drop leading zeros / negative-zero
+		// sign for the standalone value, so this refines — not reverses — the
+		// earlier E8/F3 canonicalization, which over-canonicalized the stored
+		// lexeme. `parseKey` reads the same TokenInt.Value upstream and is
+		// unaffected (keys were never canonicalized here).
+		return &ScalarNode{pos: pos{line, col}, Raw: raw, ValueType: "number"}, nil
 	case lexer.TokenFloat:
 		raw := p.current.Value
 		p.advance()

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -262,6 +262,11 @@ type ScalarVal struct {
 	// decoded escape sequences, so Raw contains the decoded value.
 	Raw  string
 	Type ScalarType
+	// Separator is true when this scalar is a parser-synthesized whitespace
+	// run between concatenated value tokens (carried from ScalarNode.Separator).
+	// isSeparator uses it to strip the run for object/array concat (S10.14)
+	// while preserving it verbatim for string concat (S10.5, go.hocon#132).
+	Separator bool
 }
 
 func (s *ScalarVal) val() {}
@@ -611,7 +616,7 @@ func (r *resolver) resolveNode(node parser.Node, ctx *ObjectVal, pathPrefix []st
 		case "null":
 			st = ScalarNull
 		}
-		return &ScalarVal{Raw: n.Raw, Type: st}, nil
+		return &ScalarVal{Raw: n.Raw, Type: st, Separator: n.Separator}, nil
 	case *parser.ObjectNode:
 		return r.resolveObject(n, nil, pathPrefix)
 	case *parser.ArrayNode:
@@ -1069,9 +1074,7 @@ func (r *resolver) findPrior(root *ObjectVal, segments []string, pathStr string)
 
 func isSeparator(v Val) bool {
 	if s, ok := v.(*ScalarVal); ok {
-		if s.Type == ScalarString && s.Raw == " " {
-			return true
-		}
+		return s.Separator
 	}
 	return false
 }

--- a/s10_concat_lexeme_test.go
+++ b/s10_concat_lexeme_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon_test
+
+import (
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// Cross-impl regression tests for go.hocon#132 (S10.5 inner whitespace in
+// value concatenation) and go.hocon#133 (S10.11 numbers stringify "as written
+// in the source file"). Both were collapsed/canonicalized pre-fix:
+//
+//   #132 — parseValue inserted a single hardcoded " " separator, collapsing
+//          every multi-space run to one space.
+//   #133 — parseSingleValue canonicalized integer lexemes via strconv.FormatInt
+//          (`05` → "5", `00_example` → "0_example"), losing the source spelling
+//          when the value is stringified in a concat.
+
+func TestS10_5_ValueConcatWhitespace(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"unquoted multi-space", "a = foo   bar\n", "foo   bar"},
+		{"quoted multi-space", `a = "foo"   "bar"` + "\n", "foo   bar"},
+		{"single space unchanged", "a = foo bar\n", "foo bar"},
+		{"defined subst multi-space", "x = mid\na = \"left\"  ${x}  \"right\"\n", "left  mid  right"},
+		{"tab run preserved", "a = foo \t bar\n", "foo \t bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := hocon.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := cfg.GetString("a"); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestS10_5_UndefinedOptionalKeepsBothRuns pins the go.hocon#132 canonical
+// repro: env unset → the optional substitution contributes nothing, but the
+// 2 + 2 whitespace runs around it must remain (→ 4 spaces).
+func TestS10_5_UndefinedOptionalKeepsBothRuns(t *testing.T) {
+	// Deferred parse + hermetic resolve (UseSystemEnvironment=false) so the
+	// optional ${?GO132_UNSET} is undefined regardless of the host env.
+	cfg, err := hocon.ParseStringWithOptions(
+		"a = \"left\"  ${?GO132_UNSET}  \"right\"\n",
+		hocon.DefaultParseOptions().WithResolveSubstitutions(false),
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	resolved, err := cfg.Resolve(hocon.DefaultResolveOptions().WithUseSystemEnvironment(false))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got := resolved.GetString("a"); got != "left    right" {
+		t.Errorf("got %q, want %q", got, "left    right")
+	}
+}
+
+func TestS10_11_NumericLexemePreserved(t *testing.T) {
+	// version concat keeps the leading zero of `minor = 05`.
+	cfg, err := hocon.ParseString("major = 26\nminor = 05\nversion = ${major}.${minor}\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("version"); got != "26.05" {
+		t.Errorf("version: got %q, want %q", got, "26.05")
+	}
+	// standalone numeric reads semantically (05 → 5).
+	if got := cfg.GetInt64("minor"); got != 5 {
+		t.Errorf("minor GetInt64: got %d, want 5", got)
+	}
+}
+
+// TestS10_11_NumericPrefixUnquotedKeepsLexeme pins the `00_example` case from
+// go.hocon#133: the numeric prefix is lexed as TokenInt(`00`) then concatenated
+// with the unquoted `_example`; the canonicalization dropped the leading zero
+// (`0_example`). With the lexeme preserved it stays `00_example`.
+func TestS10_11_NumericPrefixUnquotedKeepsLexeme(t *testing.T) {
+	cfg, err := hocon.ParseString("name = 00_example\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("name"); got != "00_example" {
+		t.Errorf("name: got %q, want %q", got, "00_example")
+	}
+}

--- a/s8_unquoted_starts_test.go
+++ b/s8_unquoted_starts_test.go
@@ -173,32 +173,37 @@ func TestE8_ValueStartHyphenAlone_LexesAsUnquoted(t *testing.T) {
 	}
 }
 
-func TestE8_ValueStartLeadingZero_NormalizesToNumber(t *testing.T) {
-	// F3 BREAKING: `a = 01` was previously TokenInt{Value: "01"} (raw preserved
-	// by readNumber); E8 normalizes via strconv.ParseInt → TokenInt{Value: "1"}.
-	// JSON serialization is unchanged (Unmarshal already produced 1), but
-	// GetString now returns "1" (was "01") — that's the breaking surface.
+func TestE8_ValueStartLeadingZero_PreservesLexeme(t *testing.T) {
+	// `a = 01` is a digit-leading run coerced via the E8 greedy numeric path
+	// (ValueType "number"). S10.11 (go.hocon#133) refines the earlier F3
+	// decision: a numeric value stringifies "as written in the source file",
+	// so the stored Raw keeps the lexeme "01" for GetString / concat, while
+	// GetInt64 re-parses it to the canonical 1. (Earlier this asserted "1",
+	// over-canonicalizing the lexeme — the go.hocon#133 bug.)
 	cfg, err := hocon.ParseString("a = 01")
 	if err != nil {
 		t.Fatalf("E8: `a = 01` must parse, got: %v", err)
 	}
-	if got := cfg.GetString("a"); got != "1" {
-		t.Errorf("E8: expected GetString(a)=\"1\" (normalized), got %q", got)
+	if got := cfg.GetString("a"); got != "01" {
+		t.Errorf("S10.11: expected GetString(a)=\"01\" (lexeme preserved), got %q", got)
 	}
 	if got := cfg.GetInt64("a"); got != 1 {
-		t.Errorf("E8: expected GetInt64(a)=1, got %d", got)
+		t.Errorf("E8: expected GetInt64(a)=1 (semantic value canonical), got %d", got)
 	}
 }
 
-func TestE8_ValueStartNegativeZero_NormalizesToZero(t *testing.T) {
-	// `-0` parses as int 0; canonical form drops the sign (no negative zero in
-	// integer arithmetic). Lightbend's parseLong does the same.
+func TestE8_ValueStartNegativeZero_PreservesLexeme(t *testing.T) {
+	// `-0` reads as int 0 (no negative zero in integer arithmetic), but its
+	// source lexeme "-0" is preserved in Raw for S10.11 stringification.
 	cfg, err := hocon.ParseString("a = -0")
 	if err != nil {
 		t.Fatalf("E8: `a = -0` must parse, got: %v", err)
 	}
-	if got := cfg.GetString("a"); got != "0" {
-		t.Errorf("E8: expected GetString(a)=\"0\" (canonicalized), got %q", got)
+	if got := cfg.GetString("a"); got != "-0" {
+		t.Errorf("S10.11: expected GetString(a)=\"-0\" (lexeme preserved), got %q", got)
+	}
+	if got := cfg.GetInt64("a"); got != 0 {
+		t.Errorf("E8: expected GetInt64(a)=0 (semantic value canonical), got %d", got)
 	}
 }
 

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -202,45 +202,27 @@ func TestSpec_S10_12_SingleValuePreservesType(t *testing.T) {
 
 // ── S10.15: quoted whitespace between obj/array substitutions is an error ─────
 
-// TestSpec_S10_15_QuotedWSBetweenArraySubsts_Pin pins current behaviour:
-// quoted whitespace between two array substitutions is silently accepted and
-// the arrays are merged. Spec HOCON.md L442 requires this to be an error.
-func TestSpec_S10_15_QuotedWSBetweenArraySubsts_Pin(t *testing.T) {
-	// pin: see #83 — quoted " " between two array substs produces merged array [1,2]
-	// Tight pin: assert the precise length and contents so the test reliably
-	// detects behavior changes (e.g. if the impl starts erroring as the spec
-	// requires, or if the merge logic changes the output shape).
-	_ = specIssueS10_15_QuotedWS
-	cfg := mustParseCfg(t, `
-a = [1]
-b = [2]
-c = ${a} " " ${b}
-`)
-	got, ok := cfg.GetInt64SliceOption("c").Get()
-	if !ok {
-		t.Fatal("[pin] expected Some (current impl merges arrays), got None")
-	}
-	want := []int64{1, 2}
-	if len(got) != len(want) {
-		t.Fatalf("[pin] expected merged array length %d, got %d (%v)", len(want), len(got), got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("[pin] expected got[%d]=%d, got %d", i, want[i], got[i])
-		}
-	}
-}
-
-// TestSpec_S10_15_QuotedWSBetweenArraySubsts_Spec is the spec-correct assertion.
+// TestSpec_S10_15_QuotedWSBetweenArraySubsts_Spec is the spec-correct assertion
+// (HOCON.md L442): a quoted whitespace string `" "` between two array
+// substitutions is a real string operand, not an ignorable separator, so
+// `${a} " " ${b}` is array + string + array — a type error per S10.13.
+//
+// Closed by go.hocon#132 as a side effect: the S10.5 value-concat whitespace
+// fix replaced isSeparator's content-based detection (`Raw == " "`, which
+// wrongly classified a *quoted* " " as a parser separator and stripped it,
+// silently merging the arrays) with a parser-set Separator flag. A quoted
+// " " now correctly carries Separator=false and is not stripped, so the
+// array+string concat raises the type error the spec requires. The old _Pin
+// test that documented the merged-array bug was removed. See #83.
 func TestSpec_S10_15_QuotedWSBetweenArraySubsts_Spec(t *testing.T) {
-	t.Skipf("[skip] spec violation per S10.15 — quoted ws between array substs should error; see #%d", specIssueS10_15_QuotedWS)
+	_ = specIssueS10_15_QuotedWS
 	_, err := hocon.ParseString(`
 a = [1]
 b = [2]
 c = ${a} " " ${b}
 `)
 	if err == nil {
-		t.Error("expected error: quoted whitespace between array substitutions must be rejected")
+		t.Error("expected error: quoted whitespace between array substitutions must be rejected (S10.15 / HOCON.md L442)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two string-concat spec fixes from the #131–#135 audit, plus an incidental S10.15 fix, cutting the coordinated v1.6.0 release.

- **#132 (S10.5)** — preserve literal whitespace runs in value concatenation. `parseValue` collapsed every multi-space run to a single `" "` separator; now carries `Token.PrecedingWhitespace` (the E13 lexer field). `"left"  ${?UNSET}  "right"` → `"left    right"` (was `"left  right"`). To keep separator identity while preserving the literal run, `ScalarNode` / `ScalarVal` gain a `Separator bool` flag and `isSeparator` reads it instead of matching `Raw == " "`.
- **#133 (S10.11)** — numbers stringify "as written in the source file". `parseSingleValue` canonicalized integer lexemes via `strconv.FormatInt` (`05` → `"5"`, `00_example` → `"0_example"`); `ScalarNode.Raw` now keeps the lexeme so `version = ${major}.${minor}` (`minor = 05`) → `"26.05"`. `GetInt64` etc. re-parse `Raw`, so standalone numeric semantics are unchanged (`05` reads as 5). Refines the earlier E8/F3 over-canonicalization; 2 E8 tests + the octal-like `GetString` test updated.
- **#83 (S10.15, incidental)** — `${a} " " ${b}` (quoted whitespace between array substitutions) now raises the spec-required type error (HOCON.md L442) instead of silently merging. The old `isSeparator` matched `Raw == " "` and wrongly stripped a *quoted* `" "`; the explicit `Separator` flag fixes it. `_Pin` test removed, `_Spec` un-skipped.

## Scope notes

- **#134** (`+=` across includes) and the **go-only #131 / #135 (Critical)** are deferred to follow-ups. #134 needs the multi-agent-review treatment the chained-self-ref machinery already required; #135 is a Critical include-child eager-vs-deferred resolution change in the same family as #128.
- Cross-impl: #132 landed in rs.hocon (PR #130) and ts.hocon (PR #140) for the same v1.6.0; #133 landed in rs.hocon (ts.hocon already preserved the lexeme).

## Version

This release cuts **v1.6.0** to align all three impls. go.hocon has no version file — the tag is the version.

## Test plan

- [x] New regression tests (`s10_concat_lexeme_test.go`: 4 sub-tests + 3 funcs)
- [x] full suite `go test ./...` — all green
- [x] `gofmt` clean, `golangci-lint run ./...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)