### PR TITLE
release(v1.6.1): #134 += include accumulation + #131 null-fallback Unmarshal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.1] - 2026-05-29
+
+Bugfix release: S13b.2 `+=` accumulation across includes ([#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0 — plus an `Unmarshal`-into-map explicit-null preservation fix ([#131](https://github.com/o3co/go.hocon/issues/131)) from the go.hocon#131–#135 audit. No public API changes; safe drop-in upgrade from v1.6.0. (The remaining go-only audit item — [#135](https://github.com/o3co/go.hocon/issues/135), defer substitution resolution across includes — is a Critical include-child eager-vs-deferred resolution change in the same family as #128 and stays deferred to a follow-up.)
 
 ### Fixed — S13b.2 `+=` accumulation across includes ([#134](https://github.com/o3co/go.hocon/issues/134))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.6.1] - 2026-05-29
 
 Bugfix release: S13b.2 `+=` accumulation across includes ([#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0 — plus an `Unmarshal`-into-map explicit-null preservation fix ([#131](https://github.com/o3co/go.hocon/issues/131)) from the go.hocon#131–#135 audit. No public API changes; safe drop-in upgrade from v1.6.0. (The remaining go-only audit item — [#135](https://github.com/o3co/go.hocon/issues/135), defer substitution resolution across includes — is a Critical include-child eager-vs-deferred resolution change in the same family as #128 and stays deferred to a follow-up.)


### PR DESCRIPTION
## Summary

Release-prep for **v1.6.1** (go.hocon). Promotes the `[Unreleased]` CHANGELOG section to `## [1.6.1] - 2026-05-29`.

Bugfix release, no public API changes — safe drop-in from v1.6.0:
- **#134** — S13b.2 `+=` accumulation across includes (the follow-up deferred from v1.6.0).
- **#131** — explicit `null` fallback keys preserved when unmarshalling into `map[string]any`.

The remaining go-only audit item (#135 — defer substitution resolution across includes) stays deferred to a follow-up (Critical, #128-family architectural change).

## Release flow

After merge to develop, `v1.6.1` is tagged on the merged develop tip; `release.yml` (push tag `v*`) triggers the Go module proxy fetch + GitHub Release (body extracted from the `[1.6.1]` CHANGELOG section). No version file to bump (tag is the version).

## Test plan

- [x] CHANGELOG-only change; full suite already green on develop (#134 + #131 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)