### PR TITLE
docs(spec-compliance): S17.7/S17.8 by-design (#72 closed, #142 filed)

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -977,8 +977,11 @@ func TestConfig_DelayedMergeNestedSubstitution(t *testing.T) {
 
 // ── Spec compliance Phase 4: S15, S17.5, S17.7, S17.8, S21.4, S21.5 ──────────────
 
-// specIssueS17_7_8 is the GitHub issue number for the S17.7/S17.8 spec violation.
-// Option accessors return None instead of an error for object/array type mismatches.
+// specIssueS17_7_8 is the GitHub issue that adjudicated S17.7/S17.8 for the
+// Option accessors: returning None on an object/array type mismatch is by-design
+// (a soft try-get, matching rs.hocon's get_string_option = get_string().ok());
+// the spec's "conversion is an error" is satisfied by the panic accessors.
+// #72 closed by-design; the additive non-panic (T, error) accessor is #142.
 const specIssueS17_7_8 = 72
 
 // TestSpec_S15_1_NumericObjectToArray verifies that an object with integer keys
@@ -1130,11 +1133,12 @@ func TestSpec_S17_7_ObjectToOtherTypePanics(t *testing.T) {
 }
 
 // TestSpec_S17_7_ObjectToOtherTypeOptionReturnsNone documents that Option accessors
-// return None (not an error) for object→scalar mismatches — a partial violation of
-// HOCON spec L1254 (should be an error, not silently absent).
-// pin: see #72
+// return None for object→scalar mismatches. This is by-design (HOCON spec L1254):
+// the spec requires the *conversion* to be an error, which the panic accessors
+// satisfy; the Option family is a soft try-get that collapses absence and failed
+// conversion into None, matching rs.hocon's get_string_option (= get_string().ok()).
+// pin: see #72 (closed by-design); non-panic (T, error) accessor tracked in #142.
 func TestSpec_S17_7_ObjectToOtherTypeOptionReturnsNone(t *testing.T) {
-	// pin: see #72 — Option accessors should return an error, not None
 	_ = specIssueS17_7_8
 	cfg := mustParseCfg(t, `obj: {a: 1}`)
 	if cfg.GetStringOption("obj").IsSome() {
@@ -1161,11 +1165,11 @@ func TestSpec_S17_8_ArrayToOtherTypePanics(t *testing.T) {
 }
 
 // TestSpec_S17_8_ArrayToOtherTypeOptionReturnsNone documents that Option accessors
-// return None (not an error) for array→scalar mismatches — a partial violation of
-// HOCON spec L1255 (should be an error, not silently absent).
-// pin: see #72
+// return None for array→scalar mismatches. By-design (HOCON spec L1255): the panic
+// accessors satisfy the spec's "conversion is an error"; the Option family is a soft
+// try-get returning None, matching rs.hocon's get_*_option (= get_*().ok()).
+// pin: see #72 (closed by-design); non-panic (T, error) accessor tracked in #142.
 func TestSpec_S17_8_ArrayToOtherTypeOptionReturnsNone(t *testing.T) {
-	// pin: see #72 — Option accessors should return an error, not None
 	cfg := mustParseCfg(t, `arr: [1,2,3]`)
 	if cfg.GetStringOption("arr").IsSome() {
 		t.Error("GetStringOption(array) should not return Some — expected None (pinned current behaviour)")

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -781,13 +781,13 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 
 - **S17.7** object → other type: error — §Automatic type conversions (L1254)
   tests: config_test.go (TestSpec_S17_7_ObjectToOtherTypePanics); config_test.go (TestSpec_S17_7_ObjectToOtherTypeOptionReturnsNone)
-  status: ⚠️
-  note: non-Option accessors panic (conformant). Option accessors return None instead of an error, indistinguishable from a missing key — partial violation; see issue #72.
+  status: ✅
+  note: non-Option accessors panic on the conversion (= error, conformant). Option accessors return None on a type mismatch by design — a soft "try-get" that collapses absence and failed conversion into None, matching rs.hocon's `get_string_option` (= `get_string().ok()`). This is not a violation: the spec requires the *conversion* to be an error, which the panic accessor satisfies. ([#72](https://github.com/o3co/go.hocon/issues/72), closed by-design.) A non-panic `(T, error)` accessor — the one API shape go currently lacks vs Lightbend/ts (throw) and rs (`Result`) — is tracked additively in [#142](https://github.com/o3co/go.hocon/issues/142).
 
 - **S17.8** array → other (except numeric-indexed): error — §Automatic type conversions (L1255)
   tests: config_test.go (TestSpec_S17_8_ArrayToOtherTypePanics); config_test.go (TestSpec_S17_8_ArrayToOtherTypeOptionReturnsNone)
-  status: ⚠️
-  note: non-Option accessors panic (conformant). Option accessors return None instead of an error, indistinguishable from a missing key — partial violation; see issue #72.
+  status: ✅
+  note: same as S17.7 — non-Option accessors panic (conformant); Option accessors return None on a type mismatch by design (soft try-get, matches rs.hocon). ([#72](https://github.com/o3co/go.hocon/issues/72) by-design; non-panic `(T, error)` accessor tracked in [#142](https://github.com/o3co/go.hocon/issues/142).)
 
 ## S18. Units format
 


### PR DESCRIPTION
## Summary

Marks S17.7/S17.8 ⚠️→✅ in `docs/spec-compliance.md` after closing #72 as by-design.

A cross-impl check disproved #72's premise that `GetStringOption` returning `None` on an object/array→scalar type mismatch is a spec violation:

- rs.hocon's `get_string_option` is literally `get_string().ok()` → returns `None` on mismatch. go matches the parity reference **exactly**.
- Lightbend (Java) / ts.hocon have **no** soft accessor — `getString` throws on mismatch.
- The spec's "object/array → other is an error" (S17.7/S17.8) is already satisfied by go's `GetString` (panic).

So the `Option` family is a soft "try-get" by design (absence + failed conversion → `None`), consistent with rs. The genuine, additive gap — go lacks a non-panic `(T, error)` accessor that Lightbend/ts (throw) and rs (`Result`) all have — is tracked in #142.

Docs-only; no code change.

## Test plan
- [x] No code changed; `OptionReturnsNone` tests correctly pin the now-confirmed behavior and remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)