### PR TITLE
release(v1.7.1): cross-impl coordinated patch (parity sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-06-14
+
+Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolves the same self-ref-below-merge shapes as of v1.7.0 (its #135 defer-substitution-resolution work), so this release carries no go-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). A cross-impl audit added [#148](https://github.com/o3co/go.hocon/pull/148) — test-only regression pins for that resolved behavior ([#147](https://github.com/o3co/go.hocon/issues/147)). No public API changes; safe drop-in upgrade from v1.7.0.
+
 ## [1.7.0] - 2026-05-30
 
 Cross-impl release coordinated to land at v1.7.0 across go.hocon / ts.hocon / rs.hocon. Drives the version bump: a new public-API surface — the error-returning `(T, error)` accessor family `GetXxxE` ([#142](https://github.com/o3co/go.hocon/issues/142)) — that completes the accessor triad alongside the existing panic-getters and Option-getters, bringing go.hocon's surface in line with rs.hocon's `Result`-primary API. Also closes the last open item of the go.hocon#131–#135 audit ([#135](https://github.com/o3co/go.hocon/issues/135) — defer substitution resolution across includes, the Critical Lightbend-parity fix in the #128 family) and the cross-impl leading-zero JSON-render validity fix ([xx.hocon#50](https://github.com/o3co/xx.hocon/issues/50)) shipped byte-aligned with ts.hocon v1.7.0. No breaking changes; safe drop-in upgrade from v1.6.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.1] - 2026-06-14
 
-Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolves the same self-ref-below-merge shapes as of v1.7.0 (its #135 defer-substitution-resolution work), so this release carries no go-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). A cross-impl audit added [#148](https://github.com/o3co/go.hocon/pull/148) — test-only regression pins for that resolved behavior ([#147](https://github.com/o3co/go.hocon/issues/147)). No public API changes; safe drop-in upgrade from v1.7.0.
+Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolves the same self-ref-below-merge shapes as of v1.7.0 (its [#135](https://github.com/o3co/go.hocon/pull/135) defer-substitution-resolution work), so this release carries no go-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). A cross-impl audit added [#148](https://github.com/o3co/go.hocon/pull/148) — test-only regression pins for that resolved behavior ([#147](https://github.com/o3co/go.hocon/issues/147)). No public API changes; safe drop-in upgrade from v1.7.0.
 
 ## [1.7.0] - 2026-05-30
 


### PR DESCRIPTION
## Summary

Release-prep for **v1.7.1** (cross-impl coordinated patch across go.hocon / ts.hocon / rs.hocon).

**No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolved the same self-ref-below-merge shapes at v1.7.0 (#135 defer-substitution-resolution). This release exists for cross-impl version parity (precedent: v1.7.0 sync). #148 added test-only regression pins (#147).

No version file (tag is the version); just finalizes `[Unreleased]` → `[1.7.1] - 2026-06-14`.

After merge: tag `v1.7.1` on develop HEAD → release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)