### PR TITLE
feat(unmarshal): UnmarshalPath + int-coercion parity with rs.hocon (1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Config.UnmarshalPath(path string, v any) error` — unmarshal the value at a
+  path into `v`, accepting **any** node (object, array, or scalar), e.g.
+  `UnmarshalPath("servers", &[]Server{})`. Unlike `GetConfig(path).Unmarshal`
+  (objects only) it returns an error (matching `Unmarshal`'s idiom, not the
+  panicking getters): missing path, an unresolved substitution at/under `path`
+  (the error wraps `ErrNotResolved`, detectable via `errors.Is`), or an
+  unmarshal failure.
+- `Unmarshal` / `UnmarshalPath` now support `any` (`interface{}`) targets,
+  decoding a node into the natural Go value (`map[string]any` / `[]any` /
+  `string` / `float64` / `bool` / `nil`).
+
+### Changed
+
+- Integer unmarshalling is now consistent with the typed getters and with
+  rs.hocon: a whole-number float/exponent (including quoted, e.g. `"1e3"`,
+  `1.0`) coerces, but a **non-whole** float such as `1.5` is now **rejected**
+  instead of silently truncated to `1`, and integer targets are overflow-checked
+  (`int8`/`int16`/`int32` no longer silently wrap).
+- A numeric-keyed object (`{ "0" = …, "1" = … }`) now unmarshals into a slice
+  target, matching the typed slice getters and rs.hocon sequence deserialization.
+
+Value introspection in Go remains served by the existing typed getters
+(`GetString` / `GetInt64` / …); rs.hocon's `HoconValue` accessors have no Go
+equivalent by design (Go exposes no public value handle).
+
 ## [1.7.1] - 2026-06-14
 
 Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolves the same self-ref-below-merge shapes as of v1.7.0 (its [#135](https://github.com/o3co/go.hocon/pull/135) defer-substitution-resolution work), so this release carries no go-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). A cross-impl audit added [#148](https://github.com/o3co/go.hocon/pull/148) — test-only regression pins for that resolved behavior ([#147](https://github.com/o3co/go.hocon/issues/147)). No public API changes; safe drop-in upgrade from v1.7.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unmarshal failure.
 - `Unmarshal` / `UnmarshalPath` now support `any` (`interface{}`) targets,
   decoding a node into the natural Go value (`map[string]any` / `[]any` /
-  `string` / `float64` / `bool` / `nil`).
+  `string` / `int64` for integer-shaped numbers or `float64` otherwise / `bool`
+  / `nil`).
 
 ### Changed
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -89,11 +89,9 @@ func unmarshalVal(val resolver.Val, target reflect.Value) error {
 			target.Set(reflect.Zero(target.Type()))
 			return nil
 		}
-		av := reflect.ValueOf(a)
-		if !av.Type().AssignableTo(target.Type()) {
-			return fmt.Errorf("hocon: cannot assign %T to %s", a, target.Type())
-		}
-		target.Set(av)
+		// target is the empty interface here (non-empty rejected above), so any
+		// concrete value from valToAny is assignable.
+		target.Set(reflect.ValueOf(a))
 		return nil
 	default:
 		return unmarshalScalar(val, target)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -42,6 +42,9 @@ func (c *Config) UnmarshalPath(path string, v any) error {
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return fmt.Errorf("hocon: UnmarshalPath requires a non-nil pointer")
 	}
+	if path == "" {
+		return fmt.Errorf("hocon: UnmarshalPath requires a non-empty path")
+	}
 	node, ok := lookupSegments(c.root, splitPath(path))
 	if !ok {
 		return fmt.Errorf("hocon: path %q: key not found", path)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -10,6 +10,7 @@ package hocon
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -26,6 +27,29 @@ func (c *Config) Unmarshal(v any) error {
 		return fmt.Errorf("hocon: Unmarshal requires a non-nil pointer")
 	}
 	return unmarshalVal(c.root, rv.Elem())
+}
+
+// UnmarshalPath maps the value at path into v using `hocon` struct tags.
+// v must be a non-nil pointer. Unlike GetConfig(path).Unmarshal (which accepts
+// only objects), path may reference any node — object, array, or scalar — so
+// e.g. UnmarshalPath("servers", &[]Server{}) deserializes a list directly.
+//
+// Returns an error if the path is missing, if the value (or any nested value)
+// is an unresolved substitution (the error wraps ErrNotResolved, detectable via
+// errors.Is), or if the value cannot be unmarshalled into v.
+func (c *Config) UnmarshalPath(path string, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("hocon: UnmarshalPath requires a non-nil pointer")
+	}
+	node, ok := lookupSegments(c.root, splitPath(path))
+	if !ok {
+		return fmt.Errorf("hocon: path %q: key not found", path)
+	}
+	if !c.resolved && isUnresolvedPlaceholder(node) {
+		return fmt.Errorf("hocon: path %q is not resolved: %w", path, ErrNotResolved)
+	}
+	return unmarshalVal(node, rv.Elem())
 }
 
 func unmarshalVal(val resolver.Val, target reflect.Value) error {
@@ -50,6 +74,27 @@ func unmarshalVal(val resolver.Val, target reflect.Value) error {
 		return unmarshalMap(val, target)
 	case reflect.Slice:
 		return unmarshalSlice(val, target)
+	case reflect.Interface:
+		// Generic target (`any`): decode the node into the natural Go value
+		// (map[string]any / []any / string / float64 / bool / nil). Only the
+		// empty interface is supported; a non-empty interface (e.g. error,
+		// fmt.Stringer) can't hold an arbitrary decoded value.
+		if target.NumMethod() != 0 {
+			return fmt.Errorf("hocon: cannot unmarshal into non-empty interface %s", target.Type())
+		}
+		a := valToAny(val)
+		if a == nil {
+			// null / nil node → reset the interface to its typed zero (nil),
+			// so an explicit null overwrites any pre-populated value.
+			target.Set(reflect.Zero(target.Type()))
+			return nil
+		}
+		av := reflect.ValueOf(a)
+		if !av.Type().AssignableTo(target.Type()) {
+			return fmt.Errorf("hocon: cannot assign %T to %s", a, target.Type())
+		}
+		target.Set(av)
+		return nil
 	default:
 		return unmarshalScalar(val, target)
 	}
@@ -211,7 +256,17 @@ func valToAny(v resolver.Val) any {
 func unmarshalSlice(val resolver.Val, target reflect.Value) error {
 	arr, ok := val.(*resolver.ArrayVal)
 	if !ok {
-		return fmt.Errorf("hocon: expected array for slice, got %T", val)
+		// S15 parity: a numeric-keyed object converts to an array in slice
+		// context (matching the typed slice getters and rs serde sequences).
+		if obj, isObj := val.(*resolver.ObjectVal); isObj {
+			if converted, convOK := resolver.NumericObjectToArray(obj); convOK {
+				arr = converted
+			} else {
+				return fmt.Errorf("hocon: expected array for slice, got %T", val)
+			}
+		} else {
+			return fmt.Errorf("hocon: expected array for slice, got %T", val)
+		}
 	}
 	elemType := target.Type().Elem()
 	slice := reflect.MakeSlice(target.Type(), len(arr.Elements), len(arr.Elements))
@@ -249,16 +304,23 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 	case reflect.String:
 		target.SetString(sv.Raw)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		parsed, err := strconv.ParseInt(sv.Raw, 10, 64)
+		n, err := strconv.ParseInt(sv.Raw, 10, 64)
 		if err != nil {
-			// Try parsing as float and truncating (e.g. "3.0" → 3)
-			if f, ferr := strconv.ParseFloat(sv.Raw, 64); ferr == nil {
-				target.SetInt(int64(f))
-				return nil
+			// Whole-number float/exponent fallback, matching rs.hocon's get_i64:
+			// only for float-like raw, finite, integral, and within int64 range.
+			// A non-whole value such as "1.5" is rejected, not truncated.
+			f, ferr := strconv.ParseFloat(sv.Raw, 64)
+			if ferr != nil || !strings.ContainsAny(sv.Raw, ".eE") ||
+				math.IsInf(f, 0) || f != math.Trunc(f) ||
+				f < math.MinInt64 || f >= math.MaxInt64 {
+				return fmt.Errorf("hocon: expected int, got %q", sv.Raw)
 			}
-			return fmt.Errorf("hocon: expected int, got %q", sv.Raw)
+			n = int64(f)
 		}
-		target.SetInt(parsed)
+		if target.OverflowInt(n) {
+			return fmt.Errorf("hocon: int %d overflows %s", n, target.Type())
+		}
+		target.SetInt(n)
 	case reflect.Float32, reflect.Float64:
 		parsed, err := strconv.ParseFloat(sv.Raw, 64)
 		if err != nil {

--- a/unmarshal_path_test.go
+++ b/unmarshal_path_test.go
@@ -125,6 +125,24 @@ func TestUnmarshalPath_NullAnyResetsToNil(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPath_NonNumericObjectToSlice_Errors(t *testing.T) {
+	// A non-numeric-keyed object is not convertible to an array.
+	cfg := mustParseCfg(t, `m { foo = "a", bar = "b" }`)
+	var v []string
+	if err := cfg.UnmarshalPath("m", &v); err == nil {
+		t.Error("non-numeric object -> slice must error")
+	}
+}
+
+func TestUnmarshalPath_ScalarToSlice_Errors(t *testing.T) {
+	// A scalar (neither array nor object) is not a slice.
+	cfg := mustParseCfg(t, `n = 5`)
+	var v []int
+	if err := cfg.UnmarshalPath("n", &v); err == nil {
+		t.Error("scalar -> slice must error")
+	}
+}
+
 func TestUnmarshal_IntCoercion_NonWholeRejected(t *testing.T) {
 	cfg := mustParseCfg(t, `n = 1.5`)
 	var s struct {

--- a/unmarshal_path_test.go
+++ b/unmarshal_path_test.go
@@ -76,6 +76,14 @@ func TestUnmarshalPath_NestedUnresolved(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPath_EmptyPath_Errors(t *testing.T) {
+	cfg := mustParseCfg(t, `a = 1`)
+	var n int
+	if err := cfg.UnmarshalPath("", &n); err == nil {
+		t.Error("empty path must error")
+	}
+}
+
 func TestUnmarshalPath_NonPointer(t *testing.T) {
 	cfg := mustParseCfg(t, `port = 1`)
 	var n int

--- a/unmarshal_path_test.go
+++ b/unmarshal_path_test.go
@@ -1,0 +1,181 @@
+package hocon_test
+
+// go.hocon 1.8 — UnmarshalPath (any node at a path) + int-coercion parity with
+// rs.hocon (whole-number-only float truncation, overflow-checked) + any-target
+// and numeric-object->slice support.
+
+import (
+	"errors"
+	"testing"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+func mustParseUnresolved(t *testing.T, src string) *hocon.Config {
+	t.Helper()
+	cfg, err := hocon.ParseStringWithOptions(src, hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	if err != nil {
+		t.Fatalf("parse(unresolved) error: %v", err)
+	}
+	return cfg
+}
+
+func TestUnmarshalPath_ObjectSubtree(t *testing.T) {
+	cfg := mustParseCfg(t, `server { host="h", port=1 }`)
+	var s ServerCfg
+	if err := cfg.UnmarshalPath("server", &s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.Host != "h" || s.Port != 1 {
+		t.Errorf("got %+v", s)
+	}
+}
+
+func TestUnmarshalPath_ListAtPath(t *testing.T) {
+	cfg := mustParseCfg(t, `ports = [1, 2, 3]`)
+	var v []int
+	if err := cfg.UnmarshalPath("ports", &v); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(v) != 3 || v[0] != 1 || v[2] != 3 {
+		t.Errorf("got %v", v)
+	}
+}
+
+func TestUnmarshalPath_ScalarAtPath(t *testing.T) {
+	cfg := mustParseCfg(t, `port = 8080`)
+	var n int
+	if err := cfg.UnmarshalPath("port", &n); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if n != 8080 {
+		t.Errorf("got %d", n)
+	}
+}
+
+func TestUnmarshalPath_Missing(t *testing.T) {
+	cfg := mustParseCfg(t, `a = 1`)
+	var n int
+	err := cfg.UnmarshalPath("nope", &n)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+	if errors.Is(err, hocon.ErrNotResolved) {
+		t.Error("missing path must not be classified as not-resolved")
+	}
+}
+
+func TestUnmarshalPath_NestedUnresolved(t *testing.T) {
+	cfg := mustParseUnresolved(t, `obj { x = ${b} }`)
+	var s struct {
+		X int `hocon:"x"`
+	}
+	err := cfg.UnmarshalPath("obj", &s)
+	if !errors.Is(err, hocon.ErrNotResolved) {
+		t.Errorf("nested placeholder must wrap ErrNotResolved, got %v", err)
+	}
+}
+
+func TestUnmarshalPath_NonPointer(t *testing.T) {
+	cfg := mustParseCfg(t, `port = 1`)
+	var n int
+	if err := cfg.UnmarshalPath("port", n); err == nil {
+		t.Error("non-pointer target must error, not panic")
+	}
+}
+
+func TestUnmarshalPath_AnyTarget(t *testing.T) {
+	cfg := mustParseCfg(t, `obj { a = 1 }`)
+	var x any
+	if err := cfg.UnmarshalPath("obj", &x); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := x.(map[string]any); !ok {
+		t.Fatalf("expected map[string]any, got %T", x)
+	}
+}
+
+func TestUnmarshalPath_NumericObjectToSlice(t *testing.T) {
+	cfg := mustParseCfg(t, `items { "0" = "a", "1" = "b" }`)
+	var v []string
+	if err := cfg.UnmarshalPath("items", &v); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(v) != 2 || v[0] != "a" || v[1] != "b" {
+		t.Errorf("got %v", v)
+	}
+}
+
+func TestUnmarshalPath_NonEmptyInterface_Errors(t *testing.T) {
+	cfg := mustParseCfg(t, `s = "x"`)
+	var e error // non-empty interface — a scalar is not assignable to it
+	if err := cfg.UnmarshalPath("s", &e); err == nil {
+		t.Error("non-empty interface target must return an error, not panic")
+	}
+}
+
+func TestUnmarshalPath_NullAnyResetsToNil(t *testing.T) {
+	cfg := mustParseCfg(t, `x = null`)
+	var v any = "preset"
+	if err := cfg.UnmarshalPath("x", &v); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if v != nil {
+		t.Errorf("null must reset an any target to nil, got %v", v)
+	}
+}
+
+func TestUnmarshal_IntCoercion_NonWholeRejected(t *testing.T) {
+	cfg := mustParseCfg(t, `n = 1.5`)
+	var s struct {
+		N int `hocon:"n"`
+	}
+	if err := cfg.Unmarshal(&s); err == nil {
+		t.Error("1.5 -> int must error (whole-number-only truncation), not silently become 1")
+	}
+}
+
+func TestUnmarshal_IntCoercion_WholeAndQuoted(t *testing.T) {
+	cfg := mustParseCfg(t, "a = 1.0\nb = 1e3\nc = \"1e3\"")
+	var s struct {
+		A int `hocon:"a"`
+		B int `hocon:"b"`
+		C int `hocon:"c"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.A != 1 || s.B != 1000 || s.C != 1000 {
+		t.Errorf("got %+v", s)
+	}
+}
+
+func TestUnmarshal_IntCoercion_NonWholeRejected_Nested(t *testing.T) {
+	// The strict coercion flows through unmarshalScalar for nested fields and
+	// slice elements too, not just top-level fields.
+	cfg := mustParseCfg(t, "obj { n = 1.5 }\nxs = [1, 2.5]")
+	var s1 struct {
+		Obj struct {
+			N int `hocon:"n"`
+		} `hocon:"obj"`
+	}
+	if err := cfg.Unmarshal(&s1); err == nil {
+		t.Error("nested 1.5 -> int must error")
+	}
+	var s2 struct {
+		Xs []int `hocon:"xs"`
+	}
+	if err := cfg.Unmarshal(&s2); err == nil {
+		t.Error("slice element 2.5 -> int must error")
+	}
+}
+
+func TestUnmarshal_IntOverflow_Rejected(t *testing.T) {
+	cfg := mustParseCfg(t, `n = 100000`)
+	var s struct {
+		N int8 `hocon:"n"`
+	}
+	if err := cfg.Unmarshal(&s); err == nil {
+		t.Error("100000 -> int8 must error (overflow), not silently wrap")
+	}
+}


### PR DESCRIPTION
## Summary

go.hocon 1.8 — cross-impl port of rs.hocon 1.8 **"value → type for any node"** ([o3co/rs.hocon#140](https://github.com/o3co/rs.hocon/pull/140), merged). Additive MINOR plus one intentional behavior change.

## Changes

- **`Config.UnmarshalPath(path string, v any) error`** — unmarshal the value at a path into `v`, accepting **any** node (object/array/scalar), e.g. `UnmarshalPath("servers", &[]Server{})`. Unlike `GetConfig(path).Unmarshal` (objects only) it returns an error (matching `Unmarshal`'s idiom, not the panicking getters): missing path; an unresolved substitution at/under `path` (error wraps `ErrNotResolved`, detectable via `errors.Is`); or an unmarshal failure.
- **`any` targets** — `Unmarshal`/`UnmarshalPath` decode a node into the natural Go value (`map[string]any` / `[]any` / `string` / `float64` / `bool` / `nil`). Empty interface only (non-empty interface → error; `null` resets to nil).
- **numeric-keyed object → slice** — `{ "0" = …, "1" = … }` now unmarshals into a slice target (S15 parity with the typed slice getters and rs serde sequences).

## Changed (behavior)

- **Integer coercion** now matches the typed getters and rs.hocon: a whole-number float/exponent (incl. quoted `"1e3"`, `1.0`) coerces, but a **non-whole** float such as `1.5` is now **rejected** instead of silently truncated to `1`, and integer targets are overflow-checked (`int8`/`int16`/`int32` no longer silently wrap).

## Design note

Value introspection in Go is served by the existing typed getters (`GetString`/`GetInt64`/…); rs.hocon's `HoconValue` accessors have no Go equivalent by design (no public value handle). Decided via cross-impl design review.

## Tests

13 new tests (`unmarshal_path_test.go`): object/list/scalar at path, missing (asserts *not* not-resolved), nested-unresolved, non-pointer, any-target, non-empty-interface error, null→any reset, numeric-object→slice, non-whole reject (top-level + nested + slice element), whole/quoted coerce, overflow reject. `gofmt`/`go vet` clean.

## Review

Multi-agent review (Claude + Codex). Codex found two P2s: (1) interface-target panic / null-not-reset — **fixed** (TDD); (2) non-whole float ≥2^53 precision hole — a **shared** rs+go edge (identical algorithm); fixing it in go alone would break parity, so tracked cross-impl in [xx.hocon#56](https://github.com/o3co/xx.hocon/issues/56).

## Note

Pre-existing `TestS13c_SuccessFixtures/ev12c` fails locally due to un-synced testdata (`make testdata`), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)