### PR TITLE
fix(unmarshal): derive int wholeness from raw text, not float64 (xx.hocon#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ Value introspection in Go remains served by the existing typed getters
 (`GetString` / `GetInt64` / …); rs.hocon's `HoconValue` accessors have no Go
 equivalent by design (Go exposes no public value handle).
 
+### Fixed — integer coercion precision hole for float-like literals ≥ 2^52 ([xx.hocon#56](https://github.com/o3co/xx.hocon/issues/56))
+
+- **Float-like integer unmarshalling now derives wholeness and the integer value
+  from the raw decimal text instead of an intermediate `float64`.** The previous
+  `f != math.Trunc(f)` check was unsound at high magnitudes: above 2^52 a
+  `float64` cannot represent fractional parts, so a non-whole literal like
+  `9007199254740992.5` rounded to a whole `float64` and was wrongly accepted, and
+  a would-be-whole literal like `9007199254740993.0` rounded to the wrong integer
+  (silent off-by-one). The text-based `wholeFloatToInt64` helper rejects genuinely
+  non-whole values at any magnitude and yields the exact integer for whole ones
+  (including `int64` boundaries and large whole literals such as `1e16`), with a
+  guard so a huge exponent cannot trigger an unbounded allocation. Byte-identical
+  to rs.hocon's `whole_float_to_i64`. ts.hocon is unaffected (no integer
+  coercion). Pinned by `issue56_i64_coercion_test.go`.
+
 ## [1.7.1] - 2026-06-14
 
 Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in go.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); go.hocon already resolves the same self-ref-below-merge shapes as of v1.7.0 (its [#135](https://github.com/o3co/go.hocon/pull/135) defer-substitution-resolution work), so this release carries no go-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). A cross-impl audit added [#148](https://github.com/o3co/go.hocon/pull/148) — test-only regression pins for that resolved behavior ([#147](https://github.com/o3co/go.hocon/issues/147)). No public API changes; safe drop-in upgrade from v1.7.0.

--- a/issue56_i64_coercion_test.go
+++ b/issue56_i64_coercion_test.go
@@ -1,0 +1,158 @@
+package hocon_test
+
+import (
+	"math"
+	"testing"
+)
+
+// xx.hocon#56: integer coercion of a float-like scalar must derive wholeness
+// from the raw decimal text, not from an intermediate float64. Above 2^52 a
+// float64 cannot represent fractional parts, so the previous
+// `f != math.Trunc(f)` check both (a) false-accepted non-whole values and
+// (b) off-by-one'd would-be-whole values. The only coercion surface is
+// Unmarshal/UnmarshalPath (typed getters use strconv.ParseInt with no float
+// fallback).
+
+func TestUnmarshalIntCoercion_NonWholeHighMagnitudeRejected(t *testing.T) {
+	for _, raw := range []string{"9007199254740992.5", "4503599627370496.5"} {
+		cfg := mustParseCfg(t, "n = "+raw)
+		var s struct {
+			N int64 `hocon:"n"`
+		}
+		if err := cfg.Unmarshal(&s); err == nil {
+			t.Errorf("%s -> int64 must error (non-whole), got %d", raw, s.N)
+		}
+	}
+}
+
+func TestUnmarshalIntCoercion_ExactWholeAbove2Pow53(t *testing.T) {
+	// 2^53 + 1 as a whole float: via float64 this off-by-ones to 2^53.
+	cfg := mustParseCfg(t, "n = 9007199254740993.0")
+	var s struct {
+		N int64 `hocon:"n"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.N != 9007199254740993 {
+		t.Errorf("got %d, want 9007199254740993", s.N)
+	}
+}
+
+func TestUnmarshalIntCoercion_LargeWholeExponentNoRegression(t *testing.T) {
+	cfg := mustParseCfg(t, "n = 1e16")
+	var s struct {
+		N int64 `hocon:"n"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.N != 10000000000000000 {
+		t.Errorf("got %d", s.N)
+	}
+}
+
+func TestUnmarshalIntCoercion_NegativeExponentTextWholeness(t *testing.T) {
+	cases := []struct {
+		raw  string
+		ok   bool
+		want int64
+	}{
+		{"1e-3", false, 0},
+		{"1000e-3", true, 1},
+		{"1500e-3", false, 0},
+		{"1.5e1", true, 15},
+		{"1.234e2", false, 0},
+	}
+	for _, tc := range cases {
+		cfg := mustParseCfg(t, "n = "+tc.raw)
+		var s struct {
+			N int64 `hocon:"n"`
+		}
+		err := cfg.Unmarshal(&s)
+		if tc.ok {
+			if err != nil || s.N != tc.want {
+				t.Errorf("%s: got (%v, %d), want %d", tc.raw, err, s.N, tc.want)
+			}
+		} else if err == nil {
+			t.Errorf("%s: want error, got %d", tc.raw, s.N)
+		}
+	}
+}
+
+func TestUnmarshalIntCoercion_Int64Boundaries(t *testing.T) {
+	cfg := mustParseCfg(t, "min = -9223372036854775808.0\nmax = 9223372036854775807.0")
+	var s struct {
+		Min int64 `hocon:"min"`
+		Max int64 `hocon:"max"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.Min != math.MinInt64 {
+		t.Errorf("min got %d, want %d", s.Min, int64(math.MinInt64))
+	}
+	if s.Max != math.MaxInt64 {
+		t.Errorf("max got %d, want %d", s.Max, int64(math.MaxInt64))
+	}
+	// one past i64::MAX as a whole float must reject, not wrap
+	over := mustParseCfg(t, "n = 9223372036854775808.0")
+	var o struct {
+		N int64 `hocon:"n"`
+	}
+	if err := over.Unmarshal(&o); err == nil {
+		t.Errorf("9223372036854775808.0 must error, got %d", o.N)
+	}
+}
+
+func TestUnmarshalIntCoercion_HugeExponentNoHugeAlloc(t *testing.T) {
+	// Unquoted, go's number lexer already rejects an overflowing exponent at
+	// parse time; the quoted form bypasses that and reaches the coercion path,
+	// where it must error quickly rather than allocate a multi-GB zero string.
+	// The last two have an exponent outside int32 range — these must be rejected
+	// without panicking (a MinInt64-valued exponent would otherwise overflow the
+	// r/zeros arithmetic and panic strings.Repeat).
+	for _, conf := range []string{
+		`n = "1e2147483647"`,
+		`n = "1e9999999999999999999"`,
+		`n = "1e2147483648"`,
+		`n = "1e-9223372036854775808"`,
+	} {
+		cfg := mustParseCfg(t, conf)
+		var s struct {
+			N int64 `hocon:"n"`
+		}
+		if err := cfg.Unmarshal(&s); err == nil {
+			t.Errorf("%s must error, got %d", conf, s.N)
+		}
+	}
+}
+
+func TestUnmarshalIntCoercion_AllZeroMantissaIsZero(t *testing.T) {
+	cfg := mustParseCfg(t, "a = 0.0\nb = 0e2147483647\nc = -0.0")
+	var s struct {
+		A int64 `hocon:"a"`
+		B int64 `hocon:"b"`
+		C int64 `hocon:"c"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.A != 0 || s.B != 0 || s.C != 0 {
+		t.Errorf("got %+v, want all 0", s)
+	}
+}
+
+func TestUnmarshalIntCoercion_LeadingZeroFloatForms(t *testing.T) {
+	cfg := mustParseCfg(t, "a = 0100.0\nb = 0001e3")
+	var s struct {
+		A int64 `hocon:"a"`
+		B int64 `hocon:"b"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.A != 100 || s.B != 1000 {
+		t.Errorf("got %+v, want {100 1000}", s)
+	}
+}

--- a/issue56_i64_coercion_test.go
+++ b/issue56_i64_coercion_test.go
@@ -114,6 +114,7 @@ func TestUnmarshalIntCoercion_HugeExponentNoHugeAlloc(t *testing.T) {
 	// r/zeros arithmetic and panic strings.Repeat).
 	for _, conf := range []string{
 		`n = "1e2147483647"`,
+		`n = "1e-2147483648"`, // int32-min exponent: must not overflow r/zeros (32-bit)
 		`n = "1e9999999999999999999"`,
 		`n = "1e2147483648"`,
 		`n = "1e-9223372036854775808"`,

--- a/issue56_i64_coercion_test.go
+++ b/issue56_i64_coercion_test.go
@@ -143,6 +143,53 @@ func TestUnmarshalIntCoercion_AllZeroMantissaIsZero(t *testing.T) {
 	}
 }
 
+func TestUnmarshalIntCoercion_PlusSignAndZeroDot(t *testing.T) {
+	cfg := mustParseCfg(t, `a = "+1.0"
+	                        b = "5."
+	                        c = ".5"`)
+	var s struct {
+		A int64 `hocon:"a"`
+		B int64 `hocon:"b"`
+	}
+	if err := cfg.Unmarshal(&s); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s.A != 1 || s.B != 5 {
+		t.Errorf("got %+v, want {1 5}", s)
+	}
+	// ".5" is not whole
+	var c struct {
+		C int64 `hocon:"c"`
+	}
+	if err := cfg.Unmarshal(&c); err == nil {
+		t.Errorf(".5 must error, got %d", c.C)
+	}
+}
+
+func TestUnmarshalIntCoercion_MalformedAndOutOfRangeRejected(t *testing.T) {
+	// Quoted so they reach the coercion path as string scalars rather than being
+	// rejected by the number lexer. Covers: non-float-like, multiple dots /
+	// non-digit runs, empty mantissa, and magnitudes that overflow int64/uint64
+	// (positive and the negative >int64 magnitude branch).
+	for _, conf := range []string{
+		`n = "abcd"`, // no '.'/'e'/'E' — hits the non-float-like early return
+		`n = "1.2.3"`,
+		`n = "1a.0"`,
+		`n = "."`,
+		`n = "12345678901234567890.0"`,    // 20-digit int part > int64 max
+		`n = "-18000000000000000000.0"`,   // ~1.8e19: fits uint64, exceeds int64
+		`n = "999999999999999999999.0"`,   // 21 digits > uint64 max (ParseUint err)
+	} {
+		cfg := mustParseCfg(t, conf)
+		var s struct {
+			N int64 `hocon:"n"`
+		}
+		if err := cfg.Unmarshal(&s); err == nil {
+			t.Errorf("%s must error, got %d", conf, s.N)
+		}
+	}
+}
+
 func TestUnmarshalIntCoercion_LeadingZeroFloatForms(t *testing.T) {
 	cfg := mustParseCfg(t, "a = 0100.0\nb = 0001e3")
 	var s struct {

--- a/issue56_i64_coercion_test.go
+++ b/issue56_i64_coercion_test.go
@@ -176,9 +176,9 @@ func TestUnmarshalIntCoercion_MalformedAndOutOfRangeRejected(t *testing.T) {
 		`n = "1.2.3"`,
 		`n = "1a.0"`,
 		`n = "."`,
-		`n = "12345678901234567890.0"`,    // 20-digit int part > int64 max
-		`n = "-18000000000000000000.0"`,   // ~1.8e19: fits uint64, exceeds int64
-		`n = "999999999999999999999.0"`,   // 21 digits > uint64 max (ParseUint err)
+		`n = "12345678901234567890.0"`,  // 20-digit int part > int64 max
+		`n = "-18000000000000000000.0"`, // ~1.8e19: fits uint64, exceeds int64
+		`n = "999999999999999999999.0"`, // 21 digits > uint64 max (ParseUint err)
 	} {
 		cfg := mustParseCfg(t, conf)
 		var s struct {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -307,16 +307,17 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, err := strconv.ParseInt(sv.Raw, 10, 64)
 		if err != nil {
-			// Whole-number float/exponent fallback, matching rs.hocon's get_i64:
-			// only for float-like raw, finite, integral, and within int64 range.
-			// A non-whole value such as "1.5" is rejected, not truncated.
-			f, ferr := strconv.ParseFloat(sv.Raw, 64)
-			if ferr != nil || !strings.ContainsAny(sv.Raw, ".eE") ||
-				math.IsInf(f, 0) || f != math.Trunc(f) ||
-				f < math.MinInt64 || f >= math.MaxInt64 {
+			// Whole-number float/exponent fallback, matching rs.hocon. Wholeness
+			// and the value are derived from the raw decimal text, never via
+			// float64 (xx.hocon#56): above 2^52 a float64 cannot represent
+			// fractional parts, so a non-whole literal like "9007199254740992.5"
+			// would round to a whole float64 and a would-be-whole one like
+			// "9007199254740993.0" would round to the wrong integer.
+			var ok bool
+			n, ok = wholeFloatToInt64(sv.Raw)
+			if !ok {
 				return fmt.Errorf("hocon: expected int, got %q", sv.Raw)
 			}
-			n = int64(f)
 		}
 		if target.OverflowInt(n) {
 			return fmt.Errorf("hocon: int %d overflows %s", n, target.Type())
@@ -338,4 +339,124 @@ func unmarshalScalar(val resolver.Val, target reflect.Value) error {
 		return fmt.Errorf("hocon: unsupported target type %v", target.Type())
 	}
 	return nil
+}
+
+// wholeFloatToInt64 coerces a whole-number float/exponent raw string to an exact
+// int64, deriving both wholeness and the value from the decimal text rather than
+// an intermediate float64 (xx.hocon#56, byte-identical to rs.hocon's
+// whole_float_to_i64). Above 2^52 a float64 cannot represent fractional parts, so
+// a float64-based check both false-accepts non-whole values (e.g.
+// "9007199254740992.5") and off-by-one's would-be-whole ones (e.g.
+// "9007199254740993.0"). Returns ok=false for non-float-like, non-whole, or
+// out-of-int64-range input. Plain integers are handled by the caller's
+// strconv.ParseInt fast path.
+func wholeFloatToInt64(raw string) (int64, bool) {
+	// Plain integers are handled by the caller's strconv.ParseInt.
+	if !strings.ContainsAny(raw, ".eE") {
+		return 0, false
+	}
+	s := strings.TrimSpace(raw)
+	neg := false
+	switch {
+	case strings.HasPrefix(s, "-"):
+		neg = true
+		s = s[1:]
+	case strings.HasPrefix(s, "+"):
+		s = s[1:]
+	}
+	// Mantissa and base-10 exponent (default 0).
+	mantissa := s
+	exp := 0
+	if i := strings.IndexAny(s, "eE"); i >= 0 {
+		mantissa = s[:i]
+		// Parse the exponent into an int32 range (matching rs.hocon's
+		// `e.parse::<i32>()`): an exponent outside that range is rejected here, so
+		// the int64 arithmetic on `r`/`zeros` below cannot overflow (a value like
+		// "1e-9223372036854775808" would otherwise wrap and panic strings.Repeat).
+		e, err := strconv.ParseInt(s[i+1:], 10, 32)
+		if err != nil {
+			return 0, false
+		}
+		exp = int(e)
+	}
+	// Integer and fractional digit runs.
+	intPart, fracPart := mantissa, ""
+	if i := strings.IndexByte(mantissa, '.'); i >= 0 {
+		intPart, fracPart = mantissa[:i], mantissa[i+1:]
+	}
+	if intPart == "" && fracPart == "" {
+		return 0, false
+	}
+	if !allDigits(intPart) || !allDigits(fracPart) {
+		return 0, false
+	}
+	// Significant digits; leading zeros never affect the value. An all-zero
+	// mantissa is exactly 0 for any exponent — handle before the append-zeros
+	// guard, which is keyed off the exponent.
+	digits := strings.TrimLeft(intPart+fracPart, "0")
+	if digits == "" {
+		return 0, true
+	}
+	r := len(fracPart) - exp // digits to the right of the decimal point
+	var magStr string
+	if r <= 0 {
+		zeros := -r
+		// int64 has at most 19 digits; bound BEFORE building the string so a huge
+		// exponent like "1e2147483647" can't allocate gigabytes. Check zeros
+		// alone first to avoid int overflow when exp is enormous.
+		if zeros > 19 || len(digits) > 19 || len(digits)+zeros > 19 {
+			return 0, false
+		}
+		magStr = digits + strings.Repeat("0", zeros)
+	} else {
+		// digits is non-empty with a non-zero leading byte, so if every digit is
+		// fractional the value is < 1 and not whole.
+		if r >= len(digits) {
+			return 0, false
+		}
+		head, tail := digits[:len(digits)-r], digits[len(digits)-r:]
+		if !allZero(tail) {
+			return 0, false
+		}
+		magStr = head
+	}
+	// Parse the unsigned magnitude, then apply the sign with an explicit range
+	// check so that math.MinInt64 (magnitude 2^63, which does not fit int64) is
+	// preserved for float-like spellings like "-9223372036854775808.0".
+	mag, err := strconv.ParseUint(magStr, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if neg {
+		switch {
+		case mag < uint64(math.MaxInt64)+1:
+			return -int64(mag), true
+		case mag == uint64(math.MaxInt64)+1:
+			return math.MinInt64, true
+		default:
+			return 0, false
+		}
+	}
+	if mag > uint64(math.MaxInt64) {
+		return 0, false
+	}
+	return int64(mag), true
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func allZero(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '0' {
+			return false
+		}
+	}
+	return true
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -364,20 +364,20 @@ func wholeFloatToInt64(raw string) (int64, bool) {
 	case strings.HasPrefix(s, "+"):
 		s = s[1:]
 	}
-	// Mantissa and base-10 exponent (default 0).
+	// Mantissa and base-10 exponent (default 0). The exponent is parsed into the
+	// int32 range (matching rs.hocon's `e.parse::<i32>()`) and all of `r`/`zeros`
+	// is computed in int64, so the arithmetic cannot overflow on any platform
+	// (including 32-bit `int`) — a value like "1e-2147483648" would otherwise
+	// wrap and panic strings.Repeat with a negative count.
 	mantissa := s
-	exp := 0
+	var exp int64
 	if i := strings.IndexAny(s, "eE"); i >= 0 {
 		mantissa = s[:i]
-		// Parse the exponent into an int32 range (matching rs.hocon's
-		// `e.parse::<i32>()`): an exponent outside that range is rejected here, so
-		// the int64 arithmetic on `r`/`zeros` below cannot overflow (a value like
-		// "1e-9223372036854775808" would otherwise wrap and panic strings.Repeat).
 		e, err := strconv.ParseInt(s[i+1:], 10, 32)
 		if err != nil {
 			return 0, false
 		}
-		exp = int(e)
+		exp = e
 	}
 	// Integer and fractional digit runs.
 	intPart, fracPart := mantissa, ""
@@ -397,24 +397,25 @@ func wholeFloatToInt64(raw string) (int64, bool) {
 	if digits == "" {
 		return 0, true
 	}
-	r := len(fracPart) - exp // digits to the right of the decimal point
+	r := int64(len(fracPart)) - exp // digits to the right of the decimal point
 	var magStr string
 	if r <= 0 {
 		zeros := -r
 		// int64 has at most 19 digits; bound BEFORE building the string so a huge
-		// exponent like "1e2147483647" can't allocate gigabytes. Check zeros
-		// alone first to avoid int overflow when exp is enormous.
-		if zeros > 19 || len(digits) > 19 || len(digits)+zeros > 19 {
+		// exponent like "1e2147483647" can't allocate gigabytes. (zeros fits int
+		// once we know it is <= 19.)
+		if zeros > 19 || int64(len(digits))+zeros > 19 {
 			return 0, false
 		}
-		magStr = digits + strings.Repeat("0", zeros)
+		magStr = digits + strings.Repeat("0", int(zeros))
 	} else {
 		// digits is non-empty with a non-zero leading byte, so if every digit is
 		// fractional the value is < 1 and not whole.
-		if r >= len(digits) {
+		if r >= int64(len(digits)) {
 			return 0, false
 		}
-		head, tail := digits[:len(digits)-r], digits[len(digits)-r:]
+		rr := int(r) // safe: r < len(digits), which fits int
+		head, tail := digits[:len(digits)-rr], digits[len(digits)-rr:]
 		if !allZero(tail) {
 			return 0, false
 		}


### PR DESCRIPTION
## Summary

Fixes the integer-coercion precision hole reported in [xx.hocon#56](https://github.com/o3co/xx.hocon/issues/56), the byte-identical sibling of [rs.hocon#141](https://github.com/o3co/rs.hocon/pull/141) (merged).

Float-like integer unmarshalling (`unmarshalScalar`, the only coercion surface — typed getters use `strconv.ParseInt` with no float fallback) checked wholeness via `f != math.Trunc(f)` on a `float64`, which is unsound at high magnitudes:

- above **2^52** a `float64` cannot represent fractional parts, so `9007199254740992.5` (and `4503599627370496.5`, in the 2^52 window) rounded to a *whole* `float64` and was **wrongly accepted**;
- a would-be-whole literal like `9007199254740993.0` rounded to the **wrong integer** (silent off-by-one).

A magnitude threshold (e.g. reject `>= 2^53`) is **insufficient** — the half-integer hole opens at 2^52.

## Fix

A new `wholeFloatToInt64(raw) (int64, bool)` helper derives **both wholeness and the exact integer from the raw decimal text** (sign / mantissa / exponent), never via `float64`. Genuinely whole large literals (e.g. `1e16`, int64 boundaries) still coerce; non-whole values reject at any magnitude. Byte-identical in behaviour to rs.hocon's `whole_float_to_i64`.

## Review hardening (multi-agent — both reviewers converged on the exponent int-width)

- **Exponent parsed into int32 range** (matching rs's `parse::<i32>()`), so the `int64` arithmetic on `r`/`zeros` cannot overflow. Previously a quoted `"1e-9223372036854775808"` gave `exp == math.MinInt64` on 64-bit, wrapping `r` and **panicking** `strings.Repeat` — now rejected as a normal coercion error.
- **Huge positive exponents** are bounded before materializing the zero-padding (no multi-GB allocation).

## Tests

`issue56_i64_coercion_test.go` — the 2^53 / 2^52 false-accepts, the off-by-one exact case, `1e16` no-regression, negative-exponent text-wholeness, int64 MIN/MAX boundaries, huge / out-of-int32-range exponent safety (no panic), all-zero mantissa, leading-zero forms. Full suite + `go vet` + `golangci-lint` clean.

## Scope

ts.hocon is **N/A** (no integer coercion — `number` is float64, int-ness is a zod concern). Part of the coordinated 1.8 line; `[Unreleased]` `### Fixed`, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)