### PR TITLE
release(v1.8.0): finalize CHANGELOG (cross-impl minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-16
+
 ### Added
 
 - `Config.UnmarshalPath(path string, v any) error` — unmarshal the value at a


### PR DESCRIPTION
Finalizes `[Unreleased]` as `[1.8.0] - 2026-06-16` for the coordinated v1.8.0 release (go: `UnmarshalPath` + any-target #150; integer-coercion precision fix xx.hocon#56 #151). No code changes; the module version derives from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)