### PR TITLE
fix(S3.1): empty document parses to {} — remove reject guard (spec corrected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — empty document parses to `{}` (S3.1 corrected, [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62))
+
+- **`ParseString("")` (and whitespace-only / comment-only / BOM-only input) returns an
+  empty `Config` instead of erroring.** The S3.1 checklist item "Empty file is invalid
+  (HOCON.md L130)" misread the L130-132 *JSON baseline* as HOCON-normative; the
+  L134-136 brace-omission relaxation parses any document not beginning with `[` or `{`
+  as if enclosed in `{}` — an empty document is therefore the empty object. Confirmed
+  by the reference implementation (Lightbend's `"Empty document"` error is
+  `ConfigSyntax.JSON`-only; `ConfigFactory.parseString("")` is a valid empty config in
+  its own test suite). Restores pre-guard behavior — the cluster 3h `parseRoot` reject
+  was a regression. The rule now applies uniformly: top-level parse, file includes
+  (the former #105 `isEmptyOrCommentOnlyHocon` carve-out is removed — the parser
+  handles it naturally), and package includes (whitespace-only / comment-only
+  registered content now contributes `{}` like zero-byte content — the zero-byte-only
+  special-case is gone). Pure loosening — no previously-valid input changes meaning;
+  previously-rejected empty documents now succeed. Pinned by
+  `TestS3_1_EmptyFile_ParsesToEmptyObject` (ef01–ef06 `{}` sidecars now normative),
+  `TestSpec_S3_1_EmptyDocumentParsesToEmptyObject`,
+  `TestIssue105_TopLevelEmptyParsesToEmptyObject`, and
+  `TestPackageLookupWhitespaceOnlyContentSucceeds`.
+
 ## [1.8.0] - 2026-06-16
 
 ### Added

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -65,9 +65,9 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 
 ## S3. Omit root braces
 
-- **S3.1** Empty file is invalid — §Omit root braces (L130)
-  tests: s3_1_empty_file_test.go (TestS3_1_EmptyFile_Error, TestS3_1_NonEmpty_Accepted); spec_phase5_test.go (TestSpec_S3_1_EmptyFileInvalid)
-  status: ✅ — Fixed in cluster 3h (Phase 6). `parseRoot` now rejects EOF-only token streams with a parse error per HOCON.md L130. Covers empty string, whitespace-only, newlines-only, comment-only, BOM-only, and mixed ws+comment inputs. Explicit empty object `{}` and files with content are unaffected.
+- **S3.1** Empty document (empty / whitespace-only / comment-only / BOM-only file) parses to the empty object `{}` — §Omit root braces (L130-136)
+  tests: s3_1_empty_file_test.go (TestS3_1_EmptyFile_ParsesToEmptyObject, TestS3_1_NonEmpty_Accepted); spec_phase5_test.go (TestSpec_S3_1_EmptyDocumentParsesToEmptyObject); issue105_test.go (TestIssue105_TopLevelEmptyParsesToEmptyObject); internal/resolver/package_include_test.go (TestPackageLookupWhitespaceOnlyContentSucceeds)
+  status: ✅ — Corrected 2026-07-23 (xx.hocon E10). The item previously read "Empty file is invalid" — a misreading of the L130-132 JSON baseline as HOCON-normative; the L134 brace-omission relaxation makes an empty document the empty object. The cluster 3h `parseRoot` reject-guard (a regression vs. pre-guard releases) is removed; the include-path `isEmptyOrCommentOnlyHocon` carve-out and the package-include zero-byte special-case are gone — empty documents parse to `{}` uniformly on every path.
 
 - **S3.2** Root non-object/non-array is invalid (when explicitly enclosed) — §Omit root braces (L131)
   tests: internal/parser/parser_test.go:532 (TestSpecS3_2_RootNonObjectNonArrayInvalid)

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -827,11 +827,6 @@ func (l *Lexer) readNumber(line, col int) Token {
 	return Token{Type: tt, Value: string(l.src[startPos:lastValidEnd]), Line: line, Col: startCol}
 }
 
-// IsHoconWhitespace reports whether r is a HOCON whitespace character.
-// Exported wrapper around isHoconWhitespace so other internal packages
-// (e.g. the resolver's empty-include probe at #105) can ask the same
-// question without re-encoding the spec definition.
-func IsHoconWhitespace(r rune) bool { return isHoconWhitespace(r) }
 
 // isHoconWhitespace reports whether r is a HOCON whitespace character per
 // HOCON.md §Whitespace (L165-184). The set is:

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -827,7 +827,6 @@ func (l *Lexer) readNumber(line, col int) Token {
 	return Token{Type: tt, Value: string(l.src[startPos:lastValidEnd]), Line: line, Col: startCol}
 }
 
-
 // isHoconWhitespace reports whether r is a HOCON whitespace character per
 // HOCON.md §Whitespace (L165-184). The set is:
 //

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -92,15 +92,12 @@ func (p *parser) skipNewlines() {
 
 func (p *parser) parseRoot() (*ObjectNode, error) {
 	p.skipNewlines()
-	// S3.1: empty file is invalid (HOCON.md L130). After stripping newlines,
-	// if only EOF remains the document has no semantic content — reject it.
-	// This covers: empty string, whitespace-only, newlines-only, comment-only,
-	// BOM-only, and mixed whitespace+comment inputs. The lexer strips BOM at
-	// init and strips comments in skipWhitespaceAndComments, so they produce
-	// no tokens other than newlines and EOF.
-	if p.current.Type == lexer.TokenEOF {
-		return nil, newError(1, 1, "empty file is not a valid HOCON document (HOCON.md L130)")
-	}
+	// S3.1 (corrected, xx.hocon E10): an empty document — empty string,
+	// whitespace-only, newlines-only, comment-only, BOM-only, or mixed — is
+	// valid HOCON and parses to the empty object, per the HOCON.md L134-136
+	// brace-omission relaxation (L130-132 is the JSON baseline). An EOF-only
+	// stream falls through to parseObjectFields(false), which returns an
+	// empty ObjectNode.
 	// root may be a bare object (no braces) or an explicit { ... }
 	if p.current.Type != lexer.TokenLBrace {
 		return p.parseObjectFields(false)

--- a/internal/resolver/package_include_test.go
+++ b/internal/resolver/package_include_test.go
@@ -131,6 +131,49 @@ include package("github.com/example/lib", "empty.conf")`
 	}
 }
 
+// TestPackageLookupWhitespaceOnlyContentSucceeds verifies that whitespace-only
+// and comment-only content merge as {} — same S3.1 rule as zero-byte content
+// (an empty document parses to the empty object; corrected 2026-07-23,
+// xx.hocon E10). Regression guard: the package path used to reject
+// non-zero-byte empty documents via the parser-entry guard.
+func TestPackageLookupWhitespaceOnlyContentSucceeds(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"whitespace-only", "   \n\t\n"},
+		{"comment-only", "# nothing here\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pkgs := map[string]string{
+				pkgKey("github.com/example/lib", "empty.conf"): tc.content,
+			}
+
+			src := `app = host
+include package("github.com/example/lib", "empty.conf")`
+			ast, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			res, err := resolver.Resolve(ast, resolver.Options{
+				PackageLookup: makeLookup(pkgs),
+			})
+			if err != nil {
+				t.Fatalf("resolve: expected {} contribution per corrected S3.1, got error: %v", err)
+			}
+			app, ok := res.Root.Get("app")
+			if !ok {
+				t.Fatal("app not found")
+			}
+			if sv, ok := app.(*resolver.ScalarVal); !ok || sv.Raw != "host" {
+				t.Errorf("app: want %q, got %v", "host", app)
+			}
+		})
+	}
+}
+
 // TestPackageLookupCaseSensitiveID verifies byte-exact case-sensitive identifier lookup.
 func TestPackageLookupCaseSensitiveID(t *testing.T) {
 	pkgs := map[string]string{

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/o3co/go.hocon/internal/lexer"
 	"github.com/o3co/go.hocon/internal/parser"
@@ -1640,62 +1639,16 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 		return propsToObjectVal(properties.Parse(string(data))), nil
 	}
 
-	// Lightbend-compat carve-out for #105: an empty or comment-only include
-	// file contributes nothing instead of erroring with "empty file is not a
-	// valid HOCON document". Top-level empty parses (ParseString("")) remain
-	// invalid per spec S3.1 (HOCON.md L130); this carve-out applies ONLY to
-	// the include path so the common optional-override-file pattern works.
-	if isEmptyOrCommentOnlyHocon(data) {
-		return newObjectVal(), nil
-	}
-
+	// S3.1 (corrected, xx.hocon E10): an empty / whitespace-only / comment-only
+	// include file parses to the empty object naturally — the former #105
+	// Lightbend-compat carve-out is now simply the rule, enforced by the parser
+	// itself (parseRoot returns an empty ObjectNode for an EOF-only stream).
 	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
 		return nil, err
 	}
 
 	return obj, nil
-}
-
-// isEmptyOrCommentOnlyHocon reports whether the given HOCON source has no
-// semantic content — i.e. only HOCON whitespace (per the lexer's full
-// definition — including NBSP, Unicode Zs, U+2028/U+2029, BOM, etc.) and
-// the two HOCON line-comment forms (# and //). Block comments are NOT a
-// HOCON syntax; if `/* ... */` appears, it falls through and the parser
-// produces its proper error. Used by loadIncludeFile to short-circuit the
-// S3.1 empty-document rejection for included files (Lightbend-compat for
-// #105).
-func isEmptyOrCommentOnlyHocon(data []byte) bool {
-	s := string(data)
-	for i := 0; i < len(s); {
-		// Decode one rune so we treat all HOCON whitespace (NBSP, U+2028,
-		// U+FEFF, etc. — multi-byte under UTF-8) consistently with the lexer.
-		r, size := utf8.DecodeRuneInString(s[i:])
-		// HOCON whitespace (per lexer.isHoconWhitespace) covers LF as well as
-		// BOM at any position, not just the leading byte — so a single
-		// IsHoconWhitespace check is sufficient.
-		if lexer.IsHoconWhitespace(r) {
-			i += size
-			continue
-		}
-		if r == '#' {
-			// # line comment — skip until newline or EOF.
-			for i < len(s) && s[i] != '\n' {
-				i++
-			}
-			continue
-		}
-		if r == '/' && i+1 < len(s) && s[i+1] == '/' {
-			// // line comment — skip until newline or EOF.
-			i += 2
-			for i < len(s) && s[i] != '\n' {
-				i++
-			}
-			continue
-		}
-		return false
-	}
-	return true
 }
 
 // parseAndResolve parses raw HOCON/JSON data and builds it into an UNRESOLVED
@@ -1768,10 +1721,9 @@ func (r *resolver) loadPackageInclude(identifier, file string) (*ObjectVal, erro
 		}
 	}
 
-	// Empty content is not a failure — contributes empty object per E11 decision 4 note.
-	if len(content) == 0 {
-		return newObjectVal(), nil
-	}
+	// S3.1 (corrected, xx.hocon E10): empty / whitespace-only / comment-only
+	// content parses to the empty object naturally and contributes {} (E11
+	// decision 4 note) — no zero-byte special-case needed.
 
 	// Build a synthetic virtual path used as a descriptive label in error messages.
 	// parseAndResolvePackage inherits r.opts.BaseDir for any nested file includes

--- a/issue105_test.go
+++ b/issue105_test.go
@@ -99,8 +99,8 @@ func TestIssue105_WhitespaceOnlyIncludeFile(t *testing.T) {
 // TestIssue105_UnicodeWhitespaceOnlyIncludeFile pins the multi-byte
 // whitespace path. HOCON's whitespace set (per HOCON.md §Whitespace) covers
 // NBSP, all Unicode Zs members, U+2028 (line sep), U+2029 (para sep), BOM,
-// etc. An included file containing only these characters must also be
-// treated as empty by the carve-out.
+// etc. An included file containing only these characters must also parse to
+// the empty object (corrected S3.1 — the parser handles it directly).
 func TestIssue105_UnicodeWhitespaceOnlyIncludeFile(t *testing.T) {
 	dir := t.TempDir()
 	uwsFile := filepath.Join(dir, "uws.conf")
@@ -146,11 +146,10 @@ func TestIssue105_BOMOnlyIncludeFile(t *testing.T) {
 	}
 }
 
-// TestIssue105_BlockCommentInIncludeIsRejected pins the narrow scope: HOCON
-// recognises only `#` and `//` comments. A `/* ... */` block-comment-only
-// include is NOT silently treated as empty; it falls through to the parser
-// which reports the syntax error. This guards against the carve-out
-// becoming a backdoor for masking malformed include files.
+// TestIssue105_BlockCommentInIncludeIsRejected: HOCON recognises only `#` and
+// `//` comments. A `/* ... */` block-comment-only document is a syntax error,
+// not an empty document — the S3.1 empty-parses-to-{} rule must not mask
+// malformed include files; the parser reports the syntax error.
 func TestIssue105_BlockCommentInIncludeIsRejected(t *testing.T) {
 	dir := t.TempDir()
 	bcFile := filepath.Join(dir, "block.conf")

--- a/issue105_test.go
+++ b/issue105_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/o3co/go.hocon"
 )
 
-// Issue #105 (cgordon): empty or comment-only included files should
-// contribute an empty config instead of erroring. The narrower scope —
-// include path only — is implemented; top-level empty parses
-// (`ParseString("")`) remain invalid per S3.1 (HOCON.md L130).
+// Issue #105 (cgordon): empty or comment-only included files contribute an
+// empty config. Originally a narrow include-path carve-out while top-level
+// parses still rejected; since the S3.1 correction (xx.hocon E10, 2026-07-23)
+// the same rule applies everywhere — an empty document parses to {} at top
+// level too (HOCON.md §Omit root braces L134-136).
 
 func TestIssue105_EmptyIncludeFile(t *testing.T) {
 	dir := t.TempDir()
@@ -166,10 +167,10 @@ func TestIssue105_BlockCommentInIncludeIsRejected(t *testing.T) {
 	}
 }
 
-// TestIssue105_TopLevelEmptyStillRejected pins the narrower scope: only
-// the include path treats empty/comment-only as no-op. ParseString of an
-// empty top-level document still errors per S3.1 (HOCON.md L130).
-func TestIssue105_TopLevelEmptyStillRejected(t *testing.T) {
+// TestIssue105_TopLevelEmptyParsesToEmptyObject pins top-level parity with the
+// include path: an empty document parses to {} everywhere per the corrected
+// S3.1 (HOCON.md L134-136; the former rejection was revoked — xx.hocon E10).
+func TestIssue105_TopLevelEmptyParsesToEmptyObject(t *testing.T) {
 	cases := []struct {
 		name string
 		src  string
@@ -181,8 +182,12 @@ func TestIssue105_TopLevelEmptyStillRejected(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := hocon.ParseString(tc.src); err == nil {
-				t.Errorf("ParseString(%q) succeeded; spec S3.1 requires rejection", tc.src)
+			cfg, err := hocon.ParseString(tc.src)
+			if err != nil {
+				t.Fatalf("ParseString(%q): expected empty config per corrected S3.1, got error: %v", tc.src, err)
+			}
+			if keys := cfg.Keys(); len(keys) != 0 {
+				t.Errorf("ParseString(%q): expected empty config, got keys %v", tc.src, keys)
 			}
 		})
 	}

--- a/s3_1_empty_file_test.go
+++ b/s3_1_empty_file_test.go
@@ -6,14 +6,17 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// S3.1 — empty file is an invalid HOCON document conformance tests.
-// Spec authority: HOCON.md L130 ("Empty files are invalid documents").
-// Fixtures: testdata/hocon/empty-file/ef01-ef06 (from xx.hocon, SHA 5beedfa).
+// S3.1 — an empty document is valid HOCON and parses to the empty object {}.
+// Spec authority: HOCON.md §Omit root braces L134-136 (a file that does not
+// begin with `[` or `{` is parsed as if enclosed in `{}`; an empty document
+// vacuously qualifies). L130-132 ("Empty files are invalid documents") is the
+// JSON baseline, not HOCON-normative — the former reject-posture was revoked
+// 2026-07-23 (xx.hocon E10). Confirmed by the Lightbend reference
+// implementation, whose "Empty document" error is ConfigSyntax.JSON-only.
+// Fixtures: testdata/hocon/empty-file/ef01-ef06 (from xx.hocon); the {}
+// -expected.json sidecars are normative — no per-impl override applies.
 //
-// All six fixtures must produce a non-nil parse error; no expected JSON sidecar
-// is needed for error cases. The test gate checks for the .conf fixtures directly.
-//
-// Positive guards: "{}", "a = 1", and "# comment\na = 1" must succeed.
+// Positive guards: "{}", "a = 1", and "# comment\na = 1" must also succeed.
 
 package hocon_test
 
@@ -25,8 +28,8 @@ import (
 	hocon "github.com/o3co/go.hocon"
 )
 
-// s3_1ErrorFixtures lists the names of empty-file error fixtures (without extension).
-var s3_1ErrorFixtures = []string{
+// s3_1EmptyFixtures lists the names of empty-file fixtures (without extension).
+var s3_1EmptyFixtures = []string{
 	"ef01-empty",
 	"ef02-whitespace-only",
 	"ef03-newlines-only",
@@ -35,21 +38,24 @@ var s3_1ErrorFixtures = []string{
 	"ef06-mixed-ws-comment",
 }
 
-// TestS3_1_EmptyFile_Error asserts that each empty-file fixture produces a non-nil
-// parse or resolve error (HOCON.md L130: empty files are invalid documents).
-func TestS3_1_EmptyFile_Error(t *testing.T) {
+// TestS3_1_EmptyFile_ParsesToEmptyObject asserts that each empty-file fixture
+// parses successfully to an empty config, matching the {} expected sidecars.
+func TestS3_1_EmptyFile_ParsesToEmptyObject(t *testing.T) {
 	fixtureDir := filepath.Join("testdata", "hocon", "empty-file")
 	if _, err := os.Stat(fixtureDir); err != nil {
 		t.Skipf("empty-file fixtures missing at %s; run `make testdata`", fixtureDir)
 	}
 
-	for _, name := range s3_1ErrorFixtures {
+	for _, name := range s3_1EmptyFixtures {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			confPath := filepath.Join(fixtureDir, name+".conf")
-			_, err := hocon.ParseFile(confPath)
-			if err == nil {
-				t.Errorf("ParseFile(%s): expected error for empty/comment-only input, got nil", confPath)
+			cfg, err := hocon.ParseFile(confPath)
+			if err != nil {
+				t.Fatalf("ParseFile(%s): expected empty config per corrected S3.1, got error: %v", confPath, err)
+			}
+			if keys := cfg.Keys(); len(keys) != 0 {
+				t.Errorf("ParseFile(%s): expected empty config, got keys %v", confPath, keys)
 			}
 		})
 	}

--- a/s3_1_empty_file_test.go
+++ b/s3_1_empty_file_test.go
@@ -61,6 +61,30 @@ func TestS3_1_EmptyFile_ParsesToEmptyObject(t *testing.T) {
 	}
 }
 
+// TestS3_1_EmptyDocument_DeferredParse pins the deferred-resolution path
+// (WithResolveSubstitutions(false)): an empty document parses to an empty
+// unresolved Config the same way the default path does — the parser is the
+// single gate for the corrected S3.1 rule.
+func TestS3_1_EmptyDocument_DeferredParse(t *testing.T) {
+	cfg, err := hocon.ParseStringWithOptions("", hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	if err != nil {
+		t.Fatalf("deferred ParseStringWithOptions(\"\"): expected empty config, got error: %v", err)
+	}
+	if keys := cfg.Keys(); len(keys) != 0 {
+		t.Errorf("deferred parse of empty document: expected no keys, got %v", keys)
+	}
+}
+
+// TestS3_1_BlockCommentOnlyTopLevelIsRejected: HOCON recognises only `#` and
+// `//` comments. A `/* ... */`-only document is a syntax error, not an empty
+// document — the S3.1 empty-parses-to-{} rule must not mask malformed files.
+// (The include-path variant is pinned in issue105_test.go.)
+func TestS3_1_BlockCommentOnlyTopLevelIsRejected(t *testing.T) {
+	if _, err := hocon.ParseString("/* multi\nline\ncomment */\n"); err == nil {
+		t.Error("ParseString on block-comment-only input succeeded; expected syntax error")
+	}
+}
+
 // TestS3_1_NonEmpty_Accepted are positive guards: these must parse without error.
 func TestS3_1_NonEmpty_Accepted(t *testing.T) {
 	cases := []struct {

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -93,18 +93,24 @@ func TestSpec_S1_1_InvalidUTF8_Spec(t *testing.T) {
 	}
 }
 
-// ── S3.1: empty file is invalid ──────────────────────────────────────────────
+// ── S3.1: empty document parses to {} ────────────────────────────────────────
 
-// TestSpec_S3_1_EmptyFileInvalid asserts that empty and comment-only inputs are
-// rejected by ParseString with a non-nil error (HOCON.md L130, fixed in cluster 3h).
+// TestSpec_S3_1_EmptyDocumentParsesToEmptyObject asserts that empty and
+// comment-only inputs parse to an empty config (HOCON.md L134-136 brace-omission
+// relaxation; the former L130-based rejection misread the JSON baseline as
+// HOCON-normative — corrected 2026-07-23, xx.hocon E10).
 // Positive guards (explicit empty object, single field, comment+field) must succeed.
-func TestSpec_S3_1_EmptyFileInvalid(t *testing.T) {
-	errInputs := []string{"", "   ", "\n\n", "# only comment\n", "\xef\xbb\xbf", "  # x \n  \n"}
-	for _, src := range errInputs {
+func TestSpec_S3_1_EmptyDocumentParsesToEmptyObject(t *testing.T) {
+	emptyInputs := []string{"", "   ", "\n\n", "# only comment\n", "\xef\xbb\xbf", "  # x \n  \n"}
+	for _, src := range emptyInputs {
 		src := src
-		t.Run("error/"+fmt.Sprintf("%q", src), func(t *testing.T) {
-			if _, err := hocon.ParseString(src); err == nil {
-				t.Errorf("expected error for empty input %q, got nil", src)
+		t.Run("empty/"+fmt.Sprintf("%q", src), func(t *testing.T) {
+			cfg, err := hocon.ParseString(src)
+			if err != nil {
+				t.Fatalf("expected empty config for %q per corrected S3.1, got error: %v", src, err)
+			}
+			if keys := cfg.Keys(); len(keys) != 0 {
+				t.Errorf("expected empty config for %q, got keys %v", src, keys)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implements the S3.1 correction from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62): an empty HOCON document (empty / whitespace-only / comment-only / BOM-only) is **valid** and parses to the empty object `{}`, per HOCON.md §Omit root braces L134-136. The former "Empty file is invalid (L130)" reading — the basis for the cluster 3h `parseRoot` guard — misread the L130-132 *JSON baseline* as HOCON-normative and was a behavior regression vs. pre-guard releases. Confirmed against the reference implementation: Lightbend's `"Empty document"` error is `ConfigSyntax.JSON`-only, and `ConfigFactory.parseString("")` is a valid empty config throughout its own test suite.

Sibling PR: [ts.hocon#153](https://github.com/o3co/ts.hocon/pull/153).

## Changes

- **`internal/parser/parser.go`** — remove the `parseRoot` EOF-only reject guard; an EOF-only stream falls through to `parseObjectFields(false)`, which returns an empty `ObjectNode`. The parser is now the single gate for the rule.
- **`internal/resolver/resolver.go`** — remove the #105 `isEmptyOrCommentOnlyHocon` carve-out from `loadIncludeFile` (helper deleted; the parser handles empty content naturally) and the zero-byte special-case from `loadPackageInclude` (whitespace-only / comment-only registered content now contributes `{}` like zero-byte content).
- **`internal/lexer/lexer.go`** — drop the now-orphaned `IsHoconWhitespace` wrapper (sole consumer was the deleted carve-out; internal package, zero remaining callers).
- **Tests** — TDD RED→GREEN: ef01–ef06 conformance asserts `{}` per the normative sidecars; `TestSpec_S3_1_EmptyDocumentParsesToEmptyObject`, `TestIssue105_TopLevelEmptyParsesToEmptyObject`, package-include whitespace/comment pins, deferred-resolution empty parse, and top-level `/* */`-only rejection (the S3.1 rule must not mask malformed files — block comments are not HOCON).
- **Docs** — `docs/spec-compliance.md` S3.1 redefined; CHANGELOG Unreleased entry.

**Pure loosening** — no previously-valid input changes meaning; previously-rejected empty documents now succeed. No public API changes.

## Verification

- RED observed first: 4 suites failing with `empty file is not a valid HOCON document` (guard-caused).
- GREEN: all 5 packages ok; `go vet` clean; `go build` clean.
- Multi-agent review (Claude + Codex): merge-ready; the 3 Minor findings (stale comments, orphaned helper) + 2 optional coverage pins addressed in the follow-up commit.

## Cross-impl

rs.hocon / py.hocon PRs follow; compliance-matrix re-roll-up in xx.hocon once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)