### PR TITLE
feat(S3.5): array-root document rejected with a type error, not a syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — array-root document rejected with a type error (S3.5, [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64))
+
+- **`ParseString("[1,2]")` now returns `*ConfigError` ("document has type array rather
+  than object at file root", HOCON.md L989-991, with origin + bracket position) instead
+  of a `*ParseError` "expected key".** An array-root document is syntactically valid
+  HOCON; the reference implementation parses it and rejects at the Config boundary
+  (`Parseable.forceParsedToObject`, `ConfigException.WrongType`). `parseRoot` now
+  parses the array fully — malformed arrays (`[1,2`) and trailing content remain
+  `*ParseError`s — and returns the `parser.ErrArrayAtRoot` sentinel, mapped to
+  `ConfigError` at the public boundary. Include paths (file + package) raise
+  `*ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming
+  the included source, improving the S14b.1 diagnostic. The package-content error
+  wrapper now preserves the cause chain (`ResolveError.Cause`), so `errors.Is` works
+  through package parse errors. Net behavior is unchanged (array-root documents still
+  error) — only the error class, layer, and message change. Pinned by
+  `s3_5_array_root_test.go` (xx.hocon `array-root/ar01–ar03` `.error` sidecars).
+
 ### Fixed — empty document parses to `{}` (S3.1 corrected, [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62))
 
 - **`ParseString("")` (and whitespace-only / comment-only / BOM-only input) returns an

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ testdata:
 	  mkdir -p testdata/hocon/self-ref-lookback && \
 	  cp "$$tmpdir/testdata/hocon/self-ref-lookback/"*.conf testdata/hocon/self-ref-lookback/ 2>/dev/null || true; \
 	fi && \
+	if [ -d "$$tmpdir/testdata/hocon/array-root" ]; then \
+	  mkdir -p testdata/hocon/array-root && \
+	  cp "$$tmpdir/testdata/hocon/array-root/"*.conf testdata/hocon/array-root/ 2>/dev/null || true; \
+	fi && \
 	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EXPECTED_DIR   := testdata/expected
 .PHONY: testdata test
 
 testdata:
-	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d testdata/hocon/array-root ]; then \
 	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
 	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \

--- a/deferred_resolution_fixture_test.go
+++ b/deferred_resolution_fixture_test.go
@@ -315,10 +315,12 @@ func categoryMatches(category string, err error) bool {
 	case "NotResolved":
 		return errors.Is(err, hocon.ErrNotResolved)
 	case "TypeError":
-		// go.hocon currently surfaces type errors as parse or resolve errors.
+		// go.hocon surfaces type errors as parse, resolve, or config errors
+		// (ConfigError since S3.5 — the array-at-file-root class).
 		var pe *hocon.ParseError
 		var re *hocon.ResolveError
-		return errors.As(err, &pe) || errors.As(err, &re)
+		var ce *hocon.ConfigError
+		return errors.As(err, &pe) || errors.As(err, &re) || errors.As(err, &ce)
 	case "CycleError":
 		// go.hocon surfaces cycles as ResolveError with "circular" / "cycle" / "self-referential" message.
 		var re *hocon.ResolveError

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -1,6 +1,6 @@
 # HOCON Spec Compliance — go.hocon
 
-This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx.hocon/blob/main/docs/spec-checklist.md) with go.hocon-specific status and test references. It inherits all 209 items in the same order; description lines are verbatim from the template and must not be edited here.
+This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx.hocon/blob/main/docs/spec-checklist.md) with go.hocon-specific status and test references. It inherits all 210 items in the same order; description lines are verbatim from the template and must not be edited here.
 
 - **`tests:`** records the test or fixture exercising each item, or `—` if no test covers it (test debt).
 - **`status:`** meanings follow the legend in the template (✅ ⚠️ ❌ 🤷 ➖).
@@ -80,6 +80,15 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 - **S3.4** Unbalanced trailing `}` without opening `{` is invalid — §Omit root braces (L138)
   tests: internal/parser/parser_test.go:427 (TestBracedRootTrailingGarbage)
   status: ✅
+
+- **S3.5** Array-root document is valid syntax; object-rooted parse API rejects with a type error — §Include semantics: merging (L989-991)
+  tests: s3_5_array_root_test.go (top-level + position + deferred + malformed guards + include/package variants + ar01–ar03 conformance loop)
+  status: ✅ — Added 2026-07-23. `parseRoot` parses the array fully (malformed arrays /
+  trailing content stay syntax errors) and returns `parser.ErrArrayAtRoot`;
+  `parseWithOptions` maps it to `ConfigError` ("document has type array rather than
+  object at file root", with origin + bracket position), matching Lightbend's
+  `Parseable.forceParsedToObject` (`WrongType`). Previously a parse error
+  "expected key" — right net outcome, wrong kind at the wrong layer.
 
 ## S4. Key-value separator
 
@@ -607,8 +616,11 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ### S14b. Include semantics: merging
 
 - **S14b.1** Included root must be an object (array → error) — §Include semantics: merging (L993)
-  tests: internal/resolver/resolver_test.go:1166 (TestSpecS14b_1_ArrayRootIncludeIsError)
-  status: ✅
+  tests: internal/resolver/resolver_test.go:1166 (TestSpecS14b_1_ArrayRootIncludeIsError); s3_5_array_root_test.go (include + package variants)
+  status: ✅ — Diagnostics improved with S3.5 (2026-07-23): the resolver now raises
+  `ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming
+  the included source (file path or package virtual path), instead of the parser's
+  generic syntax error.
 
 - **S14b.2** Included keys merge per duplicate-key rules — §Include semantics: merging (L997)
   tests: internal/resolver/resolver_test.go:286 (TestResolver_IncludeMergeAll); testdata/hocon/test03.conf (fixture)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -616,7 +616,7 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ### S14b. Include semantics: merging
 
 - **S14b.1** Included root must be an object (array → error) — §Include semantics: merging (L993)
-  tests: internal/resolver/resolver_test.go:1166 (TestSpecS14b_1_ArrayRootIncludeIsError); s3_5_array_root_test.go (include + package variants)
+  tests: internal/resolver/resolver_test.go:1341 (TestSpecS14b_1_ArrayRootIncludeIsError); s3_5_array_root_test.go (include + package variants)
   status: ✅ — Diagnostics improved with S3.5 (2026-07-23): the resolver now raises
   `ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming
   the included source (file path or package virtual path), instead of the parser's

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,15 @@ type ResolveError struct {
 	Col               int
 	FilePath          string // file path when resolving an include
 	OriginDescription string // E12: user-supplied label when no FilePath available
+	// Cause is the underlying error that triggered this resolve error, if
+	// any (e.g. the S3.5 array-at-root sentinel on include paths). Traverse
+	// with errors.Is / errors.As via Unwrap.
+	Cause error
+}
+
+// Unwrap returns the underlying cause for errors.Is / errors.As.
+func (e *ResolveError) Unwrap() error {
+	return e.Cause
 }
 
 func (e *ResolveError) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -63,7 +63,10 @@ func (e *ResolveError) Error() string {
 	return fmt.Sprintf("resolve error: %s", e.Message)
 }
 
-// ConfigError is used in panics from GetXxx methods.
+// ConfigError is the type-mismatch error class: used in panics from GetXxx
+// methods, returned by the GetXxxE variants, and returned by the Parse*
+// functions for an array-root document (S3.5 — the Lightbend WrongType
+// analog, where Path is empty because the mismatch is at the file root).
 type ConfigError struct {
 	Message string
 	Path    string // HOCON access path e.g. "server.host"
@@ -71,6 +74,10 @@ type ConfigError struct {
 }
 
 func (e *ConfigError) Error() string {
+	if e.Path == "" {
+		// File-root errors (S3.5 array-at-root) have no access path.
+		return fmt.Sprintf("config error: %s", e.Message)
+	}
 	return fmt.Sprintf("config error at path %q: %s", e.Path, e.Message)
 }
 

--- a/hocon.go
+++ b/hocon.go
@@ -55,6 +55,18 @@ func parseWithOptions(input, filePath string, opts ParseOptions) (*Config, error
 	}
 	ast, err := parser.Parse(input)
 	if err != nil {
+		// S3.5: an array-root document parsed successfully — the rejection is
+		// a TYPE error at the Config boundary (Lightbend WrongType analog),
+		// not a syntax error, so it maps to ConfigError rather than ParseError.
+		if errors.Is(err, parser.ErrArrayAtRoot) {
+			msg := err.Error()
+			if filePath != "" {
+				msg = filePath + ": " + msg
+			} else if od := opts.OriginDescription(); od != "" {
+				msg = od + ": " + msg
+			}
+			return nil, &ConfigError{Message: msg}
+		}
 		pe := &ParseError{FilePath: filePath}
 		if filePath == "" {
 			pe.OriginDescription = opts.OriginDescription()

--- a/hocon.go
+++ b/hocon.go
@@ -135,6 +135,7 @@ func wrapResolveError(err error) error {
 			Line:     re.Line,
 			Col:      re.Col,
 			FilePath: re.FilePath,
+			Cause:    re.Cause,
 		}
 	}
 	return err

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -9,6 +9,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -62,6 +63,14 @@ func ValidatePackageFile(file string) error {
 	return nil
 }
 
+// ErrArrayAtRoot marks a syntactically valid array-root document rejected by
+// the object-rooted Config API (S3.5, HOCON.md L989-991). The parser parses
+// the array successfully and returns an error wrapping this sentinel; the
+// public boundary (hocon.parseWithOptions) converts it to the type-mismatch
+// error class, and the resolver converts it for include paths (S14b.1,
+// HOCON.md L993-994). Detect with errors.Is.
+var ErrArrayAtRoot = errors.New("document has type array rather than object at file root")
+
 // Parse parses a HOCON string and returns the root ObjectNode.
 // The input may omit outer braces (root object shorthand).
 func Parse(src string) (*ObjectNode, error) {
@@ -98,6 +107,23 @@ func (p *parser) parseRoot() (*ObjectNode, error) {
 	// brace-omission relaxation (L130-132 is the JSON baseline). An EOF-only
 	// stream falls through to parseObjectFields(false), which returns an
 	// empty ObjectNode.
+	// S3.5 (HOCON.md L989-991): "both JSON and HOCON allow arrays as root
+	// values in a document" — an array-root document is valid syntax. Parse
+	// the array fully (malformed arrays and trailing content stay syntax
+	// errors), then return ErrArrayAtRoot so the Config boundary can reject
+	// it as a TYPE error, matching Lightbend's Parseable.forceParsedToObject
+	// (WrongType "has type LIST rather than object at file root").
+	if p.current.Type == lexer.TokenLBracket {
+		line, col := p.current.Line, p.current.Col
+		if _, err := p.parseArray(); err != nil {
+			return nil, err
+		}
+		p.skipNewlines()
+		if p.current.Type != lexer.TokenEOF {
+			return nil, newError(p.current.Line, p.current.Col, "unexpected token after root array")
+		}
+		return nil, fmt.Errorf("%d:%d: %w (HOCON.md L989-991); the Config API requires an object at file root", line, col, ErrArrayAtRoot)
+	}
 	// root may be a bare object (no braces) or an explicit { ... }
 	if p.current.Type != lexer.TokenLBrace {
 		return p.parseObjectFields(false)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1666,8 +1666,11 @@ func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, er
 		// at the ParseBytes site (not in loadIncludeFile) so nested include
 		// chains name the innermost file that actually has the array root.
 		if errors.Is(err, parser.ErrArrayAtRoot) {
+			// The included-source identity lives in FilePath (the public
+			// Error() prefixes it); keeping it out of Message avoids the
+			// path rendering twice.
 			return nil, &ResolveError{
-				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", filePath),
+				Message:  "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994)",
 				FilePath: filePath,
 				Cause:    err,
 			}
@@ -1761,8 +1764,9 @@ func (r *resolver) parseAndResolvePackage(data []byte, virtualPath string) (*Obj
 		// Converted here (the ParseBytes site) so nested chains name the
 		// innermost source.
 		if errors.Is(err, parser.ErrArrayAtRoot) {
+			// Same as the file-include variant: identity in FilePath only.
 			return nil, &ResolveError{
-				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", virtualPath),
+				Message:  "included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994)",
 				FilePath: virtualPath,
 				Cause:    err,
 			}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1646,18 +1646,6 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 	// itself (parseRoot returns an empty ObjectNode for an EOF-only stream).
 	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
-		// S14b.1 (HOCON.md L993-994): an included file must contain an object,
-		// not an array. The document is valid syntax (S3.5) — surface the type
-		// constraint as a ResolveError naming the included file, matching
-		// Lightbend's forceParsedToObject on the include path.
-		if errors.Is(err, parser.ErrArrayAtRoot) {
-			return nil, &ResolveError{
-				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", path),
-				Path:     path,
-				FilePath: path,
-				Cause:    err,
-			}
-		}
 		return nil, err
 	}
 
@@ -1672,6 +1660,18 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 func (r *resolver) parseAndResolve(data []byte, filePath string) (*ObjectVal, error) {
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
+		// S14b.1 (HOCON.md L993-994): an included file must contain an object,
+		// not an array. The document is valid syntax (S3.5) — surface the type
+		// constraint as a ResolveError naming THIS file. The conversion lives
+		// at the ParseBytes site (not in loadIncludeFile) so nested include
+		// chains name the innermost file that actually has the array root.
+		if errors.Is(err, parser.ErrArrayAtRoot) {
+			return nil, &ResolveError{
+				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", filePath),
+				FilePath: filePath,
+				Cause:    err,
+			}
+		}
 		return nil, err
 	}
 	childResolver := &resolver{
@@ -1745,15 +1745,6 @@ func (r *resolver) loadPackageInclude(identifier, file string) (*ObjectVal, erro
 	virtualPath := fmt.Sprintf("package:%s:%s", identifier, file)
 	obj, err := r.parseAndResolvePackage(content, virtualPath)
 	if err != nil {
-		// S14b.1: registered package content with an array root — same type
-		// constraint as file includes, naming the virtual package path.
-		if errors.Is(err, parser.ErrArrayAtRoot) {
-			return nil, &ResolveError{
-				Message: fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", virtualPath),
-				Path:    virtualPath,
-				Cause:   err,
-			}
-		}
 		return nil, err
 	}
 	return obj, nil
@@ -1765,9 +1756,19 @@ func (r *resolver) loadPackageInclude(identifier, file string) (*ObjectVal, erro
 func (r *resolver) parseAndResolvePackage(data []byte, virtualPath string) (*ObjectVal, error) {
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
+		// S14b.1: registered package content with an array root — same type
+		// constraint as file includes, naming the virtual package path.
+		// Converted here (the ParseBytes site) so nested chains name the
+		// innermost source.
+		if errors.Is(err, parser.ErrArrayAtRoot) {
+			return nil, &ResolveError{
+				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", virtualPath),
+				FilePath: virtualPath,
+				Cause:    err,
+			}
+		}
 		// Wrap raw parser error with package context so the user knows which
-		// package failed. Cause preserves the chain so callers (e.g. the S3.5
-		// ErrArrayAtRoot check in loadPackageInclude) can errors.Is through it.
+		// package failed. Cause preserves the chain for errors.Is/As.
 		return nil, &ResolveError{
 			Message:  fmt.Sprintf("in %s: %s", virtualPath, err.Error()),
 			FilePath: virtualPath,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -9,6 +9,7 @@
 package resolver
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1645,6 +1646,18 @@ func (r *resolver) loadIncludeFile(path string, required bool) (*ObjectVal, erro
 	// itself (parseRoot returns an empty ObjectNode for an EOF-only stream).
 	obj, err := r.parseAndResolve(data, path)
 	if err != nil {
+		// S14b.1 (HOCON.md L993-994): an included file must contain an object,
+		// not an array. The document is valid syntax (S3.5) — surface the type
+		// constraint as a ResolveError naming the included file, matching
+		// Lightbend's forceParsedToObject on the include path.
+		if errors.Is(err, parser.ErrArrayAtRoot) {
+			return nil, &ResolveError{
+				Message:  fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", path),
+				Path:     path,
+				FilePath: path,
+				Cause:    err,
+			}
+		}
 		return nil, err
 	}
 
@@ -1732,6 +1745,15 @@ func (r *resolver) loadPackageInclude(identifier, file string) (*ObjectVal, erro
 	virtualPath := fmt.Sprintf("package:%s:%s", identifier, file)
 	obj, err := r.parseAndResolvePackage(content, virtualPath)
 	if err != nil {
+		// S14b.1: registered package content with an array root — same type
+		// constraint as file includes, naming the virtual package path.
+		if errors.Is(err, parser.ErrArrayAtRoot) {
+			return nil, &ResolveError{
+				Message: fmt.Sprintf("included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): %s", virtualPath),
+				Path:    virtualPath,
+				Cause:   err,
+			}
+		}
 		return nil, err
 	}
 	return obj, nil
@@ -1743,10 +1765,13 @@ func (r *resolver) loadPackageInclude(identifier, file string) (*ObjectVal, erro
 func (r *resolver) parseAndResolvePackage(data []byte, virtualPath string) (*ObjectVal, error) {
 	ast, err := parser.ParseBytes(data)
 	if err != nil {
-		// Wrap raw parser error with package context so the user knows which package failed.
+		// Wrap raw parser error with package context so the user knows which
+		// package failed. Cause preserves the chain so callers (e.g. the S3.5
+		// ErrArrayAtRoot check in loadPackageInclude) can errors.Is through it.
 		return nil, &ResolveError{
 			Message:  fmt.Sprintf("in %s: %s", virtualPath, err.Error()),
 			FilePath: virtualPath,
+			Cause:    err,
 		}
 	}
 	childResolver := &resolver{

--- a/s3_5_array_root_test.go
+++ b/s3_5_array_root_test.go
@@ -128,12 +128,20 @@ func TestS3_5_IncludeOfArrayRootNamesIncludedFile(t *testing.T) {
 	if !strings.Contains(re.Message, "array at file root") {
 		t.Errorf("message must name the array-at-file-root condition, got: %s", re.Message)
 	}
+	// The included-source identity is carried in FilePath (rendered by
+	// Error()), not embedded in Message.
+	if !strings.Contains(re.FilePath, "arr.conf") {
+		t.Errorf("FilePath must name the included file, got: %q", re.FilePath)
+	}
 	if !strings.Contains(err.Error(), "arr.conf") {
-		t.Errorf("error must name the included file, got: %v", err)
+		t.Errorf("rendered error must name the included file, got: %v", err)
 	}
 }
 
 func TestS3_5_PackageIncludeOfArrayRootIsError(t *testing.T) {
+	// Global registry isolation (same idiom as e11_include_package_test.go).
+	hocon.ResetPackageRegistry()
+	t.Cleanup(hocon.ResetPackageRegistry)
 	if err := hocon.RegisterPackage("test/s3-5-array-root", "ref.conf", []byte("[1,2]\n")); err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -220,17 +228,20 @@ func TestS3_5_NestedIncludeNamesInnermostFile(t *testing.T) {
 	if !errors.As(err, &re) {
 		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
 	}
-	if !strings.Contains(re.Message, "arr.conf") {
-		t.Errorf("error must name the innermost file arr.conf, got: %s", re.Message)
+	if !strings.Contains(re.FilePath, "arr.conf") {
+		t.Errorf("FilePath must name the innermost file arr.conf, got: %q", re.FilePath)
 	}
-	if strings.Contains(re.Message, "mid.conf") {
-		t.Errorf("error must not accuse the intermediate file mid.conf, got: %s", re.Message)
+	if strings.Contains(re.FilePath, "mid.conf") || strings.Contains(re.Message, "mid.conf") {
+		t.Errorf("error must not accuse the intermediate file mid.conf, got: %v", re)
 	}
 }
 
 // TestS3_5_FileIncludesPackageWithArrayRoot pins the file -> package nesting
 // direction: the error names the package virtual path, not the including file.
 func TestS3_5_FileIncludesPackageWithArrayRoot(t *testing.T) {
+	// Global registry isolation (same idiom as e11_include_package_test.go).
+	hocon.ResetPackageRegistry()
+	t.Cleanup(hocon.ResetPackageRegistry)
 	if err := hocon.RegisterPackage("test/s3-5-nested-pkg", "ref.conf", []byte("[1,2]\n")); err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -251,10 +262,10 @@ func TestS3_5_FileIncludesPackageWithArrayRoot(t *testing.T) {
 	if !errors.As(err, &re) {
 		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
 	}
-	if !strings.Contains(re.Message, "test/s3-5-nested-pkg") {
-		t.Errorf("error must name the package virtual path, got: %s", re.Message)
+	if !strings.Contains(re.FilePath, "test/s3-5-nested-pkg") {
+		t.Errorf("FilePath must name the package virtual path, got: %q", re.FilePath)
 	}
-	if strings.Contains(re.Message, "mid.conf") {
-		t.Errorf("error must not accuse the including file mid.conf, got: %s", re.Message)
+	if strings.Contains(re.FilePath, "mid.conf") || strings.Contains(re.Message, "mid.conf") {
+		t.Errorf("error must not accuse the including file mid.conf, got: %v", re)
 	}
 }

--- a/s3_5_array_root_test.go
+++ b/s3_5_array_root_test.go
@@ -192,3 +192,69 @@ func TestS3_5_ArrayRoot_Conformance(t *testing.T) {
 		})
 	}
 }
+
+// TestS3_5_NestedIncludeNamesInnermostFile pins that a nested include chain
+// (parent -> mid -> arr) names the innermost file that actually has the array
+// root — not an intermediate file. Regression guard for the conversion living
+// at the ParseBytes site rather than in loadIncludeFile (where errors.Is
+// re-fired at each level and re-wrapped with the outer file's path).
+func TestS3_5_NestedIncludeNamesInnermostFile(t *testing.T) {
+	dir := t.TempDir()
+	arrFile := filepath.Join(dir, "arr.conf")
+	if err := os.WriteFile(arrFile, []byte("[1,2]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	midFile := filepath.Join(dir, "mid.conf")
+	if err := os.WriteFile(midFile, []byte("include \"arr.conf\"\nb = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	if err := os.WriteFile(mainFile, []byte("include \"mid.conf\"\na = 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := hocon.ParseFile(mainFile)
+	if err == nil {
+		t.Fatal("expected array-at-file-root error through the nested chain, got nil")
+	}
+	var re *hocon.ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Message, "arr.conf") {
+		t.Errorf("error must name the innermost file arr.conf, got: %s", re.Message)
+	}
+	if strings.Contains(re.Message, "mid.conf") {
+		t.Errorf("error must not accuse the intermediate file mid.conf, got: %s", re.Message)
+	}
+}
+
+// TestS3_5_FileIncludesPackageWithArrayRoot pins the file -> package nesting
+// direction: the error names the package virtual path, not the including file.
+func TestS3_5_FileIncludesPackageWithArrayRoot(t *testing.T) {
+	if err := hocon.RegisterPackage("test/s3-5-nested-pkg", "ref.conf", []byte("[1,2]\n")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	dir := t.TempDir()
+	midFile := filepath.Join(dir, "mid.conf")
+	if err := os.WriteFile(midFile, []byte("include package(\"test/s3-5-nested-pkg\", \"ref.conf\")\nb = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	if err := os.WriteFile(mainFile, []byte("include \"mid.conf\"\na = 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := hocon.ParseFile(mainFile)
+	if err == nil {
+		t.Fatal("expected array-at-file-root error through the file->package chain, got nil")
+	}
+	var re *hocon.ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Message, "test/s3-5-nested-pkg") {
+		t.Errorf("error must name the package virtual path, got: %s", re.Message)
+	}
+	if strings.Contains(re.Message, "mid.conf") {
+		t.Errorf("error must not accuse the including file mid.conf, got: %s", re.Message)
+	}
+}

--- a/s3_5_array_root_test.go
+++ b/s3_5_array_root_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// S3.5 — an array-root document ([1,2]) is syntactically valid HOCON
+// (HOCON.md L989-991: "both JSON and HOCON allow arrays as root values in a
+// document"), but the object-rooted Config API rejects it with a TYPE error
+// after a successful syntax parse. Reference: Lightbend parses the document,
+// then Parseable.forceParsedToObject throws ConfigException.WrongType "has
+// type LIST rather than object at file root". The former behavior — a parse
+// error "expected key" — was the right net outcome (reject) as the wrong kind
+// of error at the wrong layer.
+//
+// S14b.1 (HOCON.md L993-994): an INCLUDED file with an array root is invalid;
+// the error names the included file.
+//
+// Fixtures: xx.hocon array-root/ar01-ar03 with .error sidecars (see
+// TestS3_5_ArrayRoot_Conformance for the fixture loop).
+
+package hocon_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	hocon "github.com/o3co/go.hocon"
+)
+
+// requireConfigError asserts err is a *hocon.ConfigError (the type-mismatch
+// class — Lightbend WrongType analog) and NOT a *hocon.ParseError.
+func requireConfigError(t *testing.T, err error, label string) *hocon.ConfigError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected ConfigError, got nil", label)
+	}
+	var pe *hocon.ParseError
+	if errors.As(err, &pe) {
+		t.Fatalf("%s: got ParseError %q; array-root documents are valid syntax — expected the type-error class", label, pe.Message)
+	}
+	var ce *hocon.ConfigError
+	if !errors.As(err, &ce) {
+		t.Fatalf("%s: expected *hocon.ConfigError, got %T: %v", label, err, err)
+	}
+	if !strings.Contains(ce.Message, "array rather than object at file root") {
+		t.Errorf("%s: message must name the array-at-file-root condition, got: %s", label, ce.Message)
+	}
+	return ce
+}
+
+func TestS3_5_ArrayRoot_TopLevelIsTypeError(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"basic", "[1,2]"},
+		{"multiline-objects", "[\n  { a : 1 },\n  { b : 2 }\n]\n"},
+		{"empty-array", "[]"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := hocon.ParseString(tc.src)
+			requireConfigError(t, err, tc.name)
+		})
+	}
+}
+
+func TestS3_5_ArrayRoot_ErrorCarriesPosition(t *testing.T) {
+	_, err := hocon.ParseString("\n  [1,2]")
+	ce := requireConfigError(t, err, "position")
+	if !strings.Contains(ce.Message, "2:3") {
+		t.Errorf("message must carry the opening bracket position 2:3, got: %s", ce.Message)
+	}
+}
+
+func TestS3_5_ArrayRoot_DeferredLifecycle(t *testing.T) {
+	_, err := hocon.ParseStringWithOptions("[1,2]", hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+	requireConfigError(t, err, "deferred")
+}
+
+func TestS3_5_MalformedArraysStaySyntaxErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"unterminated", "[1,2"},
+		{"trailing-content", "[1,2]\na = 1"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := hocon.ParseString(tc.src)
+			var pe *hocon.ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("%s: expected *hocon.ParseError (syntax), got %T: %v", tc.name, err, err)
+			}
+		})
+	}
+}
+
+func TestS3_5_IncludeOfArrayRootNamesIncludedFile(t *testing.T) {
+	dir := t.TempDir()
+	arrFile := filepath.Join(dir, "arr.conf")
+	if err := os.WriteFile(arrFile, []byte("[1,2]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainFile := filepath.Join(dir, "parent.conf")
+	slashArr := strings.ReplaceAll(arrFile, "\\", "/")
+	if err := os.WriteFile(mainFile, []byte(fmt.Sprintf("include \"%s\"\na = 1\n", slashArr)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := hocon.ParseFile(mainFile)
+	if err == nil {
+		t.Fatal("expected error for include of array-root file (HOCON.md L993-994), got nil")
+	}
+	var re *hocon.ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Message, "array at file root") {
+		t.Errorf("message must name the array-at-file-root condition, got: %s", re.Message)
+	}
+	if !strings.Contains(err.Error(), "arr.conf") {
+		t.Errorf("error must name the included file, got: %v", err)
+	}
+}
+
+func TestS3_5_PackageIncludeOfArrayRootIsError(t *testing.T) {
+	if err := hocon.RegisterPackage("test/s3-5-array-root", "ref.conf", []byte("[1,2]\n")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	_, err := hocon.ParseString("include package(\"test/s3-5-array-root\", \"ref.conf\")\na = 1")
+	if err == nil {
+		t.Fatal("expected error for package include of array-root content, got nil")
+	}
+	var re *hocon.ResolveError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *hocon.ResolveError, got %T: %v", err, err)
+	}
+	if !strings.Contains(re.Message, "array at file root") {
+		t.Errorf("message must name the array-at-file-root condition, got: %s", re.Message)
+	}
+}
+
+func TestS3_5_NonRootArraysUnaffected(t *testing.T) {
+	cfg, err := hocon.ParseString("a = [1,2]")
+	if err != nil {
+		t.Fatalf("field-value array: %v", err)
+	}
+	if got := cfg.GetIntSlice("a"); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("a = %v, want [1 2]", got)
+	}
+	if _, err := hocon.ParseString("{ a = [1,2] }"); err != nil {
+		t.Errorf("braced root with array field: %v", err)
+	}
+}
+
+// TestS3_5_ArrayRoot_Conformance loops the xx.hocon array-root fixtures
+// (ar01-ar03, .error sidecars — Lightbend WrongType ground truth).
+// ar03-inner.conf is a sibling include-target, not a standalone fixture.
+func TestS3_5_ArrayRoot_Conformance(t *testing.T) {
+	fixtureDir := filepath.Join("testdata", "hocon", "array-root")
+	if _, err := os.Stat(fixtureDir); err != nil {
+		t.Skipf("array-root fixtures missing at %s; run `make testdata` (requires xx.hocon#64)", fixtureDir)
+	}
+	entries, err := filepath.Glob(filepath.Join(fixtureDir, "ar*.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, conf := range entries {
+		conf := conf
+		name := filepath.Base(conf)
+		if strings.HasSuffix(name, "-inner.conf") {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			_, err := hocon.ParseFile(conf)
+			if err == nil {
+				t.Fatalf("%s: expected array-at-file-root error, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "array") || !strings.Contains(err.Error(), "file root") {
+				t.Errorf("%s: error must name the array-at-file-root condition, got: %v", name, err)
+			}
+		})
+	}
+}

--- a/s3_5_array_root_test.go
+++ b/s3_5_array_root_test.go
@@ -68,7 +68,7 @@ func TestS3_5_ArrayRoot_TopLevelIsTypeError(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := hocon.ParseString(tc.src)
-			requireConfigError(t, err, tc.name)
+			_ = requireConfigError(t, err, tc.name)
 		})
 	}
 }
@@ -83,7 +83,7 @@ func TestS3_5_ArrayRoot_ErrorCarriesPosition(t *testing.T) {
 
 func TestS3_5_ArrayRoot_DeferredLifecycle(t *testing.T) {
 	_, err := hocon.ParseStringWithOptions("[1,2]", hocon.DefaultParseOptions().WithResolveSubstitutions(false))
-	requireConfigError(t, err, "deferred")
+	_ = requireConfigError(t, err, "deferred")
 }
 
 func TestS3_5_MalformedArraysStaySyntaxErrors(t *testing.T) {

--- a/s3_5_array_root_test.go
+++ b/s3_5_array_root_test.go
@@ -81,6 +81,29 @@ func TestS3_5_ArrayRoot_ErrorCarriesPosition(t *testing.T) {
 	}
 }
 
+func TestS3_5_ArrayRoot_FileOriginNamed(t *testing.T) {
+	// ParseFile prefixes the ConfigError with the file path (Lightbend origin
+	// parity; the rs/py siblings behave the same).
+	dir := t.TempDir()
+	arrFile := filepath.Join(dir, "arr.conf")
+	if err := os.WriteFile(arrFile, []byte("[1,2]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := hocon.ParseFile(arrFile)
+	ce := requireConfigError(t, err, "file origin")
+	if !strings.Contains(ce.Message, "arr.conf") {
+		t.Errorf("file parse must name the file in the origin, got: %s", ce.Message)
+	}
+}
+
+func TestS3_5_ArrayRoot_CustomOriginNamed(t *testing.T) {
+	_, err := hocon.ParseStringWithOptions("[1,2]", hocon.DefaultParseOptions().WithOriginDescription("my-source"))
+	ce := requireConfigError(t, err, "custom origin")
+	if !strings.Contains(ce.Message, "my-source") {
+		t.Errorf("message must carry the custom origin, got: %s", ce.Message)
+	}
+}
+
 func TestS3_5_ArrayRoot_DeferredLifecycle(t *testing.T) {
 	_, err := hocon.ParseStringWithOptions("[1,2]", hocon.DefaultParseOptions().WithResolveSubstitutions(false))
 	_ = requireConfigError(t, err, "deferred")
@@ -135,6 +158,10 @@ func TestS3_5_IncludeOfArrayRootNamesIncludedFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "arr.conf") {
 		t.Errorf("rendered error must name the included file, got: %v", err)
+	}
+	// The cause chain survives the public wrapping (ResolveError.Unwrap).
+	if errors.Unwrap(re) == nil {
+		t.Error("ResolveError must expose its Cause via Unwrap")
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements S3.5 from [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64): an array-root document (`[1,2]`) is **syntactically valid HOCON** (HOCON.md L989-991); the reference implementation parses it, then rejects at the Config boundary via `Parseable.forceParsedToObject` with `ConfigException.WrongType` "has type LIST rather than object at file root". Previously go.hocon rejected with a parse error "expected key" — the right net outcome as the wrong kind of error at the wrong layer.

Sibling PR: [ts.hocon#154](https://github.com/o3co/ts.hocon/pull/154).

## Changes

- **Parser** — `parseRoot` parses the array fully on `[` at root (malformed arrays and trailing content stay syntax errors) and returns the `parser.ErrArrayAtRoot` sentinel with the bracket position.
- **Config boundary** — `parseWithOptions` maps the sentinel to `*ConfigError` with origin prefix + position, ahead of the `ParseError` mapping (covers the deferred lifecycle). `ConfigError.Error()` omits the path clause when `Path` is empty (file-root errors have no access path).
- **Include paths** — the sentinel converts to `*ResolveError` "included file has array at file root … (HOCON.md L993-994)" **at the `ParseBytes` sites** (`parseAndResolve` / `parseAndResolvePackage`) so nested include chains name the **innermost** file that actually has the array root (review-caught: a post-hoc check in `loadIncludeFile` re-fired per level and accused intermediate files). `FilePath` carries the source; `Path` stays a substitution-path field. The package-content wrapper now preserves `Cause` for `errors.Is` traversal.
- **Makefile** — `array-root/` fixture group synced (guarded), and the fast-path predicate requires the group so a stale cache cannot silently skip the conformance suite.
- **Tests** — TDD RED→GREEN: type-error class + position + deferred pins, malformed guards, include/package variants, **nested-chain regression tests** (file→file→array, file→package→array), conformance ar01–ar03 loop (skip-guard until xx#64 merges).
- **Docs** — spec-compliance S3.5 added (210 items) + S14b.1 notes; CHANGELOG.

**Net behavior unchanged** — array-root documents still error; only the error class, layer, and message change. No public API changes (`ConfigError` / `ResolveError` are existing exported types).

## Verification

- RED observed first (5 suites failing on the old classification); GREEN: all packages ok, `go vet` clean, `gofmt` clean.
- Multi-agent review (Claude + Codex): the Critical (nested-include mislabeling, empirically confirmed by the reviewer) and both Codex P2s (package `Path`/`FilePath` metadata, Makefile cache fast-path) addressed in the follow-up commit, plus error-rendering/doc/test-harness minors.

## Cross-impl

rs.hocon / py.hocon PRs follow; matrix roll-up in xx.hocon once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)