### PR TITLE
release(v1.9.0): finalize CHANGELOG for the cross-impl spec-correction minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-23
+
+Cross-impl release coordinated to land at v1.9.0 across ts.hocon / go.hocon / rs.hocon / py.hocon. Covers the two same-day spec corrections from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62) (S3.1 — empty document parses to `{}`) and [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64) (S3.5 — array-root document rejected with a type error). MINOR (not PATCH): go adds public API surface (`ResolveError.Cause` field + `Unwrap()` method — additive, enables `errors.Is/As` traversal), and the error-taxonomy / empty-document behavior changes are consumer-observable. The tag is the version (no version file).
+
 ### Fixed — array-root document rejected with a type error (S3.5, [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64))
 
 - **`ParseString("[1,2]")` now returns `*ConfigError` ("document has type array rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.9.0] - 2026-07-23
 
-Cross-impl release coordinated to land at v1.9.0 across ts.hocon / go.hocon / rs.hocon / py.hocon. Covers the two same-day spec corrections from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62) (S3.1 — empty document parses to `{}`) and [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64) (S3.5 — array-root document rejected with a type error). MINOR (not PATCH): go adds public API surface (`ResolveError.Cause` field + `Unwrap()` method — additive, enables `errors.Is/As` traversal), and the error-taxonomy / empty-document behavior changes are consumer-observable. The tag is the version (no version file).
+Cross-impl release coordinated to land at v1.9.0 across ts.hocon / go.hocon / rs.hocon / py.hocon. Covers the two same-day spec corrections from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62) (S3.1 — empty document parses to `{}`) and [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64) (S3.5 — array-root document rejected with a type error). MINOR (not PATCH): go adds public API surface (`ResolveError.Cause` field + `Unwrap()` method — additive, enables `errors.Is`/`errors.As` traversal), and the error-taxonomy / empty-document behavior changes are consumer-observable. The tag is the version (no version file).
 
 ### Fixed — array-root document rejected with a type error (S3.5, [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64))
 


### PR DESCRIPTION
Cross-impl v1.9.0 (ts / go / rs / py). Ships S3.1 (empty document → `{}`) and S3.5 (array-root type error; adds public `ResolveError.Cause` + `Unwrap` — additive). Tag is the version per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)