### PR TITLE
fix(resolver): whitespace-separated undefined optionals materialize the separator (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — whitespace-separated undefined optionals materialize the separator ([#158](https://github.com/o3co/go.hocon/issues/158))
+
+- **`cf = ${?vv} ${?vv}` (all operands undefined, whitespace between) now yields
+  `cf = " "` instead of dropping the field**, matching the reference
+  implementation and the ts/rs/py siblings. Per HOCON.md §Substitutions an
+  undefined `${?foo}` becomes an empty string inside a value concatenation with
+  another string — the inter-token whitespace is that string. The spec's
+  field-drop example (`foo : ${?bar}${?baz}`, no whitespace) still drops the
+  field. Found by the harvested ecosystem corpus
+  ([xx.hocon#66](https://github.com/o3co/xx.hocon/pull/66),
+  `mikai233-hocon-rs/concat3.conf`). Pinned by
+  `issue158_ws_only_optional_concat_test.go`.
+
 ## [1.9.0] - 2026-07-23
 
 Cross-impl release coordinated to land at v1.9.0 across ts.hocon / go.hocon / rs.hocon / py.hocon. Covers the two same-day spec corrections from [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62) (S3.1 — empty document parses to `{}`) and [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64) (S3.5 — array-root document rejected with a type error). MINOR (not PATCH): go adds public API surface (`ResolveError.Cause` field + `Unwrap()` method — additive, enables `errors.Is`/`errors.As` traversal), and the error-taxonomy / empty-document behavior changes are consumer-observable. The tag is the version (no version file).

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1168,14 +1168,28 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string, line,
 		}
 	}
 
-	// Per HOCON spec § "Optional substitution materialisation in concat contexts":
-	// when the entire concat consists only of undefined optional substitutions
-	// (all operands resolved to nil, no real scalar/array/object content),
-	// the field is omitted — return nil so the parent drops this key.
-	// This differs from a mixed concat like `${?x} "tail"` where the separator
-	// and the literal "tail" count as concrete values.
+	// When the entire concat consists only of undefined optional substitutions
+	// (all operands resolved to nil, no real scalar/array/object content), the
+	// outcome depends on whether separator whitespace sits between them
+	// (issue #158, HOCON.md §Substitutions):
+	//   - `${?a}${?b}`  → no separators → the field is omitted (the spec's own
+	//     field-drop example) — return nil so the parent drops this key.
+	//   - `${?a} ${?b}` → each undefined operand becomes an empty string in the
+	//     concatenation and the separator whitespace survives, yielding " "
+	//     (reference behaviour) — fall through to concatStrings, which skips
+	//     nils and keeps separator tokens.
 	if !hasConcreteValue {
-		return nil, nil
+		hasSeparator := false
+		for _, rv := range resolved {
+			if rv != nil && isSeparator(rv) {
+				hasSeparator = true
+				break
+			}
+		}
+		if !hasSeparator {
+			return nil, nil
+		}
+		return r.concatStrings(resolved), nil
 	}
 
 	// Pure-scalar concat: pass the full resolved slice (including whitespace-separator

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1176,7 +1176,7 @@ func (r *resolver) resolveConcat(vals []Val, root *ObjectVal, path string, line,
 	//     field-drop example) — return nil so the parent drops this key.
 	//   - `${?a} ${?b}` → each undefined operand becomes an empty string in the
 	//     concatenation and the separator whitespace survives, yielding " "
-	//     (reference behaviour) — fall through to concatStrings, which skips
+	//     (reference behaviour) — return the concatStrings result, which skips
 	//     nils and keeps separator tokens.
 	if !hasConcreteValue {
 		hasSeparator := false

--- a/issue158_ws_only_optional_concat_test.go
+++ b/issue158_ws_only_optional_concat_test.go
@@ -1,0 +1,89 @@
+package hocon_test
+
+import (
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// Issue #158: a value concatenation consisting solely of undefined optional
+// substitutions SEPARATED BY WHITESPACE must materialize the separator
+// whitespace as a string, matching the reference implementation
+// (`cf = ${?vv} ${?vv}` → "cf": " ").
+//
+// HOCON.md §Substitutions: an undefined ${?foo} "should become an empty
+// string" when part of a value concatenation with another string — the
+// inter-token whitespace is that other string. The spec's field-drop example
+// (`foo : ${?bar}${?baz}`) has no whitespace between the substitutions and
+// keeps dropping the field (covered below as a guard).
+
+func TestIssue158_WhitespaceSeparatedUndefinedOptionalsKeepField(t *testing.T) {
+	cfg, err := hocon.ParseString("cf = ${?vv} ${?vv}\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.Has("cf") {
+		t.Fatalf(`cf dropped; want cf = " " (reference behaviour)`)
+	}
+	if got := cfg.GetString("cf"); got != " " {
+		t.Errorf("cf = %q, want %q", got, " ")
+	}
+}
+
+func TestIssue158_ThreeUndefinedOptionalsTwoSeparators(t *testing.T) {
+	cfg, err := hocon.ParseString("cf = ${?a} ${?b} ${?c}\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("cf"); got != "  " {
+		t.Errorf("cf = %q, want two spaces", got)
+	}
+}
+
+// Guard: the spec's own example — adjacent undefined optionals with NO
+// whitespace still drop the field (all five parsers agree here).
+func TestIssue158_AdjacentUndefinedOptionalsStillDropField(t *testing.T) {
+	cfg, err := hocon.ParseString("x = ${?a}${?b}\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Has("x") {
+		t.Errorf("x = %q; want field dropped (HOCON.md §Substitutions example)", cfg.GetString("x"))
+	}
+}
+
+// Array-element context takes the same concat path: pre-fix `[${?a} ${?b}]`
+// resolved to []; the materialized separator now yields [" "].
+func TestIssue158_ArrayElementContext(t *testing.T) {
+	cfg, err := hocon.ParseString("arr = [${?a} ${?b}]\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := cfg.GetStringSlice("arr")
+	if len(got) != 1 || got[0] != " " {
+		t.Errorf("arr = %q, want [\" \"]", got)
+	}
+}
+
+// Boundary between drop and materialize: an adjacent undefined pair plus a
+// whitespace-separated third still materializes the one separator.
+func TestIssue158_AdjacentPairPlusSeparatedThird(t *testing.T) {
+	cfg, err := hocon.ParseString("cf = ${?a}${?b} ${?c}\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("cf"); got != " " {
+		t.Errorf("cf = %q, want %q", got, " ")
+	}
+}
+
+// Guard: partial-vanish concat keeps working (leading separator preserved).
+func TestIssue158_PartialVanishKeepsSeparator(t *testing.T) {
+	cfg, err := hocon.ParseString("y = ${?vv} 1\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.GetString("y"); got != " 1" {
+		t.Errorf("y = %q, want %q", got, " 1")
+	}
+}


### PR DESCRIPTION
Fixes #158.

A value concatenation consisting solely of undefined optional substitutions **separated by whitespace** dropped the field; the reference implementation (and the ts/rs/py siblings) yields the surviving separator whitespace as a string:

```hocon
cf = ${?vv} ${?vv}   # reference: cf = " "   go.hocon (before): field dropped
```

## Change

In the all-operands-nil branch of `resolveConcat`, return nil (drop the field) only when **no separator token** is present; otherwise fall through to `concatStrings`, which skips nils and keeps separator tokens. The spec's no-whitespace field-drop example (`foo : ${?bar}${?baz}`) is unchanged — separator presence is exactly the discriminator (separators are only ever created *between* two concat operands).

## Spec basis

HOCON.md §Substitutions: an undefined `${?foo}` "should become an empty string" when part of a value concatenation with another string — the inter-token whitespace is that string. The field-drop example covers only the adjacent (no-whitespace) form.

## Tests

`issue158_ws_only_optional_concat_test.go`: bug case (`" "`), three-substitution case (`"  "`), adjacent-pair-plus-separated-third boundary (`" "`), array-element context (`[${?a} ${?b}]` → `[" "]`, a deliberate behaviour change pinned per review), spec-guard (`${?a}${?b}` still drops), partial-vanish guard (`${?vv} 1` → `" 1"`). Full suite green (`make testdata` + `go test ./...`).

Verified against the harvested ecosystem corpus (xx.hocon#66): `mikai233-hocon-rs/concat3.conf` now matches the reference-generated expected JSON.

Reviewed pre-PR via multi-agent-review (Claude reviewer; Codex unavailable on this machine) — verdict "ready", with the two recommended test additions included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)