### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-25
+
 ### Added — `adapters/`, a nested module for reading foreign config formats
 
 - **`include`-adjacent formats owned by other programs can now be mounted as
@@ -48,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (including surrogate pairs), escaped separators (`\:` `\=` `\ `) belonging to
   the key, whitespace alone as a separator, `\r\n` and bare `\r` line endings,
   and UTF-8 validation.
-- **Behaviour change**: trailing whitespace in a value is now **preserved**.
+- **Behavior change**: trailing whitespace in a value is now **preserved**.
   Java skips whitespace before a value but never after it, so `key = value  `
   yields `"value  "`. The previous parser trimmed both ends.
 - A malformed escape (an unpaired `\uXXXX` surrogate, a truncated one) is now a


### PR DESCRIPTION
Finalizes the CHANGELOG for **1.10.0**, the format-adapters + `.properties`-syntax
minor. No source change beyond the release-prep itself.

## Why minor, not major

- The adapters are **additive** — a new nested module, nothing in the existing API moves.
- The `.properties` fix is a spec correction. The precedent is set: S19.8, a
  `fix!`, shipped as a minor in 1.9.0.
- Version is the git tag; there is no manifest to bump.

Behaviour note carried in the CHANGELOG: a `.properties` value now keeps its
trailing whitespace, matching `java.util.Properties` (Java skips whitespace
before a value, never after it).

The feature work is already on `main` (adapters + syntax fix); this PR only adds
the CHANGELOG entries that landed without them and marks the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)