### PR TITLE
feat: Config.RenderHOCON() — HOCON text emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `Config.RenderHOCON()`, a HOCON text emitter
+
+- **A resolved config can now be rendered back to HOCON text**, the missing
+  reverse of parsing. `RenderHOCON()` walks the value tree (objects, arrays,
+  string / number / boolean / null scalars — exactly what `FromMap` and the
+  format adapters produce) and returns idiomatic HOCON: root fields without
+  enclosing braces, nested objects as `key { … }`, arrays newline-separated,
+  two-space indent.
+- The contract is **round-trip**, not byte formatting: parsing the output
+  yields the same tree. A scalar is quoted whenever leaving it bare would
+  re-parse as a different type (a string `"8080"` stays a string, `no` stays a
+  string, an empty or space-padded value is quoted); a multi-line value is
+  triple-quoted when that is lossless and escaped in double quotes otherwise.
+  An unresolved placeholder is an error — substitutions have no textual round
+  trip through a value tree.
+- This is the core half of the reverse-conversion work tracked in
+  [xx.hocon#74](https://github.com/o3co/xx.hocon/issues/74); hocon2's
+  `xxx2hocon` commands build on it.
+
 ## [1.10.0] - 2026-07-25
 
 ### Added — `adapters/`, a nested module for reading foreign config formats

--- a/render_hocon.go
+++ b/render_hocon.go
@@ -1,0 +1,187 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/o3co/go.hocon/internal/resolver"
+)
+
+// RenderHOCON renders a resolved Config as HOCON text.
+//
+// The output round-trips: parsing it back yields the same value tree. That is
+// the correctness contract, not byte-for-byte formatting — a scalar is quoted
+// whenever leaving it bare would re-parse as a different type (a string "8080"
+// becomes "8080", not 8080), and left bare only when it provably cannot.
+//
+// The Config must be resolved and hold only data (objects, arrays, string /
+// number / boolean / null scalars) — exactly what FromMap and the format
+// adapters produce. An unresolved placeholder is an error; substitutions have
+// no textual round trip through a value tree.
+//
+// The root object's fields are emitted without enclosing braces, nested
+// objects as `key { … }`, arrays as newline-separated `[ … ]`, indented two
+// spaces. Source comments are not represented — a value tree does not carry
+// them.
+func (c *Config) RenderHOCON() (string, error) {
+	var b strings.Builder
+	if err := renderObjectBody(&b, c.root, 0); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func renderObjectBody(b *strings.Builder, o *resolver.ObjectVal, depth int) error {
+	indent := strings.Repeat("  ", depth)
+	for _, k := range o.Keys() {
+		// Keys() lists only present keys, so Get always succeeds; a nil here
+		// would fall through to renderValue's error rather than be skipped.
+		v, _ := o.Get(k)
+		b.WriteString(indent)
+		b.WriteString(renderKey(k))
+		switch child := v.(type) {
+		case *resolver.ObjectVal:
+			b.WriteString(" {")
+			if len(child.Keys()) == 0 {
+				b.WriteString("}\n")
+				continue
+			}
+			b.WriteString("\n")
+			if err := renderObjectBody(b, child, depth+1); err != nil {
+				return err
+			}
+			b.WriteString(indent)
+			b.WriteString("}\n")
+		default:
+			b.WriteString(" = ")
+			if err := renderValue(b, v, depth); err != nil {
+				return err
+			}
+			b.WriteString("\n")
+		}
+	}
+	return nil
+}
+
+func renderValue(b *strings.Builder, v resolver.Val, depth int) error {
+	switch x := v.(type) {
+	case *resolver.ObjectVal:
+		if len(x.Keys()) == 0 {
+			b.WriteString("{}")
+			return nil
+		}
+		b.WriteString("{\n")
+		if err := renderObjectBody(b, x, depth+1); err != nil {
+			return err
+		}
+		b.WriteString(strings.Repeat("  ", depth))
+		b.WriteString("}")
+		return nil
+	case *resolver.ArrayVal:
+		return renderArray(b, x, depth)
+	case *resolver.ScalarVal:
+		b.WriteString(renderScalar(x))
+		return nil
+	}
+	return fmt.Errorf("RenderHOCON: unrenderable value %T (config must be resolved data)", v)
+}
+
+func renderArray(b *strings.Builder, a *resolver.ArrayVal, depth int) error {
+	if len(a.Elements) == 0 {
+		b.WriteString("[]")
+		return nil
+	}
+	inner := strings.Repeat("  ", depth+1)
+	b.WriteString("[\n")
+	for _, e := range a.Elements {
+		b.WriteString(inner)
+		if err := renderValue(b, e, depth+1); err != nil {
+			return err
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(strings.Repeat("  ", depth))
+	b.WriteString("]")
+	return nil
+}
+
+func renderScalar(s *resolver.ScalarVal) string {
+	switch s.Type {
+	case resolver.ScalarNull:
+		return "null"
+	case resolver.ScalarBoolean, resolver.ScalarNumber:
+		// Raw already holds the canonical textual form; both re-parse to their
+		// own type, so they are emitted bare.
+		return s.Raw
+	default:
+		return renderString(s.Raw)
+	}
+}
+
+// safeUnquotedKey matches a key that is unambiguous unquoted: no dot (which
+// would nest), no whitespace, no forbidden character.
+var safeUnquotedKey = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+func renderKey(k string) string {
+	if safeUnquotedKey.MatchString(k) {
+		return k
+	}
+	return quoteString(k)
+}
+
+// safeBareString matches a string value that cannot be misread as another
+// type: an identifier that is not a boolean/null keyword and not numeric. Any
+// other string is quoted, which always round-trips.
+var safeBareString = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
+
+var stringKeywords = map[string]bool{
+	"true": true, "false": true, "null": true,
+	"yes": true, "no": true, "on": true, "off": true,
+}
+
+func renderString(s string) string {
+	if safeBareString.MatchString(s) && !stringKeywords[strings.ToLower(s)] {
+		return s
+	}
+	return quoteString(s)
+}
+
+func quoteString(s string) string {
+	// A string containing newlines is triple-quoted when that is unambiguous
+	// and lossless: no embedded `"""`, no trailing `"`, and no carriage return
+	// (the parser normalizes CRLF inside triple quotes, which would drop the
+	// `\r`, so those fall through to escaped double quotes below).
+	if strings.Contains(s, "\n") && !strings.Contains(s, "\r") &&
+		!strings.Contains(s, `"""`) && !strings.HasSuffix(s, `"`) {
+		return `"""` + s + `"""`
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/render_hocon_test.go
+++ b/render_hocon_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon
+
+import (
+	"strings"
+	"testing"
+)
+
+// roundTrip renders a config to HOCON, parses it back, and returns the
+// re-parsed config's canonical JSON alongside the original's. Equal JSON means
+// the emit → parse round trip preserved the value tree, which is the emitter's
+// correctness contract.
+func roundTrip(t *testing.T, values map[string]any) (before, after string, text string) {
+	t.Helper()
+	cfg, err := FromMap(values, "test")
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	before, err = cfg.RenderJSONForTest()
+	if err != nil {
+		t.Fatalf("RenderJSONForTest(before): %v", err)
+	}
+	text, err = cfg.RenderHOCON()
+	if err != nil {
+		t.Fatalf("RenderHOCON: %v", err)
+	}
+	reparsed, err := ParseString(text)
+	if err != nil {
+		t.Fatalf("ParseString of emitted HOCON failed: %v\n--- emitted ---\n%s", err, text)
+	}
+	after, err = reparsed.RenderJSONForTest()
+	if err != nil {
+		t.Fatalf("RenderJSONForTest(after): %v", err)
+	}
+	return before, after, text
+}
+
+func assertRoundTrip(t *testing.T, name string, values map[string]any) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		before, after, text := roundTrip(t, values)
+		if before != after {
+			t.Errorf("round trip changed the tree\n  before: %s\n  after:  %s\n--- emitted ---\n%s", before, after, text)
+		}
+	})
+}
+
+func TestRenderHOCONRoundTrip(t *testing.T) {
+	assertRoundTrip(t, "scalars", map[string]any{
+		"s": "hello", "n": 8080, "f": 1.5, "b": true, "z": false, "nul": nil,
+	})
+	assertRoundTrip(t, "nested-objects", map[string]any{
+		"db": map[string]any{"host": "localhost", "port": 5432,
+			"opts": map[string]any{"ssl": true}},
+	})
+	assertRoundTrip(t, "arrays", map[string]any{
+		"tags":    []any{"a", "b", "c"},
+		"nums":    []any{1, 2, 3},
+		"objs":    []any{map[string]any{"id": 1}, map[string]any{"id": 2}},
+		"nested":  []any{[]any{1, 2}, []any{3, 4}},
+		"empty-a": []any{},
+	})
+	// Strings that would re-parse as another type MUST stay strings.
+	assertRoundTrip(t, "ambiguous-strings", map[string]any{
+		"looks-num":   "8080",
+		"looks-float": "1.5",
+		"looks-bool":  "true",
+		"looks-null":  "null",
+		"norway":      "no",
+		"neg":         "-5",
+	})
+	// Strings needing quoting for their content.
+	assertRoundTrip(t, "special-strings", map[string]any{
+		"spaces":   "hello world",
+		"empty":    "",
+		"reserved": "a:b=c,d",
+		"leading":  "  padded  ",
+		"url":      "https://example.com/a?b=1",
+		"substish": "${foo.bar}",
+	})
+	assertRoundTrip(t, "multiline", map[string]any{
+		"block": "line1\nline2\nline3",
+		"crlf":  "a\r\nb",
+		"tab":   "a\tb",
+	})
+	// Keys that cannot be bare.
+	assertRoundTrip(t, "awkward-keys", map[string]any{
+		"a.b":       "dotted key",
+		"has space": 1,
+		"":          "empty key",
+		"a=b":       true,
+		"123":       "numeric key ok",
+	})
+	assertRoundTrip(t, "empty-object", map[string]any{
+		"outer": map[string]any{"inner": map[string]any{}},
+	})
+	assertRoundTrip(t, "unicode", map[string]any{
+		"jp": "こんにちは", "emoji": "😀", "mixed": "a😀b",
+	})
+	// Strings that defeat triple-quoting (embedded """, a trailing ") must fall
+	// through to escaped double quotes and still round-trip.
+	assertRoundTrip(t, "quote-heavy", map[string]any{
+		"embedded-triple": "a\"\"\"b\nc",
+		"trailing-quote":  "ends\"",
+		"lone-quote":      "a\"b",
+		"multiline-quote": "x\ny\"",
+		"backslash":       "a\\b\\\\c",
+	})
+	// Empty object as an array element and as a direct value exercise the
+	// value-position empty-object branch (distinct from a nested key).
+	assertRoundTrip(t, "empty-object-positions", map[string]any{
+		"in-array": []any{map[string]any{}, map[string]any{"a": 1}},
+		"direct":   map[string]any{},
+	})
+}
+
+// An unresolved config has no textual round trip through a value tree, so
+// RenderHOCON must refuse it rather than emit a broken document. The
+// placeholders sit at three depths so the error propagates through the nested
+// object and array paths, not only the top level.
+func TestRenderHOCONRejectsUnresolved(t *testing.T) {
+	for name, src := range map[string]string{
+		"top-level":  "a = 1\nb = ${a}\n",
+		"nested":     "a = 1\nb { c = ${a} }\n",
+		"in-array":   "a = 1\nb = [1, ${a}, 3]\n",
+		"obj-in-arr": "a = 1\nb = [{ c = ${a} }]\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := ParseStringWithOptions(
+				src, DefaultParseOptions().WithResolveSubstitutions(false),
+			)
+			if err != nil {
+				t.Fatalf("ParseStringWithOptions: %v", err)
+			}
+			if _, err := cfg.RenderHOCON(); err == nil {
+				t.Fatalf("RenderHOCON on unresolved %q succeeded, want error", name)
+			}
+		})
+	}
+}
+
+// The emitted text should be idiomatic where it is safe: a plain identifier
+// value and key stay bare, a number is not quoted.
+func TestRenderHOCONIdiomatic(t *testing.T) {
+	cfg, err := FromMap(map[string]any{
+		"name": "svc", "port": 8080, "enabled": true,
+	}, "")
+	if err != nil {
+		t.Fatalf("FromMap: %v", err)
+	}
+	got, err := cfg.RenderHOCON()
+	if err != nil {
+		t.Fatalf("RenderHOCON: %v", err)
+	}
+	for _, want := range []string{"name = svc\n", "port = 8080\n", "enabled = true\n"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("emitted HOCON missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// A parsed HOCON document (not from FromMap) also round-trips once resolved.
+func TestRenderHOCONFromParsedDocument(t *testing.T) {
+	src := `
+a = 1
+b { c = "x", d = [1, 2, "three"] }
+e = ${a}
+`
+	cfg, err := ParseString(src)
+	if err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	text, err := cfg.RenderHOCON()
+	if err != nil {
+		t.Fatalf("RenderHOCON: %v", err)
+	}
+	reparsed, err := ParseString(text)
+	if err != nil {
+		t.Fatalf("re-parse: %v\n%s", err, text)
+	}
+	before, err := cfg.RenderJSONForTest()
+	if err != nil {
+		t.Fatalf("RenderJSONForTest(before): %v", err)
+	}
+	after, err := reparsed.RenderJSONForTest()
+	if err != nil {
+		t.Fatalf("RenderJSONForTest(after): %v", err)
+	}
+	if before != after {
+		t.Errorf("parsed-doc round trip diverged\n  before: %s\n  after:  %s\n%s", before, after, text)
+	}
+}


### PR DESCRIPTION
The reverse of parsing: a resolved config renders back to HOCON text. This is
the core half of the reverse-conversion work tracked in
[xx.hocon#74](https://github.com/o3co/xx.hocon/issues/74) — hocon2's `xxx2hocon`
commands (yaml2hocon, …) build on it.

## What it does

`RenderHOCON()` walks the value tree (objects, arrays, string/number/boolean/null
scalars — exactly what `FromMap` and the format adapters produce) and returns
idiomatic HOCON:

```hocon
name = svc
port = 8080
db {
  host = localhost
  replicas = [
    { id = 1 }
    { id = 2 }
  ]
}
```

Root fields are unbraced, nested objects are `key { … }`, arrays are
newline-separated, indent is two spaces.

## The contract is round-trip, not byte formatting

`emit → parse` yields the same tree. That is stronger and more useful than a
golden-text comparison, which would over-constrain formatting. The quoting
rules follow from it:

- A scalar is quoted whenever leaving it bare would re-parse as a **different
  type**: a string `"8080"` stays a string, `no`/`true`/`null` as string values
  are quoted, an empty or space-padded value is quoted. A number/boolean/null is
  emitted bare.
- A key is bare only when unambiguous (`[A-Za-z0-9_-]+`, no dot); otherwise
  quoted — a dotted key would nest.
- A multi-line value is triple-quoted when that is lossless, escaped in double
  quotes otherwise. A `\r` falls through to escapes, since triple quotes
  normalize CRLF and would drop it.
- An unresolved placeholder is an error — substitutions have no textual round
  trip through a value tree.

Pinned by `render_hocon_test.go`: a round-trip corpus (nested objects, arrays of
objects, ambiguous strings, special/multiline/unicode strings, awkward keys)
plus a parsed-document case. Full suite, vet and golangci-lint are clean.

## Why core, not hocon2

The emitter is general-purpose — a future `hoconfmt`, programmatic config
generation — so it lives in the parser core rather than the CLI. Each sibling
parser will gain the equivalent for cross-impl round-trip parity (#74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)