### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-26
+
 ### Added — `Config.RenderHOCON()`, a HOCON text emitter
 
 - **A resolved config can now be rendered back to HOCON text**, the missing


### PR DESCRIPTION
Cuts 1.11.0 from the merged adapter fixes (#165) plus the `Config.RenderHOCON()` emitter already on develop.

**Why minor, not patch.** `Config.RenderHOCON()` is new public API, so 1.10.1 would understate the release. The other three implementations go out as 1.11.0 at the same time so the ecosystem stays on one version line — that alignment is deliberate, not an accident of each repo's own semver arithmetic.

CHANGELOG only; Go modules take the version from the tag.

**Not included, deliberately**: the nested `adapters/` module still has no tag of its own. Its `go.mod` currently requires core `v1.10.0`, and the release sequence this repo now documents is core tag → PR bumping the adapters require → `adapters/v*` tag. That follow-up is the first real exercise of the tagging scheme #165 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)