### PR TITLE
test(adapters): dispatch the properties format in the ingestion harness

### DIFF
--- a/adapters/format_ingestion_test.go
+++ b/adapters/format_ingestion_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/o3co/go.hocon"
 	"github.com/o3co/go.hocon/adapters/env"
 	"github.com/o3co/go.hocon/adapters/jsonc"
+	"github.com/o3co/go.hocon/adapters/properties"
 	"github.com/o3co/go.hocon/adapters/toml"
 	"github.com/o3co/go.hocon/adapters/yaml"
 )
@@ -112,6 +113,8 @@ func ingest(format, kind string, data []byte, origin string) (*hocon.Config, err
 	switch format {
 	case "jsonc":
 		return jsonc.Parse(data, origin)
+	case "properties":
+		return properties.Parse(data, origin)
 	case "toml":
 		return toml.Parse(data, origin)
 	case "yaml":


### PR DESCRIPTION
Preparation for a new fixture group in xx.hocon.

The shared `format-ingestion` corpus is gaining `properties` cases — needed because F2.9 (`__proto__`, `constructor`, `prototype` survive as ordinary keys) **cannot be expressed through the env format**: `__proto__` begins and ends with the `__` separator, so it maps to empty segments in all four implementations.

This runner hits its `default` arm on an unknown format, which panics. Since the Makefile pins `TESTDATA_REF := main`, merging the fixtures first would break CI here the moment they land — so the arm goes in first. Until then it is unused.

No behaviour change; `go test ./...` in the adapters module is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)