### PR TITLE
chore(adapters): require core v1.11.0

### DIFF
--- a/adapters/go.mod
+++ b/adapters/go.mod
@@ -3,7 +3,7 @@ module github.com/o3co/go.hocon/adapters
 go 1.23.0
 
 require (
-	github.com/o3co/go.hocon v1.10.0
+	github.com/o3co/go.hocon v1.11.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 )
 


### PR DESCRIPTION
Second step of the release sequence this repo documented in #165: core tag → require bump → `adapters/v*` tag.

Core `v1.11.0` is tagged and on the module proxy, so the nested module can now point at it. Until this lands, `adapters/v1.11.0` cannot be cut — a consumer ignores a dependency's `replace`, so the require has to name a published version. That is exactly what broke in v1.10.0.

Verified the way the go.mod comment prescribes: a copy with the `replace` dropped, built and tested against the published core.

```
go: downloading github.com/o3co/go.hocon v1.11.0
BUILD OK — all 8 packages test ok
```

The `adapters without replace (published core)` CI job should take its strict path here rather than warning-and-skipping, since the required version now exists. That is the first real exercise of the guard added in #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)