### PR TITLE
docs: correct four stale README claims and pin them with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — README stated four things that were no longer true
+
+The README's factual claims had drifted release by release, with nothing
+checking them. All four are corrected, and the ones that can be recomputed from
+a source of truth in this repository are now pinned by `docs_test.go`, which
+runs in the release workflow — a stale README fails the cut.
+
+- **The stated minimum Go version was wrong.** The README said "Requires Go
+  1.21+" while `go.mod` has declared `go 1.23.0` since v1.8.0, so a user on
+  1.21 or 1.22 got a toolchain error on `go get`. Now 1.23+, and pinned against
+  the `go` directive.
+- **"Stricter than Lightbend — S8.6 leading-hyphen rejection" described behavior
+  retracted in v1.3.0.** `a = -foo`, `a = -`, and (since v1.9.0) `a.-foo = 1`
+  all parse; the section told readers to quote values that need no quoting. The
+  E8 amendment and its retraction are already recorded in the [1.3.0] and
+  [1.9.0] sections, so the section is removed rather than rewritten.
+- **The compliance rates were a 2026-05-13 snapshot** (71.8% / 80.2%) against
+  the current 89.0% / 98.4%. They are now recomputed from the status glyphs in
+  `docs/spec-compliance.md` by `TestDocs_ReadmeComplianceRates` and compared
+  against the table, so the two cannot diverge again.
+- **Both comparison tables were stale in the reader's favour and against the
+  other project's.** gurkankaymak/hocon v1.3.0 has deferred resolution
+  (`ParseStringUnresolved` + `WithFallback` + `Resolve`), `include required(...)`,
+  object/array concatenation and type coercion — all four were marked ❌ or ⚠️.
+  Our own row was stale too: YAML and TOML were ❌ although `adapters/` has
+  shipped both since v1.10.0. Both tables now name the version they were
+  verified against and carry the date.
+
 ## [1.11.0] - 2026-07-26
 
 ### Added — `Config.RenderHOCON()`, a HOCON text emitter

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) pars
 go get github.com/o3co/go.hocon
 ```
 
-Requires Go 1.21+.
+Requires Go 1.23+.
 
 ### 2. Use
 
@@ -267,34 +267,38 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ### HOCON Implementation
 
-| Feature | go.hocon | [gurkankaymak/hocon](https://github.com/gurkankaymak/hocon) |
+Verified against [gurkankaymak/hocon](https://github.com/gurkankaymak/hocon) **v1.3.0** on 2026-07-26.
+
+| Feature | go.hocon | gurkankaymak/hocon v1.3.0 |
 | --- | :---: | :---: |
 | Substitutions (`${path}`) | ✅ | ✅ |
 | Optional substitutions (`${?path}`) | ✅ | ✅ |
 | Include | ✅ | ✅ |
-| `include required(...)` | ✅ | ❌ |
-| Object/Array concatenation | ✅ | ⚠️ |
-| Type coercion | ✅ | ⚠️ |
+| `include required(...)` / `file(...)` | ✅ | ✅ |
+| Object/Array concatenation | ✅ | ✅ |
+| Type coercion | ✅ | ✅ |
 | Duration parsing (`30s`, `5m`) | ✅ | ✅ |
-| Byte size parsing (`512MB`) | ✅ | ❌ |
+| Byte size parsing (`512MB`) | ✅ | ❌ (parses as a string) |
 | `+=` append | ✅ | ✅ |
 | Struct unmarshal | ✅ | ❌ |
-| `Option[T]` safe access | ✅ | ❌ |
+| Non-panicking access | ✅ (`GetXxxE` + `Option[T]`) | ✅ (`GetXxxE`) |
 | Env variable fallback | ✅ | ✅ |
-| Deferred resolution (parse / withFallback / resolve) | ✅ (v1.4.0) | ❌ |
+| Deferred resolution (parse / withFallback / resolve) | ✅ (v1.4.0) | ✅ (v1.3.0) |
 | `FromMap` / `Empty` value factories | ✅ (v1.4.0) | ❌ |
 
 ### Config Framework
 
-| | go.hocon | [viper](https://github.com/spf13/viper) |
+Compared against [viper](https://github.com/spf13/viper) **v1.21.0** on 2026-07-26.
+
+| | go.hocon | viper v1.21.0 |
 | --- | :---: | :---: |
 | **Formats** | | |
 | HOCON | ✅ | ❌ |
 | JSON | ✅ | ✅ |
-| YAML | ❌ | ✅ |
-| TOML | ❌ | ✅ |
-| Env vars | ✅ (fallback) | ✅ |
-| .properties | ✅ (via include) | ✅ |
+| YAML | ✅ (`adapters/yaml`) | ✅ |
+| TOML | ✅ (`adapters/toml`) | ✅ |
+| Env vars | ✅ (fallback + `adapters/env`) | ✅ |
+| .properties | ✅ (via include + `adapters/properties`) | ✅ |
 | **Features** | | |
 | Substitutions | ✅ | ❌ |
 | File includes | ✅ | ❌ |
@@ -305,18 +309,14 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-13; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md), which is the source these rates are computed from — `TestDocs_ReadmeComplianceRates` recomputes them and fails the build if this table drifts. See [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for the cross-implementation roll-up.
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **71.8%** |
-| In-scope only | **80.2%** |
-| Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 passing |
-| [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | 77/77 passing |
-
-### Stricter than Lightbend
-
-- **S8.6 leading-hyphen rejection** (Unreleased): `a = -foo`, `a = -bar`, `a = -` etc. now raise a lex error per HOCON.md L270–276, where Lightbend silently falls back to unquoted strings. The same rule applies to dotted key segments (`a.-foo = 1`). Mitigation: quote the value (`a = "-foo"`). See [CHANGELOG](CHANGELOG.md#unreleased) and [`docs/spec-compliance.md`](docs/spec-compliance.md) §S8.6.
+| Spec total (incl. out-of-scope) | **89.0%** |
+| In-scope only | **98.4%** |
+| Lightbend `equiv01`–`equiv05` + `test01`–`test13` | passing (`TestLightbendEquiv` / `TestLightbendSuite`; three `*-expected.json` comparisons carry documented environment-dependent exclusions) |
+| [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | passing |
 
 ## Format adapters
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -113,14 +113,15 @@ func readReadme(t *testing.T) string {
 }
 
 // findOne returns the single capture group of re in text, failing the test when
-// the pattern no longer matches — a README rewrite that drops the claim must
-// fail loudly rather than silently stop checking it.
-func findOne(t *testing.T, text string, re *regexp.Regexp, what string) string {
+// the pattern no longer matches — a rewrite that drops the claim must fail
+// loudly rather than silently stop checking it. source names the file the text
+// came from, since this reads go.mod as well as the README.
+func findOne(t *testing.T, source, text string, re *regexp.Regexp, what string) string {
 	t.Helper()
 
 	m := re.FindStringSubmatch(text)
 	if m == nil {
-		t.Fatalf("%s not found in README.md (pattern %s); update the pattern if the README was restructured", what, re)
+		t.Fatalf("%s not found in %s (pattern %s); update the pattern if %s was restructured", what, source, re, source)
 	}
 	return m[1]
 }
@@ -155,7 +156,7 @@ func TestDocs_ReadmeComplianceRates(t *testing.T) {
 			want: counts.inScopeRate(),
 		},
 	} {
-		got := findOne(t, readme, tc.re, tc.what)
+		got := findOne(t, "README.md", readme, tc.re, tc.what)
 		if want := fmt.Sprintf("%.1f", tc.want); got != want {
 			t.Errorf("README %s is %s%%, recomputed from docs/spec-compliance.md it is %s%% (✅%d ⚠️%d ❌%d ➖%d)",
 				tc.what, got, want, counts.pass, counts.partial, counts.fail, counts.outOfScope)
@@ -168,9 +169,9 @@ func TestDocs_ReadmeGoVersionMatchesGoMod(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
 	}
-	declared := findOne(t, string(data), regexp.MustCompile(`(?m)^go (\d+\.\d+)`), "go directive")
+	declared := findOne(t, "go.mod", string(data), regexp.MustCompile(`(?m)^go (\d+\.\d+)`), "go directive")
 
-	claimed := findOne(t, readReadme(t), regexp.MustCompile(`Requires Go (\d+\.\d+)\+`), "minimum Go version")
+	claimed := findOne(t, "README.md", readReadme(t), regexp.MustCompile(`Requires Go (\d+\.\d+)\+`), "minimum Go version")
 	if claimed != declared {
 		t.Errorf("README says Go %s+, go.mod requires go %s — a user on %s cannot build this module", claimed, declared, claimed)
 	}

--- a/docs_test.go
+++ b/docs_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The README states facts that go stale on their own: the compliance rates, the
+// minimum Go version, and "unreleased" markers left behind after the release
+// that shipped the behavior. None of those are exercised by any other test, so
+// they only ever drift in one direction. These tests recompute each from the
+// artifact that actually decides it — docs/spec-compliance.md and go.mod — and
+// run in the release workflow, so a stale README fails the cut instead of
+// shipping.
+
+// specItemTotal is the number of S-items in the shared spec checklist
+// (xx.hocon/docs/spec-checklist.md). Both compliance rates use it as the
+// denominator, so a per-impl doc that has drifted away from the checklist would
+// silently change the rates; the count is asserted rather than derived.
+const specItemTotal = 210
+
+// complianceCounts is the per-status tally of the S-items in
+// docs/spec-compliance.md.
+type complianceCounts struct {
+	pass, partial, fail, unverified, outOfScope int
+}
+
+func (c complianceCounts) total() int {
+	return c.pass + c.partial + c.fail + c.unverified + c.outOfScope
+}
+
+// specTotalRate answers "how much of HOCON.md does this implementation
+// handle?" — out-of-scope items are in the denominator on purpose.
+func (c complianceCounts) specTotalRate() float64 {
+	return (float64(c.pass) + float64(c.partial)*0.5) / float64(specItemTotal) * 100
+}
+
+// inScopeRate answers "of what the implementation chooses to support, how much
+// is covered?" — out-of-scope items drop out of the denominator.
+func (c complianceCounts) inScopeRate() float64 {
+	return (float64(c.pass) + float64(c.partial)*0.5) / float64(specItemTotal-c.outOfScope) * 100
+}
+
+var (
+	// An S-item heading: "- **S13a.10** Some rule — §Section (L123)". E-items
+	// (extra-spec conventions) use the same block shape but are not part of the
+	// checklist, so the heading pattern is what separates them.
+	specItemHeadRe = regexp.MustCompile(`^\s*- \*\*(S[0-9A-Za-z._]+)\*\*`)
+	otherHeadRe    = regexp.MustCompile(`^\s*- \*\*[0-9A-Za-z._]+\*\*`)
+	statusRe       = regexp.MustCompile(`^\s*status:`)
+)
+
+// countCompliance tallies the status glyph of every S-item block in
+// docs/spec-compliance.md. Only the first `status:` line after an S-item
+// heading counts: a block may carry sub-bullets, and E-item blocks that follow
+// the S-items must not be picked up.
+func countCompliance(t *testing.T) complianceCounts {
+	t.Helper()
+
+	data, err := os.ReadFile("docs/spec-compliance.md")
+	if err != nil {
+		t.Fatalf("read docs/spec-compliance.md: %v", err)
+	}
+
+	var counts complianceCounts
+	inSpecItem := false
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case specItemHeadRe.MatchString(line):
+			inSpecItem = true
+		case otherHeadRe.MatchString(line):
+			inSpecItem = false
+		case inSpecItem && statusRe.MatchString(line):
+			inSpecItem = false
+			switch {
+			case strings.Contains(line, "✅"):
+				counts.pass++
+			case strings.Contains(line, "⚠️"):
+				counts.partial++
+			case strings.Contains(line, "❌"):
+				counts.fail++
+			case strings.Contains(line, "🤷"):
+				counts.unverified++
+			case strings.Contains(line, "➖"):
+				counts.outOfScope++
+			default:
+				t.Errorf("status line carries no known glyph: %q", strings.TrimSpace(line))
+			}
+		}
+	}
+	return counts
+}
+
+func readReadme(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	return string(data)
+}
+
+// findOne returns the single capture group of re in text, failing the test when
+// the pattern no longer matches — a README rewrite that drops the claim must
+// fail loudly rather than silently stop checking it.
+func findOne(t *testing.T, text string, re *regexp.Regexp, what string) string {
+	t.Helper()
+
+	m := re.FindStringSubmatch(text)
+	if m == nil {
+		t.Fatalf("%s not found in README.md (pattern %s); update the pattern if the README was restructured", what, re)
+	}
+	return m[1]
+}
+
+func TestDocs_SpecComplianceItemCount(t *testing.T) {
+	counts := countCompliance(t)
+	if got := counts.total(); got != specItemTotal {
+		t.Errorf("docs/spec-compliance.md has %d S-items, want %d (the shared checklist count) — an item was added, dropped, or its status line is malformed", got, specItemTotal)
+	}
+	if counts.unverified != 0 {
+		t.Errorf("docs/spec-compliance.md has %d unverified (🤷) items; every item must be pinned by a test", counts.unverified)
+	}
+}
+
+func TestDocs_ReadmeComplianceRates(t *testing.T) {
+	counts := countCompliance(t)
+	readme := readReadme(t)
+
+	for _, tc := range []struct {
+		what string
+		re   *regexp.Regexp
+		want float64
+	}{
+		{
+			what: "spec-total compliance rate",
+			re:   regexp.MustCompile(`\| Spec total \(incl\. out-of-scope\) \| \*\*([0-9.]+)%\*\* \|`),
+			want: counts.specTotalRate(),
+		},
+		{
+			what: "in-scope compliance rate",
+			re:   regexp.MustCompile(`\| In-scope only \| \*\*([0-9.]+)%\*\* \|`),
+			want: counts.inScopeRate(),
+		},
+	} {
+		got := findOne(t, readme, tc.re, tc.what)
+		if want := fmt.Sprintf("%.1f", tc.want); got != want {
+			t.Errorf("README %s is %s%%, recomputed from docs/spec-compliance.md it is %s%% (✅%d ⚠️%d ❌%d ➖%d)",
+				tc.what, got, want, counts.pass, counts.partial, counts.fail, counts.outOfScope)
+		}
+	}
+}
+
+func TestDocs_ReadmeGoVersionMatchesGoMod(t *testing.T) {
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	declared := findOne(t, string(data), regexp.MustCompile(`(?m)^go (\d+\.\d+)`), "go directive")
+
+	claimed := findOne(t, readReadme(t), regexp.MustCompile(`Requires Go (\d+\.\d+)\+`), "minimum Go version")
+	if claimed != declared {
+		t.Errorf("README says Go %s+, go.mod requires go %s — a user on %s cannot build this module", claimed, declared, claimed)
+	}
+}
+
+func TestDocs_ReadmeHasNoUnreleasedMarkers(t *testing.T) {
+	for i, line := range strings.Split(readReadme(t), "\n") {
+		if strings.Contains(line, "(Unreleased)") {
+			t.Errorf("README.md:%d still marks shipped behavior as unreleased: %q", i+1, strings.TrimSpace(line))
+		}
+	}
+}


### PR DESCRIPTION
The README's factual claims had drifted release by release with nothing checking
them. An external review of v1.10.0 surfaced the first two; auditing the rest of
the file found two more. All four are corrected here, and the ones that can be
recomputed from a source of truth in this repository are pinned by `docs_test.go`,
which runs in the release workflow — so a stale README now fails the cut instead
of shipping.

| Claim | Was | Is |
| --- | --- | --- |
| Minimum Go version | "Requires Go 1.21+" | `go.mod` has said `go 1.23.0` since v1.8.0 — a user on 1.21/1.22 got a toolchain error on `go get` |
| "Stricter than Lightbend — S8.6" | `a = -foo` / `a.-foo = 1` are lex errors, quote to work around | Retracted in v1.3.0 (value position) and v1.9.0 (key position); both parse. The section told readers to quote values that need no quoting |
| Compliance rates | 71.8% / 80.2%, snapshot 2026-05-13 | 89.0% / 98.4% |
| Comparison tables | gurkankaymak/hocon ❌ deferred resolution, ❌ `include required`, ⚠️ concat, ⚠️ coercion; our own YAML/TOML ❌ | v1.3.0 has all four (verified by probing the module); `adapters/` has shipped YAML and TOML since v1.10.0 |

### What the test pins

- **Compliance rates** — recomputed from the status glyphs in `docs/spec-compliance.md`
  using the documented formula, and compared against the README table. The item
  count is asserted at 210 so a per-impl doc that drifts from the shared checklist
  fails rather than silently changing the rates.
- **Minimum Go version** — README claim vs the `go` directive.
- **`(Unreleased)` markers** — rejected outright, which is what would have caught
  the S8.6 section two releases ago.

Each check was mutation-tested: editing the README to reintroduce each drift makes
the corresponding test fail with a message naming both sides.

The comparison tables cannot be checked this way, so they now name the version they
were verified against (gurkankaymak/hocon v1.3.0, viper v1.21.0) and the date.
Re-verifying them at each cut is part of the release procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)