### PR TITLE
test(docs): reject an ambiguous match, and say where the gate actually is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The README's factual claims had drifted release by release, with nothing
 checking them. All four are corrected, and the ones that can be recomputed from
 a source of truth in this repository are now pinned by `docs_test.go`, which
-runs in the release workflow — a stale README fails the cut.
+runs on every pull request and on `develop`. That is where the gate has to be
+for a Go module: pushing the tag *is* the publish, so nothing at release time
+can hold a stale README back — only refusing to merge it can.
 
 - **The stated minimum Go version was wrong.** The README said "Requires Go
   1.21+" while `go.mod` has declared `go 1.23.0` since v1.8.0, so a user on

--- a/docs_test.go
+++ b/docs_test.go
@@ -116,14 +116,27 @@ func readReadme(t *testing.T) string {
 // the pattern no longer matches — a rewrite that drops the claim must fail
 // loudly rather than silently stop checking it. source names the file the text
 // came from, since this reads go.mod as well as the README.
+//
+// More than one match is also a failure: it would mean the doc states the claim
+// twice and only the first is pinned, so the pair can drift apart while this
+// stays green.
 func findOne(t *testing.T, source, text string, re *regexp.Regexp, what string) string {
 	t.Helper()
 
-	m := re.FindStringSubmatch(text)
-	if m == nil {
+	ms := re.FindAllStringSubmatch(text, -1)
+	switch len(ms) {
+	case 0:
 		t.Fatalf("%s not found in %s (pattern %s); update the pattern if %s was restructured", what, source, re, source)
+	case 1:
+	default:
+		found := make([]string, len(ms))
+		for i, m := range ms {
+			found[i] = m[1]
+		}
+		t.Fatalf("%s matched %d times in %s (pattern %s); the claim must appear once so there is one thing to pin: %v",
+			what, len(ms), source, re, found)
 	}
-	return m[1]
+	return ms[0][1]
 }
 
 func TestDocs_SpecComplianceItemCount(t *testing.T) {


### PR DESCRIPTION
Two follow-ups to #171.

**`findOne` returned the first match** while promising "the single capture
group". A doc that states the same claim twice would have had only the first one
pinned, so the pair could drift apart with the test still green — the exact
failure mode this file exists to prevent. More than one match is now a failure
naming every value found:

```
minimum Go version matched 2 times in README.md (pattern Requires Go (\d+\.\d+)\+);
the claim must appear once so there is one thing to pin: [1.23 1.24]
```

(The finding is Copilot's, on the py.hocon companion PR; this ports it so all
four implementations' guards behave the same.)

**The CHANGELOG entry claimed these checks "run in the release workflow."** True
of ts/rs/py, whose publish workflows run the suite before publishing — but not
here. Pushing a `v*` tag *is* the publish for a Go module; `release.yml` only
asks the proxy to index it and writes the GitHub Release. Nothing at release
time can hold a stale README back, so the gate is the CI that runs on every PR
and on `develop`, plus the practice of only tagging commits that passed it. The
entry now says that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)