### PR TITLE
fix(adapters/yaml)!: a leading empty document discarded the whole file (F5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters/yaml`: a leading empty document discarded the whole file
+
+**BREAKING** (input previously accepted is now refused; quote or remove the
+extra `---` if the file really is one document).
+
+`yaml.Parse("---\n---\na: 1\n")` returned an empty config with no error, and so
+did every `---`-prefixed stream whose first document holds nothing but comments
+— the shape generated YAML takes once a header block is stripped. The F5.7
+guard against multi-document streams never ran: goccy answers `io.EOF` for
+these, and the adapter read that as "empty input" (F5.9). Every document was
+dropped, which is a worse outcome than the silent loss of document 2..n that
+F5.7 exists to prevent. `parser.ParseBytes` cannot see it either — it reports
+one body-less document — so the count is now taken from the library's token
+stream, which still carries both `---` markers and knows that a `---` inside a
+block scalar or a quoted string is text ([#166](https://github.com/o3co/go.hocon/issues/166)).
+
+A trailing `---` (`a: 1\n---\n`) is a second, empty document and is now refused
+for the same reason; ts.hocon, rs.hocon and py.hocon already refused it, so
+this closes a four-way parity gap rather than opening one. A directive line
+(`%YAML 1.2`) still belongs to the document that follows it, and a malformed
+document is still reported as malformed by the decoder rather than as a stream.
+
 ### Fixed — README stated four things that were no longer true
 
 The README's factual claims had drifted release by release, with nothing

--- a/adapters/yaml/keys.go
+++ b/adapters/yaml/keys.go
@@ -111,9 +111,10 @@ func (c *collisions) report(path []string, key string, a, b *ast.MappingValueNod
 	}
 	sort.Strings(forms)
 	c.found = append(c.found, fmt.Sprintf(
-		"mapping keys %s and %s both resolve to %s; quote the one you mean to "+
-			"keep distinct, because one of the two values would otherwise be "+
-			"lost (spec F5.3)",
+		"mapping keys %s and %s both resolve to %s; rename one of them, because "+
+			"one of the two values would otherwise be lost. Quoting a non-string "+
+			"key helps only where that changes the key text, as 0x10 does and 1 "+
+			"does not (spec F5.3)",
 		forms[0], forms[1], where))
 }
 

--- a/adapters/yaml/yaml.go
+++ b/adapters/yaml/yaml.go
@@ -52,6 +52,8 @@ import (
 	"time"
 
 	goyaml "github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/lexer"
+	"github.com/goccy/go-yaml/token"
 	"github.com/o3co/go.hocon"
 	"github.com/o3co/go.hocon/adapters/internal/bom"
 	"github.com/o3co/go.hocon/adapters/internal/keypath"
@@ -290,17 +292,27 @@ func ParseFile(path string) (*hocon.Config, error) {
 // decode reads exactly one document.
 //
 // F5.7: goyaml.Unmarshal returns the first document of a stream and discards
-// the rest without a word, so the second decode below exists to turn that
-// silent data loss into an error.
+// the rest without a word, so the checks below exist to turn that silent data
+// loss into an error. Two of them, because neither sees every stream:
+// countDocuments misses a `...`-separated stream, whose second document the
+// lexer does not announce with a header token, and the trailing decode misses
+// every stream the decoder itself never gets to (see countDocuments).
 func decode(data []byte, origin string) (any, error) {
 	dec := goyaml.NewDecoder(bytes.NewReader(data))
 
 	var doc any
-	if err := dec.Decode(&doc); err != nil {
-		if errors.Is(err, io.EOF) {
-			return nil, nil // empty input
-		}
+	switch err := dec.Decode(&doc); {
+	case err == nil:
+	case errors.Is(err, io.EOF):
+		doc = nil // no first document to decode
+	default:
 		return nil, fmt.Errorf("yaml: %s: %w", describe(origin), err)
+	}
+
+	// After the decode, so that a syntax error is still reported by the
+	// decoder, which words it better.
+	if countDocuments(data) > 1 {
+		return nil, errMultiDocument(origin)
 	}
 
 	var extra any
@@ -308,13 +320,64 @@ func decode(data []byte, origin string) (any, error) {
 	case errors.Is(err, io.EOF):
 		return doc, nil
 	case err == nil:
-		return nil, fmt.Errorf(
-			"yaml: %s: multi-document streams are not supported (spec F5.7); "+
-				"a config is one document, and decoding only the first would drop the rest silently",
-			describe(origin))
+		return nil, errMultiDocument(origin)
 	default:
 		return nil, fmt.Errorf("yaml: %s: %w", describe(origin), err)
 	}
+}
+
+func errMultiDocument(origin string) error {
+	return fmt.Errorf(
+		"yaml: %s: multi-document streams are not supported (spec F5.7); "+
+			"a config is one document, and decoding only the first would drop the rest silently",
+		describe(origin))
+}
+
+// countDocuments reports how many documents data holds, counted from the
+// library's own token stream.
+//
+// Neither of the higher layers can answer this. goccy v1.19.2 collapses a
+// stream whose *first* document is empty — "---\n---\na: 1\n", which is what
+// `---`-prefixed generated YAML looks like once its header block is stripped —
+// into one empty document: the decoder reports io.EOF and parser.ParseBytes
+// reports a single body-less Doc, so by the time either has spoken, `a: 1` is
+// already gone and the F5.7 guard has nothing left to catch. The lexer still
+// emits both header tokens.
+//
+// It is also the only layer that knows which `---` starts a document: one
+// inside a block scalar or a quoted string is ordinary text, and a `---` line
+// is a header, not a value. Matching the text would have to re-derive all of
+// that.
+//
+// The count is the number of header tokens, plus one for a document written
+// before the first header. Directives are the exception: `%YAML 1.2` sits
+// before the `---` it applies to, so the tokens on that line are not a
+// document of their own.
+func countDocuments(data []byte) int {
+	headers, directive, bare := 0, false, false
+	for _, tk := range lexer.Tokenize(string(data)) {
+		if headers > 0 {
+			// Past the first header, only further headers add to the count.
+			if tk.Type == token.DocumentHeaderType {
+				headers++
+			}
+			continue
+		}
+		switch tk.Type {
+		case token.DocumentHeaderType:
+			headers++
+		case token.DirectiveType:
+			directive = true
+		case token.CommentType, token.DocumentEndType:
+			// Neither is a document on its own.
+		default:
+			bare = true
+		}
+	}
+	if bare && !directive {
+		return headers + 1
+	}
+	return headers
 }
 
 func describe(origin string) string {

--- a/adapters/yaml/yaml_test.go
+++ b/adapters/yaml/yaml_test.go
@@ -161,6 +161,88 @@ func TestMultiDocumentRejected(t *testing.T) {
 	}
 }
 
+// F5.7, the shapes the decoder alone cannot see. goccy answers io.EOF for a
+// stream whose first document is empty and drops every later document with it,
+// so "---\n---\na: 1\n" used to parse as {} — worse than the data loss F5.7
+// exists to prevent, and exactly what `---`-prefixed generated YAML looks like.
+// A trailing "---" is a second (empty) document too, which the sibling
+// implementations all refuse.
+func TestMultiDocumentShapesRejected(t *testing.T) {
+	for _, src := range []string{
+		"---\n---\na: 1\n",
+		"---\n# generated\n---\na: 1\n",
+		"---\n---\n---\na: 1\n",
+		"--- null\n---\na: 1\n",
+		"---\n---\n",
+		"a: 1\n---\n",
+		"a: 1\n...\n---\nb: 2\n",
+		"a: 1\n...\nb: 2\n",
+		"%YAML 1.2\n---\n---\na: 1\n",
+	} {
+		t.Run(src, func(t *testing.T) {
+			_, err := yaml.Parse([]byte(src), "test.yaml")
+			if err == nil {
+				t.Fatalf("Parse(%q) succeeded, want a multi-document error", src)
+			}
+			if !strings.Contains(err.Error(), "F5.7") {
+				t.Errorf("error %q does not cite the spec item F5.7", err)
+			}
+		})
+	}
+}
+
+// The other half of the F5.7 count: a single document keeps parsing, however
+// it is spelled. A "---" inside a block scalar or a quoted string is text, and
+// a directive line belongs to the document after it rather than being one.
+func TestSingleDocumentShapesAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		src  string
+		want string
+	}{
+		{"a: 1\n", "1"},
+		{"---\na: 1\n", "1"},
+		{"a: 1\n...\n", "1"},
+		{"%YAML 1.2\n---\na: 1\n", "1"},
+		{"a: \"---\"\n", "---"},
+		{"a: |-\n  ---\n  ---\n", "---\n---"},
+	} {
+		t.Run(tc.src, func(t *testing.T) {
+			cfg, err := yaml.Parse([]byte(tc.src), "test.yaml")
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.src, err)
+			}
+			if got := cfg.GetString("a"); got != tc.want {
+				t.Errorf("a = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A stream that is only document markers holds one empty document, not two.
+func TestMarkerOnlyStreamIsEmptyObject(t *testing.T) {
+	for _, src := range []string{"---\n", "...\n", "   \n\n"} {
+		cfg, err := yaml.Parse([]byte(src), "test.yaml")
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", src, err)
+		}
+		if n := len(cfg.Keys()); n != 0 {
+			t.Errorf("Parse(%q) produced %d keys, want 0", src, n)
+		}
+	}
+}
+
+// The document count runs after the decode so that a broken document is still
+// reported as broken, not as a stream.
+func TestSyntaxErrorOutranksDocumentCount(t *testing.T) {
+	_, err := yaml.Parse([]byte("a: [1\n---\nb: 2\n"), "test.yaml")
+	if err == nil {
+		t.Fatal("malformed document accepted, want error")
+	}
+	if strings.Contains(err.Error(), "F5.7") {
+		t.Errorf("error %q reports the stream, not the syntax error the decoder saw", err)
+	}
+}
+
 // F5.8 — a duplicate key in hand-written YAML is a mistake, not an override.
 func TestDuplicateKeyRejected(t *testing.T) {
 	if _, err := yaml.Parse([]byte("a: 1\na: 2\n"), "test.yaml"); err == nil {


### PR DESCRIPTION
Closes #166.

## The bug

`yaml.Parse("---\n---\na: 1\n")` returned `{}` with no error, and so did any
`---`-prefixed stream whose first document holds only comments — the shape
generated YAML takes once a header block is stripped. Every document was
dropped, which is worse than the loss of document 2..n that F5.7 exists to
prevent.

The cause is that goccy answers `io.EOF` for these streams, the adapter read
that as "empty input" (F5.9), and the multi-document guard never ran.

## Why the count comes from the lexer

The issue suggested `parser.ParseBytes(data, 0).Docs`. Measured against goccy
v1.19.2 (already the latest release), that does not work — it reports the same
stream as **one body-less document**, so `a: 1` is gone at the AST layer too:

| input | `len(file.Docs)` | bodies |
|---|---|---|
| `---\n---\na: 1\n` | 1 | 0 |
| `---\n# c\n---\na: 1\n` | 1 | 0 |
| `---\n---\n---\na: 1\n` | 1 | 0 |

The lexer still emits both `---` tokens, and it is the only layer that knows a
`---` inside a block scalar or a quoted string is text rather than a header, so
the count is taken there. Directive lines are excluded: `%YAML 1.2` precedes
the `---` it applies to rather than being a document of its own.

Both F5.7 checks are kept, because they see different streams: the token count
misses `a: 1\n...\nb: 2\n` (second document, no header token), and the decode
misses every stream it never reaches. Both run *after* the first decode, so a
malformed document is still reported by the decoder, which words it better.

## Cross-implementation check

All 22 stream shapes were run against ts.hocon, rs.hocon and py.hocon. The
three agree with each other everywhere; go was the sole outlier on three
shapes, one of which is **not in the issue**:

| input | go (before) | ts / rs / py | go (after) |
|---|---|---|---|
| `---\n---\na: 1\n` | `{}` | F5.7 error | F5.7 error |
| `---\n# c\n---\na: 1\n` | `{}` | F5.7 error | F5.7 error |
| `---\n---\n` | `{}` | F5.7 error | F5.7 error |
| **`a: 1\n---\n`** (trailing empty doc) | `{"a":1}` | F5.7 error | F5.7 error |
| `---\n`, `...\n`, `""`, `# c\n` | `{}` | `{}` | `{}` |
| `a: 1\n...\n`, `%YAML 1.2\n---\na: 1\n` | `{"a":1}` | `{"a":1}` | `{"a":1}` |

So the trailing-`---` change closes an existing four-way parity gap rather than
opening one.

## SemVer

`BREAKING` in the CHANGELOG under a minor: input previously accepted is now
refused (the AGENTS.md rule for spec-correction fixes). The workaround is to
remove the extra `---`, or quote it if it was meant as a value.