### PR TITLE
ci: SHA-pin every action, pin golangci-lint, drop the inherited write grant

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,21 +6,29 @@ on:
   push:
     branches: [develop, main]
 
+# The repository default is write, so a workflow that says nothing gets it.
+# Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.25"
 
+      # Pinned for the same reason the actions above are: @latest runs whatever
+      # the newest tag points at today, in a job the repository default grants
+      # write. It also keeps a lint release from turning an unrelated PR red.
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
       - name: golangci-lint
         run: golangci-lint run --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,9 @@ jobs:
           go-version: "1.25"
 
       # Pinned for the same reason the actions above are: @latest runs whatever
-      # the newest tag points at today, in a job the repository default grants
-      # write. It also keeps a lint release from turning an unrelated PR red.
+      # the newest tag points at today, which is the mutable-tag risk in a
+      # different package manager. It also keeps a lint release from turning an
+      # unrelated PR red.
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Fetch via GOPROXY
         run: |
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
@@ -97,7 +97,7 @@ jobs:
           curl -sSf "https://sum.golang.org/lookup/${MODULE}@${VERSION}" || true
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.25"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [develop, main]
 
+# The repository default is write, so a workflow that says nothing gets it.
+# Nothing here writes; Codecov uploads with CODECOV_TOKEN, not with OIDC.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: go${{ matrix.go }} / ${{ matrix.os }}
@@ -22,15 +27,15 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Cache expected JSON
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             testdata/expected
@@ -61,7 +66,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.go == '1.25' && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: o3co/go.hocon
@@ -87,10 +92,10 @@ jobs:
         working-directory: adapters
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go }}
 
@@ -121,10 +126,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.25"
 


### PR DESCRIPTION
Closes #167.

## What the issue asked for

`release.yml` runs with `contents: write` and reached `softprops/action-gh-release@v2`
and `codecov/codecov-action@v5` by mutable major tag. Every action reference in
the repository is now pinned to the commit its current major tag resolves to,
with the exact version in a trailing comment:

| action | pinned SHA | tag resolved |
|---|---|---|
| `actions/checkout` | `fbc6f39…` | v5 → v5.1.0 |
| `actions/setup-go` | `924ae3a…` | v6 → v6.5.0 |
| `actions/cache` | `caa2961…` | v5 → v5.1.0 |
| `codecov/codecov-action` | `0fb7174…` | v5 → v5.5.5 |
| `softprops/action-gh-release` | `3bb1273…` | v2 → v2.6.2 |

**No version upgrades** — each pin is the major tag already in use, so CI
behaviour is unchanged. The four SHAs shared with rs.hocon (o3co/rs.hocon#154)
are identical, so the two repositories agree on what "v5" meant.

## Two things found while checking the blast radius

- **The repository's default workflow permission is `write`**
  (`default_workflow_permissions: "write"`, `can_approve_pull_request_reviews: true`).
  `lint.yml` and `test.yml` declare no `permissions:` block, so they were
  running with `contents: write` too — the issue's premise ("workflows that run
  with contents: write") covers all three, not just `release.yml`. Neither
  writes anything, so both now declare `contents: read`. Codecov uploads with
  `CODECOV_TOKEN`, not OIDC, so it needs nothing extra.

- **`lint.yml` installed golangci-lint from `@latest`** — the same mutable
  supply chain, in a job that until this commit had write. Pinned to v2.12.2,
  matching the reasoning behind rs.hocon's `cargo install cargo-set-version
  --locked --version 0.0.4`. It also stops a golangci-lint release from turning
  an unrelated PR red.

## Verification

All three workflow files re-parse as YAML. The change is declarative only — no
step logic touched.