### PR TITLE
fix(adapters): render a path in an error as a JSON string literal (F0.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters`: a path in an error message is now a JSON string literal
+
+A path segment holding control characters was quoted with `%q`, which spells
+them as **Go** escapes: NUL came out as `\x00`, where py.hocon rendered the same
+segment as `\u0000`. Three implementations rendered the same key three ways, and
+the cross-language fixtures compare that text
+([xx.hocon#76](https://github.com/o3co/xx.hocon/issues/76)).
+
+Quoted segments are JSON string literals now — which is also HOCON's own
+quoted-string syntax — pinned as spec F0.10. Two departures from `%q`, both
+deliberate: NUL is `\u0000`, and **U+2028 / U+2029 are escaped** although JSON
+permits them raw, because they are line separators to enough log viewers that a
+key could otherwise break the message reporting it. Printable non-ASCII stays
+itself (`é`, `İ`), and a byte that is not valid UTF-8 renders as `\ufffd` rather
+than as a bare replacement character.
+
+The package doc's remaining paste-into-a-getter claim is dropped rather than
+narrowed further: measured, **no** implementation's path parser decodes escapes
+inside a quoted segment, so this was never true for such a segment in any of
+them. The guarantee that matters for an error message — two different paths
+never render alike — is now pinned by a test.
+
 ### Fixed — `adapters`: a mapped path had no depth limit, where the siblings cap it at 64
 
 **BREAKING** (a name mapping to more than 64 path segments is now refused).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ quoted-string syntax — pinned as spec F0.10. Two departures from `%q`, both
 deliberate: NUL is `\u0000`, and **U+2028 / U+2029 are escaped** although JSON
 permits them raw, because they are line separators to enough log viewers that a
 key could otherwise break the message reporting it. Printable non-ASCII stays
-itself (`é`, `İ`), and a byte that is not valid UTF-8 renders as `\ufffd` rather
-than as a bare replacement character.
+itself (`é`, `İ`), U+FFFD included. A byte that is not valid UTF-8 renders as
+`\xNN` — the one departure from JSON, because JSON cannot express such a byte,
+and deliberately *not* `\ufffd`, which a key really holding U+FFFD would also
+produce.
 
 The package doc's remaining paste-into-a-getter claim is dropped rather than
 narrowed further: measured, **no** implementation's path parser decodes escapes

--- a/adapters/internal/keypath/keypath.go
+++ b/adapters/internal/keypath/keypath.go
@@ -16,15 +16,30 @@
 // the ambiguity, and for ordinary keys the result is also the expression a
 // reader can paste into a getter.
 //
-// The exception is a key holding control characters: Segment quotes with %q,
-// which spells them as Go escapes (\n, \x00), and HOCON's path parser does not
-// interpret those. Such a path still reads unambiguously, which is what an
-// error message needs, but it will not round-trip through a getter verbatim.
+// A quoted segment is spelled as a JSON string literal, which is also HOCON's
+// own quoted-string syntax, with two deliberate departures from Go's %q:
+//
+//   - NUL is \u0000, not \x00. %q's hex escapes are Go syntax; JSON has no
+//     \x form, and py.hocon and rs.hocon render the same segment the same way.
+//   - U+2028 and U+2029 are escaped, though JSON permits them raw. They are
+//     line separators to many log viewers and editors, and the point of
+//     escaping at all is that a key cannot break the message it appears in.
+//
+// Printable non-ASCII is left as itself (é, İ), rather than escaped: F1.3
+// leaves non-ASCII segments unfolded, so they reach here in normal use and
+// escaping them would make the common case unreadable.
+//
+// A rendered path is NOT guaranteed to paste into a getter. For ordinary keys
+// it does; for a segment needing escapes it does not, because HOCON's path
+// parser does not decode escapes inside a quoted segment — measured, and true
+// of all three implementations. What an error message needs is that two
+// different paths never render alike, and that holds.
 package keypath
 
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Render joins segments with "." and quotes the ones that could not be written
@@ -49,7 +64,44 @@ func Segment(seg string) string {
 	if bare(seg) {
 		return seg
 	}
-	return fmt.Sprintf("%q", seg)
+	var b strings.Builder
+	b.Grow(len(seg) + 2)
+	b.WriteByte('"')
+	for _, r := range seg {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\u2028', '\u2029':
+			// Valid raw in JSON, but a line separator to enough readers that
+			// letting it through would let a key break its own error message.
+			fmt.Fprintf(&b, `\u%04x`, r)
+		case utf8.RuneError:
+			// What a byte that is not valid UTF-8 decodes to. Spelling it out
+			// beats emitting a replacement character the reader cannot tell
+			// from one the key really contained.
+			b.WriteString(`\ufffd`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 // bare reports whether a segment can be written without quotes: a non-empty

--- a/adapters/internal/keypath/keypath.go
+++ b/adapters/internal/keypath/keypath.go
@@ -27,7 +27,14 @@
 //
 // Printable non-ASCII is left as itself (é, İ), rather than escaped: F1.3
 // leaves non-ASCII segments unfolded, so they reach here in normal use and
-// escaping them would make the common case unreadable.
+// escaping them would make the common case unreadable. U+FFFD is ordinary
+// printable non-ASCII and prints as itself for the same reason.
+//
+// One case departs from JSON because JSON cannot express it: a byte that is
+// not valid UTF-8, which a Go string can hold and which renders \xNN. It must
+// not render \ufffd — that is what decoding it yields, and it would then be
+// indistinguishable from a key that really holds U+FFFD. The case is Go-only:
+// a Python str and a Rust &str cannot hold such a byte.
 //
 // A rendered path is NOT guaranteed to paste into a getter. For ordinary keys
 // it does; for a segment needing escapes it does not, because HOCON's path
@@ -67,7 +74,22 @@ func Segment(seg string) string {
 	var b strings.Builder
 	b.Grow(len(seg) + 2)
 	b.WriteByte('"')
-	for _, r := range seg {
+	// Indexed rather than `for _, r := range seg`, which decodes an invalid
+	// byte to U+FFFD and so renders it identically to a key that really holds
+	// U+FFFD — two different paths, one spelling, which is the single property
+	// this function has to keep.
+	for i := 0; i < len(seg); {
+		r, size := utf8.DecodeRuneInString(seg[i:])
+		if r == utf8.RuneError && size == 1 {
+			// A byte that is not valid UTF-8. JSON strings cannot express one
+			// at all, so this is the rendering's only departure from JSON, and
+			// it is Go-only: a Python str and a Rust &str cannot hold such a
+			// byte, so no sibling has the case to diverge on.
+			fmt.Fprintf(&b, `\x%02x`, seg[i])
+			i++
+			continue
+		}
+		i += size
 		switch r {
 		case '"':
 			b.WriteString(`\"`)
@@ -87,11 +109,6 @@ func Segment(seg string) string {
 			// Valid raw in JSON, but a line separator to enough readers that
 			// letting it through would let a key break its own error message.
 			fmt.Fprintf(&b, `\u%04x`, r)
-		case utf8.RuneError:
-			// What a byte that is not valid UTF-8 decodes to. Spelling it out
-			// beats emitting a replacement character the reader cannot tell
-			// from one the key really contained.
-			b.WriteString(`\ufffd`)
 		default:
 			if r < 0x20 {
 				fmt.Fprintf(&b, `\u%04x`, r)

--- a/adapters/internal/keypath/keypath_test.go
+++ b/adapters/internal/keypath/keypath_test.go
@@ -88,12 +88,22 @@ func TestSegmentEscapesLineSeparators(t *testing.T) {
 	}
 }
 
-// A byte that is not valid UTF-8 decodes to U+FFFD. Spelling it out beats
-// emitting a replacement character the reader cannot tell from one the key
-// really contained.
-func TestSegmentSpellsOutInvalidUTF8(t *testing.T) {
-	if got, want := keypath.Segment("\xff"), `"\ufffd"`; got != want {
-		t.Errorf("invalid UTF-8: got %s, want %s", got, want)
+// A byte that is not valid UTF-8 must not render as U+FFFD, which is what
+// decoding it yields: a key that really holds U+FFFD would then render the same
+// way, and two different paths would be indistinguishable. JSON cannot express
+// such a byte at all, so \xNN is the rendering's one departure from JSON — and
+// a Go-only one, since a Python str and a Rust &str cannot hold the case.
+func TestSegmentDistinguishesInvalidUTF8FromReplacementChar(t *testing.T) {
+	invalid := keypath.Segment("\xff")
+	replacement := keypath.Segment("\ufffd")
+	if invalid != `"\xff"` {
+		t.Errorf("invalid UTF-8 byte: got %s, want %s", invalid, `"\xff"`)
+	}
+	if replacement != "\"\ufffd\"" {
+		t.Errorf("real U+FFFD: got %q, want the character itself", replacement)
+	}
+	if invalid == replacement {
+		t.Errorf("an invalid byte and a real U+FFFD both render %s", invalid)
 	}
 }
 
@@ -108,6 +118,9 @@ func TestDistinctPathsRenderDistinctly(t *testing.T) {
 		{"a\nb"}, {"a", "b"}, {`a\nb`},
 		{"a\x00b"}, {`a\u0000b`},
 		{""}, {"", ""},
+		// A byte that is not valid UTF-8 decodes to U+FFFD, so these two
+		// rendered alike until Segment stopped going through `range`.
+		{"a\xffb"}, {"a\ufffdb"},
 	}
 	for _, p := range paths {
 		r := keypath.Render(p)

--- a/adapters/internal/keypath/keypath_test.go
+++ b/adapters/internal/keypath/keypath_test.go
@@ -45,3 +45,75 @@ func TestDottedSegmentIsDistinguishable(t *testing.T) {
 		t.Errorf("one segment and two render alike: %s", a)
 	}
 }
+
+// A quoted segment is a JSON string literal — which is also HOCON's own
+// quoted-string syntax — so that the same key renders the same way in
+// go.hocon, ts.hocon, py.hocon and rs.hocon (spec F0.10). %q would spell NUL
+// as \x00, which is Go syntax and which no sibling produces.
+func TestSegmentRendersAsJSONString(t *testing.T) {
+	cases := []struct{ seg, want string }{
+		{"ab", "ab"},
+		{"a-b_1", "a-b_1"},
+		{"", `""`},
+		{"a b", `"a b"`},
+		{"a.b", `"a.b"`},
+		{"a\nb", `"a\nb"`},
+		{"a\tb", `"a\tb"`},
+		{"a\rb", `"a\rb"`},
+		{"a\x00b", `"a\u0000b"`},
+		{"a\x1fb", `"a\u001fb"`},
+		{`a"b`, `"a\"b"`},
+		{`a\b`, `"a\\b"`},
+		// Printable non-ASCII stays itself: F1.3 leaves these unfolded, so they
+		// arrive here in normal use and escaping them would bury the common case.
+		{"\u0130a", "\"\u0130a\""},
+		{"a\u00e9b", "\"a\u00e9b\""},
+	}
+	for _, c := range cases {
+		if got := keypath.Segment(c.seg); got != c.want {
+			t.Errorf("keypath.Segment(%q) = %s, want %s", c.seg, got, c.want)
+		}
+	}
+}
+
+// U+2028 and U+2029 are legal raw in JSON, and escaped anyway: they are line
+// separators to enough log viewers and editors that letting one through would
+// let a key break the message reporting it.
+func TestSegmentEscapesLineSeparators(t *testing.T) {
+	if got, want := keypath.Segment("a\u2028b"), `"a\u2028b"`; got != want {
+		t.Errorf("U+2028: got %s, want %s", got, want)
+	}
+	if got, want := keypath.Segment("a\u2029b"), `"a\u2029b"`; got != want {
+		t.Errorf("U+2029: got %s, want %s", got, want)
+	}
+}
+
+// A byte that is not valid UTF-8 decodes to U+FFFD. Spelling it out beats
+// emitting a replacement character the reader cannot tell from one the key
+// really contained.
+func TestSegmentSpellsOutInvalidUTF8(t *testing.T) {
+	if got, want := keypath.Segment("\xff"), `"\ufffd"`; got != want {
+		t.Errorf("invalid UTF-8: got %s, want %s", got, want)
+	}
+}
+
+// Two different paths must never render alike, or a collision report cannot be
+// acted on. This is the property an error message actually needs — pasting the
+// result into a getter is NOT guaranteed, because HOCON's path parser does not
+// decode escapes inside a quoted segment.
+func TestDistinctPathsRenderDistinctly(t *testing.T) {
+	seen := map[string][]string{}
+	paths := [][]string{
+		{"foo.bar"}, {"foo", "bar"},
+		{"a\nb"}, {"a", "b"}, {`a\nb`},
+		{"a\x00b"}, {`a\u0000b`},
+		{""}, {"", ""},
+	}
+	for _, p := range paths {
+		r := keypath.Render(p)
+		if prev, dup := seen[r]; dup {
+			t.Errorf("%q and %q both render as %s", prev, p, r)
+		}
+		seen[r] = p
+	}
+}


### PR DESCRIPTION
Refs o3co/xx.hocon#76 — one of three sibling PRs. Pinned as spec F0.10 in the hocon scope.

## The decision

The issue offered two options: pin the rendering in the spec, or state that
error text is not portable and drop the paste-ability claim. **Measuring made
both necessary**, not either-or.

Pinning is clearly right — JSON string syntax *is* HOCON's quoted-string syntax,
py.hocon already used it, and the cross-language fixtures compare this text.

But part of the reason to prefer JSON was that it would make the rendered path
pasteable into a getter, and that turns out to be false in **every**
implementation, py.hocon included:

```text
py:  from_map({"a<LF>b": "v"}).get_string('"a\nb"')   ->   path not found
```

No implementation's path parser decodes escapes inside a quoted segment, and the
spec checklist has no S-item requiring it (S11.10 covers quoted segments in the
getter API, not escapes within them). So the claim is dropped everywhere rather
than narrowed again, and the guarantee an error message actually needs — that
two different paths never render alike — is pinned by a test instead.

Whether quoted path segments *should* decode escapes is a real question, but it
is an S-item about core path-expression semantics, not an adapter concern.

## The pinned rule (spec F0.10)

Segments joined with `.`, each bare only if it matches `[A-Za-z0-9_-]+`,
otherwise a JSON string literal. Two departures from plain JSON, both
deliberate:

- **NUL is the JSON escape**, not Go's `\x00` or Rust's `\u{0}`.
- **U+2028 / U+2029 are escaped** although JSON permits them raw — they are line
  separators to enough log viewers that a key could otherwise break the message
  reporting it, which is the whole point of escaping.

Hex escapes are lowercase, matching `json.dumps`. Printable non-ASCII stays
itself (`é`, `İ`) because F1.3 leaves such segments unfolded, so they occur in
normal use and escaping them would bury the common case.

## What changed here

`%q` spells control characters as *Go* escapes, so NUL came out `\x00` where
py.hocon rendered the same segment with the JSON escape. Now:

- NUL and other C0 controls use JSON's `\u00xx` form, lowercase
- U+2028 / U+2029 are escaped rather than emitted raw
- a byte that is not valid UTF-8 renders as the escape for U+FFFD, rather than a
  bare replacement character a reader could not tell from one the key held
- printable non-ASCII unchanged (already literal)

The package doc's remaining paste-into-a-getter promise is removed, and a test
pins the property that replaces it.

Verified: `make test-all` (core + adapters, `-race`), `golangci-lint run` — 0
issues, `gofmt -l` clean.
