### PR TITLE
fix(adapters/jsonc)!: refuse an unpaired surrogate instead of substituting U+FFFD (F3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters/jsonc`: an unpaired surrogate became U+FFFD, silently
+
+**BREAKING** (input previously accepted is now refused).
+
+`jsonc.Parse` on `{"a":"\\ud800"}` returned a config whose value was U+FFFD, with
+no error: `encoding/json` substitutes the replacement character for an escape a
+Go string cannot hold. The config held a character the document never contained
+and nothing failed — the plausible-but-wrong output this spec ranks as the worst
+failure mode ([xx.hocon#75](https://github.com/o3co/xx.hocon/issues/75)).
+
+Now an error citing spec F3.5, which mirrors F2.8 for `.properties` — the
+reasoning transfers verbatim, and neither stdlib decoder does this for us. The
+check runs before the decode, because afterwards the evidence is gone. Valid
+surrogate **pairs** still combine into the astral codepoint, and keys are checked
+as well as values.
+
+For the record on the other three: rs.hocon already refused (serde_json does),
+py.hocon refuses as of its sibling change, and **ts.hocon deliberately accepts** —
+a JavaScript string is UTF-16 like Java's and holds one natively, the same
+S1.2.6-class divergence F2.8 already records.
+
 ### Fixed — `adapters`: a path in an error message is now a JSON string literal
 
 A path segment holding control characters was quoted with `%q`, which spells

--- a/adapters/jsonc/jsonc.go
+++ b/adapters/jsonc/jsonc.go
@@ -305,8 +305,16 @@ func checkStringSurrogates(lit []byte) error {
 		switch {
 		case hi >= 0xD800 && hi <= 0xDBFF:
 			lo, ok := 0, false
-			if i+11 < len(lit) && lit[i+6] == '\\' && lit[i+7] == 'u' {
+			if i+7 < len(lit) && lit[i+6] == '\\' && lit[i+7] == 'u' {
 				lo, ok = hex4(lit[i+8:])
+				if !ok {
+					// A \\u whose digits are malformed or truncated. Calling
+					// this an unpaired surrogate would blame the wrong half:
+					// the decoder says "invalid character in \\u escape" and
+					// points at the digits, which is the accurate error, and
+					// deferring to it is what the rest of this scan does.
+					return nil
+				}
 			}
 			if !ok || lo < 0xDC00 || lo > 0xDFFF {
 				return fmt.Errorf(

--- a/adapters/jsonc/jsonc.go
+++ b/adapters/jsonc/jsonc.go
@@ -85,6 +85,14 @@ func decode(data []byte, origin string) (any, error) {
 	}
 	cleaned = stripTrailingCommas(cleaned)
 
+	// F3.5, and it has to happen before the decode: encoding/json substitutes
+	// U+FFFD for an unpaired surrogate without a word, so by the time the
+	// decoder has spoken the evidence is gone and the config holds a character
+	// the document never contained.
+	if err := checkSurrogates(cleaned); err != nil {
+		return nil, fmt.Errorf("jsonc: %s: %w", describe(origin), err)
+	}
+
 	dec := json.NewDecoder(bytes.NewReader(cleaned))
 	dec.UseNumber() // keep the source's integer/float distinction (spec F0.5)
 
@@ -250,4 +258,92 @@ func stripTrailingCommas(data []byte) []byte {
 
 func isJSONSpace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// checkSurrogates rejects an unpaired \uXXXX surrogate escape (spec F3.5,
+// mirroring F2.8 for .properties).
+//
+// A Go string cannot hold a lone surrogate, so encoding/json substitutes
+// U+FFFD — silently, which makes it the plausible-but-wrong output this spec
+// ranks worst: the config holds a character the document never contained and
+// nothing failed. Refusing costs one pass over the string literals, which the
+// strip passes have already located.
+//
+// Only escapes are examined. A lone surrogate cannot appear as raw bytes in a
+// well-formed UTF-8 document, and one that does is caught by the decoder.
+func checkSurrogates(data []byte) error {
+	for i := 0; i < len(data); i++ {
+		if data[i] != '"' {
+			continue
+		}
+		end, err := endOfString(data, i)
+		if err != nil {
+			// Malformed input; the decoder reports it with better context.
+			return nil
+		}
+		if err := checkStringSurrogates(data[i:end]); err != nil {
+			return err
+		}
+		i = end - 1
+	}
+	return nil
+}
+
+func checkStringSurrogates(lit []byte) error {
+	for i := 0; i+5 < len(lit); i++ {
+		if lit[i] != '\\' {
+			continue
+		}
+		if lit[i+1] != 'u' {
+			i++ // an escaped byte, including \\ itself
+			continue
+		}
+		hi, ok := hex4(lit[i+2:])
+		if !ok {
+			return nil // the decoder words a bad escape better
+		}
+		switch {
+		case hi >= 0xD800 && hi <= 0xDBFF:
+			lo, ok := 0, false
+			if i+11 < len(lit) && lit[i+6] == '\\' && lit[i+7] == 'u' {
+				lo, ok = hex4(lit[i+8:])
+			}
+			if !ok || lo < 0xDC00 || lo > 0xDFFF {
+				return fmt.Errorf(
+					"\\u%04X is an unpaired high surrogate; a Go string cannot hold "+
+						"one, and admitting it would substitute U+FFFD for the character "+
+						"the document meant (spec F3.5)", hi)
+			}
+			i += 11
+		case hi >= 0xDC00 && hi <= 0xDFFF:
+			return fmt.Errorf(
+				"\\u%04X is an unpaired low surrogate; a Go string cannot hold one, "+
+					"and admitting it would substitute U+FFFD for the character the "+
+					"document meant (spec F3.5)", hi)
+		default:
+			i += 5
+		}
+	}
+	return nil
+}
+
+// hex4 reads exactly four hex digits.
+func hex4(b []byte) (int, bool) {
+	if len(b) < 4 {
+		return 0, false
+	}
+	v := 0
+	for _, c := range b[:4] {
+		switch {
+		case c >= '0' && c <= '9':
+			v = v<<4 | int(c-'0')
+		case c >= 'a' && c <= 'f':
+			v = v<<4 | int(c-'a'+10)
+		case c >= 'A' && c <= 'F':
+			v = v<<4 | int(c-'A'+10)
+		default:
+			return 0, false
+		}
+	}
+	return v, true
 }

--- a/adapters/jsonc/jsonc_test.go
+++ b/adapters/jsonc/jsonc_test.go
@@ -285,3 +285,58 @@ func TestUseAsSubstitutionSourceUnderHOCON(t *testing.T) {
 		t.Errorf("artifacts = %q, want ./dist/bundle.js", got)
 	}
 }
+
+// F3.5 — an unpaired surrogate escape is an error, mirroring F2.8 for
+// .properties.
+//
+// encoding/json substitutes U+FFFD for one without a word, so the config held a
+// character the document never contained and nothing failed: the
+// plausible-but-wrong output this spec ranks worst. rs.hocon already refused
+// (serde_json does); py.hocon kept the lone surrogate and failed later, at
+// encode time, far from the parse that admitted it. ts.hocon accepts it and
+// stays that way — JavaScript strings are UTF-16 like Java's, the S1.2.6-class
+// divergence F2.8 already records.
+func TestUnpairedSurrogateRejected(t *testing.T) {
+	for name, src := range map[string]string{
+		"lone high in a value": `{"a":"\ud800"}`,
+		"lone low in a value":  `{"a":"\udc00"}`,
+		"lone high in a key":   `{"\ud800":1}`,
+		"lone after a pair":    `{"a":"\ud83d\ude00\ud800"}`,
+		"high then non-low":    `{"a":"\ud800\u0041"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := jsonc.Parse([]byte(src), "test.jsonc")
+			if err == nil {
+				t.Fatalf("Parse(%s) succeeded, want an F3.5 error", src)
+			}
+			if !strings.Contains(err.Error(), "F3.5") {
+				t.Errorf("error %q does not cite the spec item F3.5", err)
+			}
+		})
+	}
+}
+
+// The other half: what must keep working. A valid pair is one astral
+// codepoint, and the scan must not mistake text that merely looks like an
+// escape for one.
+func TestSurrogateCheckLeavesValidDocumentsAlone(t *testing.T) {
+	for name, tc := range map[string]struct{ src, want string }{
+		"valid pair":      {`{"a":"\ud83d\ude00"}`, "\U0001F600"},
+		"astral literal":  {"{\"a\":\"\U0001F600\"}", "\U0001F600"},
+		"ordinary escape": {`{"a":"x\u0041y"}`, "xAy"},
+		// `\` is an escaped backslash, so the `u` after it is text, not an
+		// escape — a scan that just looked for `\u` would misread this.
+		"escaped backslash":      {`{"a":"\\u0041"}`, `\u0041`},
+		"surrogate-looking text": {`{"a":"\\ud800 is text"}`, `\ud800 is text`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := jsonc.Parse([]byte(tc.src), "test.jsonc")
+			if err != nil {
+				t.Fatalf("Parse(%s): %v", tc.src, err)
+			}
+			if got := cfg.GetString("a"); got != tc.want {
+				t.Errorf("a = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/adapters/jsonc/jsonc_test.go
+++ b/adapters/jsonc/jsonc_test.go
@@ -340,3 +340,26 @@ func TestSurrogateCheckLeavesValidDocumentsAlone(t *testing.T) {
 		})
 	}
 }
+
+// A high surrogate followed by a \u escape whose digits are malformed is the
+// decoder's error to report, not ours: it says "invalid character in \u
+// hexadecimal escape" and points at the digits, where an unpaired-surrogate
+// error would blame the wrong half. Deferring is what the rest of the scan
+// already does for a bad escape.
+func TestMalformedLowHalfIsTheDecodersError(t *testing.T) {
+	for name, src := range map[string]string{
+		"short hex": `{"a":"\ud800\u12"}`,
+		"bad digit": `{"a":"\ud800\uZZZZ"}`,
+		"truncated": `{"a":"\ud800\u"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := jsonc.Parse([]byte(src), "test.jsonc")
+			if err == nil {
+				t.Fatalf("Parse(%s) succeeded, want a decode error", src)
+			}
+			if strings.Contains(err.Error(), "F3.5") {
+				t.Errorf("error %q blames the surrogate, not the malformed escape", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs o3co/xx.hocon#75 — one of three sibling PRs. Pinned as spec F3.5 in the hocon scope.

## Measured before pinning

| impl | `{"a":"\ud800"}` before | after |
|---|---|---|
| **go.hocon** | parses, value is **U+FFFD** — no error | F3.5 error |
| **py.hocon** | parses, keeps the lone surrogate; fails later at encode time | F3.5 error |
| rs.hocon | already refused (serde_json does) | unchanged |
| ts.hocon | parses, keeps it | **unchanged, deliberately** |

go.hocon's was the worst: the config held a character the document never
contained and nothing failed — the plausible-but-wrong output this spec ranks as
its worst failure mode.

## The rule (spec F3.5)

An unpaired `\uXXXX` surrogate in a JSON/JSONC document is an error, mirroring
F2.8 for `.properties` — the reasoning transfers verbatim and neither stdlib
decoder does it for us. Valid **pairs** still combine into the astral codepoint.
Keys are checked as well as values: a key no lookup can match is worse than a
value, not better.

**ts.hocon accepts and stays that way.** A JavaScript string is UTF-16 like
Java's and holds a lone surrogate natively; a Go or Rust string cannot hold one
at all, and a Python `str` can hold one but cannot encode it as UTF-8. Refusing
in ts would be the spec overriding the host language rather than protecting
anyone — the same S1.2.6-class divergence F2.8 already records for the
properties adapter.

Whether the **core parser** follows is deliberately out of scope: that is HOCON
source text, so an S-item, and the four disagree there too (py.hocon's core
accepts a lone surrogate *and* does not combine valid pairs).

## What changed here

The check runs **before** the decode, because `encoding/json` destroys the
evidence: by the time it has returned, the escape is already U+FFFD.

Only escape sequences are examined, reusing the string-literal boundaries the
strip passes already locate. So `"\\u0041"` — an escaped backslash followed by
the text `u0041` — and `"\\ud800 is text"` are untouched, with tests for both.

Verified: `make test-all` (core + adapters, `-race`), `golangci-lint run` — 0
issues.

## SemVer

`BREAKING` in the CHANGELOG under a minor: input previously accepted is now
refused. Anything relying on the old behaviour was relying on U+FFFD in place of
the character it asked for.
