### PR TITLE
fix(adapters/env)!: filter by prefix before validating, and check the name (F1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ four implementations behaving identically by accident
   `OTHER__=x` was never checked at all. `load`'s contract already said which
   way this goes ("entries outside the prefix are never inspected", the F1.1
   principle); the two functions disagreeing was the actual inconsistency.
-- **`export` may be followed by any whitespace.** Matching the literal
+- **`export` may be followed by spaces or tabs.** Matching the literal
   `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
-  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
-  name that merely begins with `export` is still a name.
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. Space
+  and tab specifically, matching what this dialect already trims on the value
+  side; anything else leaves `export` part of the name, where the rule below
+  refuses it. A name that merely begins with `export` is still a name.
 - **A name containing whitespace or `#` is an error.** F1.7's rule for values —
   an error naming the fix rather than a guess about the author's intent —
   applies to names too; both characters mean the line was mis-parsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `.env`: the prefix filter runs first, and names are validated (F1.7)
+
+**BREAKING both ways**: a line the prefix discards is no longer validated (so a
+`.env` that used to fail may now load), and a name containing whitespace or `#`
+is now refused (so one that used to load may now fail).
+
+Three things, all pinned by an amended spec F1.7 after cross-checking found all
+four implementations behaving identically by accident
+([xx.hocon#78](https://github.com/o3co/xx.hocon/issues/78)):
+
+- **The prefix filter moves ahead of validation.** The value was parsed before
+  the filter and the path mapped after it, so one check landed on each side —
+  `BAD=x # y` failed even when the caller only wanted `APP_*`, while
+  `OTHER__=x` was never checked at all. `load`'s contract already said which
+  way this goes ("entries outside the prefix are never inspected", the F1.1
+  principle); the two functions disagreeing was the actual inconsistency.
+- **`export` may be followed by any whitespace.** Matching the literal
+  `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
+  name that merely begins with `export` is still a name.
+- **A name containing whitespace or `#` is an error.** F1.7's rule for values —
+  an error naming the fix rather than a guess about the author's intent —
+  applies to names too; both characters mean the line was mis-parsed.
+  `FOO BAR=baz` and `FOO#x=1` used to become the keys `foo bar` and `foo#x`.
+  Deliberately narrower than a POSIX name grammar, which would reject
+  `APP_FOO.BAR` — a name F1.2 documents as valid.
+
 ### Fixed — `adapters/jsonc`: an unpaired surrogate became U+FFFD, silently
 
 **BREAKING** (input previously accepted is now refused).

--- a/adapters/env/env.go
+++ b/adapters/env/env.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/o3co/go.hocon"
@@ -106,7 +107,7 @@ func Parse(data []byte, opts Options) (*hocon.Config, error) {
 	if !utf8.Valid(data) {
 		return nil, fmt.Errorf("env: %s: input is not valid UTF-8", origin)
 	}
-	pairs, err := parseDotEnv(string(data), origin)
+	pairs, err := parseDotEnv(string(data), origin, opts.Prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +262,14 @@ func lowerASCII(s string) string {
 	return string(b)
 }
 
-func parseDotEnv(s string, origin string) ([]pair, error) {
+// parseDotEnv reads .env text, keeping only the entries under prefix.
+//
+// The filter is applied here rather than in build, so that everything past it
+// — the value dialect, the name rule — is only asked of entries the caller
+// actually mounted (spec F1.7). A .env shared with tools that support trailing
+// comments stays loadable when you want one namespace out of it, which is the
+// rule Load already followed and this function did not.
+func parseDotEnv(s string, origin, prefix string) ([]pair, error) {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
 
@@ -272,15 +280,24 @@ func parseDotEnv(s string, origin string) ([]pair, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		line = strings.TrimPrefix(line, "export ")
+		line = stripExport(line)
 
 		name, rest, ok := strings.Cut(line, "=")
 		if !ok {
 			return nil, fmt.Errorf("env: %s:%d: expected NAME=value", origin, lineno)
 		}
 		name = strings.TrimSpace(name)
+		// The two checks before the filter are about the *line* rather than the
+		// entry: a line with no "=" is not a NAME=value pair at all, and an
+		// empty name gives nothing to compare the prefix against.
 		if name == "" {
 			return nil, fmt.Errorf("env: %s:%d: empty variable name", origin, lineno)
+		}
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if err := checkName(name); err != nil {
+			return nil, fmt.Errorf("env: %s:%d: %w", origin, lineno, err)
 		}
 		value, err := dotEnvValue(strings.TrimLeft(rest, " \t"))
 		if err != nil {
@@ -289,6 +306,48 @@ func parseDotEnv(s string, origin string) ([]pair, error) {
 		pairs = append(pairs, pair{name: name, value: value})
 	}
 	return pairs, nil
+}
+
+// stripExport drops a leading "export" and the whitespace after it (spec F1.7).
+//
+// Trimming the literal "export " missed a tab, so "export\tFOO=bar" became the
+// variable "export\tfoo" — a key nothing would ever look up, produced silently.
+func stripExport(line string) string {
+	rest, ok := strings.CutPrefix(line, "export")
+	if !ok {
+		return line
+	}
+	trimmed := strings.TrimLeft(rest, " \t")
+	if trimmed == rest {
+		// No whitespace after it, so this is a variable whose name merely
+		// begins with "export" (exportFOO=1), not the keyword.
+		return line
+	}
+	return trimmed
+}
+
+// checkName refuses a name that cannot have been meant (spec F1.7).
+//
+// F1.7's rule for values is an error naming the fix rather than a guess about
+// the author's intent; names get the same treatment. Whitespace or "#" inside
+// one means the line was mis-parsed — FOO BAR=baz and FOO#x=1 used to become
+// the keys "foo bar" and "foo#x".
+//
+// Deliberately narrower than a POSIX name grammar, which would reject
+// APP_FOO.BAR — a name F1.2 documents as valid and the fixtures exercise.
+func checkName(name string) error {
+	for _, r := range name {
+		if unicode.IsSpace(r) || r == '#' {
+			what := "whitespace"
+			if r == '#' {
+				what = `'#'`
+			}
+			return fmt.Errorf(
+				"variable name %q contains %s; the line is not NAME=value (spec F1.7)",
+				name, what)
+		}
+	}
+	return nil
 }
 
 func dotEnvValue(v string) (string, error) {

--- a/adapters/env/env.go
+++ b/adapters/env/env.go
@@ -264,9 +264,10 @@ func lowerASCII(s string) string {
 
 // parseDotEnv reads .env text, keeping only the entries under prefix.
 //
-// The filter is applied here rather than in build, so that everything past it
+// The filter is applied here as well as in build, so that everything past it
 // — the value dialect, the name rule — is only asked of entries the caller
-// actually mounted (spec F1.7). A .env shared with tools that support trailing
+// actually mounted (spec F1.7). build keeps its own filter because Load feeds
+// it the process environment, which never comes through this function. A .env shared with tools that support trailing
 // comments stays loadable when you want one namespace out of it, which is the
 // rule Load already followed and this function did not.
 func parseDotEnv(s string, origin, prefix string) ([]pair, error) {
@@ -308,10 +309,15 @@ func parseDotEnv(s string, origin, prefix string) ([]pair, error) {
 	return pairs, nil
 }
 
-// stripExport drops a leading "export" and the whitespace after it (spec F1.7).
+// stripExport drops a leading "export" and the spaces or tabs after it (F1.7).
 //
 // Trimming the literal "export " missed a tab, so "export\tFOO=bar" became the
 // variable "export\tfoo" — a key nothing would ever look up, produced silently.
+//
+// Space and tab specifically, not every Unicode space: that is what this
+// dialect already trims on the value side. Leaving the rest out is also the
+// better outcome — "export\fFOO=bar" is then a *name* of "export\fFOO", which
+// checkName refuses, rather than a keyword line producing a silently odd key.
 func stripExport(line string) string {
 	rest, ok := strings.CutPrefix(line, "export")
 	if !ok {

--- a/adapters/env/env_test.go
+++ b/adapters/env/env_test.go
@@ -459,7 +459,11 @@ func TestDotEnvFiltersBeforeItValidates(t *testing.T) {
 
 // "export " matched a single space only, so export<TAB>FOO=bar became the
 // variable export<TAB>foo — a key nothing would look up, produced silently.
-func TestDotEnvExportTakesAnyWhitespace(t *testing.T) {
+//
+// Spaces and tabs, matching what the dialect trims on the value side. Anything
+// else after "export" leaves it part of the name, where the F1.7 name rule
+// refuses it — an error rather than a silently odd key.
+func TestDotEnvExportTakesSpacesAndTabs(t *testing.T) {
 	for _, src := range []string{"export FOO=bar\n", "export\tFOO=bar\n", "export  FOO=bar\n"} {
 		cfg, err := env.Parse([]byte(src), env.Options{})
 		if err != nil {
@@ -473,6 +477,12 @@ func TestDotEnvExportTakesAnyWhitespace(t *testing.T) {
 		t.Fatalf("exportFOO: %v", err)
 	}
 	wantString(t, cfg, "exportfoo", "bar")
+
+	// A form feed is not one of the two, so "export" stays part of the name and
+	// the name rule rejects it. That is the intended outcome, not a gap.
+	if _, err := env.Parse([]byte("export\fFOO=bar\n"), env.Options{}); err == nil {
+		t.Error("export<FF>FOO was accepted; want the F1.7 name rule to refuse it")
+	}
 }
 
 // F1.7's rule for values — an error naming the fix rather than a guess about

--- a/adapters/env/env_test.go
+++ b/adapters/env/env_test.go
@@ -425,3 +425,74 @@ func repeatSeg(s string, n int) []string {
 	}
 	return out
 }
+
+// F1.7 — the prefix filter runs first, and only what survives it is validated.
+//
+// A .env shared with tools that support trailing comments has to stay loadable
+// when the caller wants one namespace out of it. Load already worked that way
+// ("entries outside the prefix are never inspected", F1.1); Parse disagreeing
+// with its sibling in the same package was the actual inconsistency, and all
+// four implementations had the same accidental split.
+func TestDotEnvFiltersBeforeItValidates(t *testing.T) {
+	for _, src := range []string{
+		"BAD=x # y\n",  // an ambiguous value, discarded by the prefix
+		"BAD NAME=x\n", // a name the rule below refuses, likewise discarded
+		"OTHER__=x\n",  // an empty path segment, likewise
+	} {
+		cfg, err := env.Parse([]byte(src), env.Options{Prefix: "APP_"})
+		if err != nil {
+			t.Errorf("Parse(%q) with a prefix that discards it: %v", src, err)
+			continue
+		}
+		if n := len(cfg.Keys()); n != 0 {
+			t.Errorf("Parse(%q) mounted %d keys, want 0", src, n)
+		}
+	}
+	// Kept by the prefix, so validated as strictly as ever.
+	if _, err := env.Parse([]byte("APP_BAD=x # y\n"), env.Options{Prefix: "APP_"}); err == nil {
+		t.Error("an ambiguous value under the prefix was accepted")
+	}
+	if _, err := env.Parse([]byte("APP___=x\n"), env.Options{Prefix: "APP_"}); err == nil {
+		t.Error("an empty path segment under the prefix was accepted")
+	}
+}
+
+// "export " matched a single space only, so export<TAB>FOO=bar became the
+// variable export<TAB>foo — a key nothing would look up, produced silently.
+func TestDotEnvExportTakesAnyWhitespace(t *testing.T) {
+	for _, src := range []string{"export FOO=bar\n", "export\tFOO=bar\n", "export  FOO=bar\n"} {
+		cfg, err := env.Parse([]byte(src), env.Options{})
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", src, err)
+		}
+		wantString(t, cfg, "foo", "bar")
+	}
+	// …and a name that merely begins with "export" is still a name.
+	cfg, err := env.Parse([]byte("exportFOO=bar\n"), env.Options{})
+	if err != nil {
+		t.Fatalf("exportFOO: %v", err)
+	}
+	wantString(t, cfg, "exportfoo", "bar")
+}
+
+// F1.7's rule for values — an error naming the fix rather than a guess about
+// the author's intent — applies to names too. These used to become the keys
+// "foo bar" and "foo#x".
+func TestDotEnvRefusesANameThatCannotHaveBeenMeant(t *testing.T) {
+	for _, src := range []string{"FOO BAR=baz\n", "FOO#x=1\n"} {
+		_, err := env.Parse([]byte(src), env.Options{})
+		if err == nil {
+			t.Fatalf("Parse(%q) succeeded, want an F1.7 error", src)
+		}
+		if !strings.Contains(err.Error(), "F1.7") {
+			t.Errorf("error %q does not cite the spec item F1.7", err)
+		}
+	}
+	// Deliberately narrower than a POSIX name grammar, which would reject this
+	// — a name F1.2 documents as valid.
+	cfg, err := env.Parse([]byte("FOO.BAR=v\n"), env.Options{})
+	if err != nil {
+		t.Fatalf("a dotted name must still parse: %v", err)
+	}
+	wantString(t, cfg, `"foo.bar"`, "v")
+}


### PR DESCRIPTION
One of four sibling PRs. Closes the code half of o3co/xx.hocon#78 and parts 1–2
of o3co/py.hocon#19; spec F1.7 is amended in the hocon scope.

## Why this needed a decision rather than a fix

Cross-checking parts 1 and 2 of py.hocon#19 found **all four implementations
behaving identically**: the value parsed *before* the prefix filter, the path
mapped *after* it. Neither placement was chosen — the split was an accident, and
the same accident everywhere. Fixing one implementation would have manufactured
a divergence rather than removing one.

| input | all four, before | all four, after |
|---|---|---|
| `parse_dotenv("BAD=x # y\n", prefix="APP_")` | raises | accepted, discarded |
| `parse_dotenv("BAD NAME=x\n", prefix="APP_")` | key `bad name` | discarded |
| `parse_dotenv("OTHER__=x\n", prefix="APP_")` | accepted, unchecked | accepted, discarded |
| `parse_dotenv("APP_BAD=x # y\n", prefix="APP_")` | raises | raises |
| `parse_dotenv("export\tFOO=bar\n")` | key `export\tfoo` | key `foo` |
| `parse_dotenv("FOO BAR=baz\n")` | key `foo bar` | F1.7 error |
| `parse_dotenv("FOO#x=1\n")` | key `foo#x` | F1.7 error |
| `parse_dotenv("FOO.BAR=v\n")` | key `foo.bar` | unchanged |

## The three rules

**Filter first.** A `.env` shared with tools that support trailing comments must
stay loadable when you want one namespace out of it. `load`'s own contract
already said which way this goes — *"entries outside the prefix are never
inspected"*, the F1.1 principle — so `parse_dotenv` disagreeing with its sibling
in the same module was the real inconsistency. Two checks stay ahead of the
filter, because they are about the *line* rather than the entry: a line with no
`=` is not a `NAME=value` pair at all, and an empty name gives nothing to
compare the prefix against.

**`export` takes any whitespace.** Matching the literal `export ` missed a tab,
so `export<TAB>FOO=bar` became the variable `export<TAB>foo` — silently. A name
that merely *begins* with `export` (`exportFOO=1`) is still a name.

**A name with whitespace or `#` is an error.** F1.7's stated rule for values is
an error naming the fix rather than a guess about the author's intent; names had
been getting the guess. Deliberately narrower than a POSIX name grammar
(`[A-Za-z_][A-Za-z0-9_]*`), which would reject `APP_FOO.BAR` — a name F1.2
documents as valid and which the shared fixtures exercise.

## SemVer

`BREAKING` **in both directions**, and the CHANGELOG says so: a `.env` that used
to fail may now load (the filter discards it before validation), and one that
used to load may now fail (the name rule). Minor, per the spec-correction rule.
