### PR TITLE
docs(adapters): cite the F-item spec at its public location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,18 @@ can hold a stale README back — only refusing to merge it can.
   shipped both since v1.10.0. Both tables now name the version they were
   verified against and carry the date.
 
+### Fixed — the F-item spec citations pointed at a document readers cannot open
+
+Seven doc comments, the `adapters/` README and the fixture manifest cited
+`docs/specs/format-ingestion-mapping.md`, which is not in this repository — it
+lived in a private working scope. Adapter errors name items from it (`(spec
+F0.5)`, `(spec F1.6)`), so anyone following a citation reached nothing. The
+spec is now published at
+[`xx.hocon/docs/format-ingestion-mapping.md`](https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md)
+and every citation points there
+([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)). Error text is
+unchanged; only the pointers move.
+
 ## [1.11.0] - 2026-07-26
 
 ### Added — `Config.RenderHOCON()`, a HOCON text emitter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@ can hold a stale README back — only refusing to merge it can.
 
 ### Fixed — the F-item spec citations pointed at a document readers cannot open
 
-Seven doc comments, the `adapters/` README and the fixture manifest cited
+Six doc comments, the `adapters/` README and the fixture manifest cited
 `docs/specs/format-ingestion-mapping.md`, which is not in this repository — it
 lived in a private working scope. Adapter errors name items from it (`(spec
 F0.5)`, `(spec F1.6)`), so anyone following a citation reached nothing. The

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -82,8 +82,8 @@ text, because the file belongs to a program that never agreed to HOCON's
 syntax.
 
 The mapping rules, including how each format's edge cases are pinned, live in
-`docs/specs/format-ingestion-mapping.md` in the `hocon` ecosystem scope. Items
-are cited from code and error messages as F0.1, F2.5 and so on.
+[`xx.hocon/docs/format-ingestion-mapping.md`](https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md).
+Items are cited from code and error messages as F0.1, F2.5 and so on.
 
 ## Packages
 

--- a/adapters/env/env.go
+++ b/adapters/env/env.go
@@ -24,7 +24,8 @@
 // Values are always strings and ${...} inside them stays literal, since the
 // environment belongs to whoever launched the process (spec F0.2, F1.4).
 //
-// See docs/specs/format-ingestion-mapping.md items F1.x in the hocon scope.
+// See the F1.x items in the format-ingestion mapping spec:
+// https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
 package env
 
 import (

--- a/adapters/internal/pathmap/pathmap.go
+++ b/adapters/internal/pathmap/pathmap.go
@@ -33,7 +33,8 @@ type Entry struct {
 
 // Build nests entries into the map[string]any accepted by hocon.FromMap.
 //
-// Two rules from docs/specs/format-ingestion-mapping.md apply:
+// Two rules from the format-ingestion mapping spec apply
+// (https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md):
 //
 //   - F2.5 (objects win): a path that is both a value and a parent of another
 //     path loses its scalar, so `a=1` plus `a.b=2` yields {"a":{"b":"2"}}.

--- a/adapters/jsonc/jsonc.go
+++ b/adapters/jsonc/jsonc.go
@@ -35,7 +35,8 @@
 // is versioned separately from the parser: see the module README for the
 // go get line and the core-version requirement.
 //
-// See docs/specs/format-ingestion-mapping.md items F3.x in the hocon scope.
+// See the F3.x items in the format-ingestion mapping spec:
+// https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
 package jsonc
 
 import (

--- a/adapters/properties/properties.go
+++ b/adapters/properties/properties.go
@@ -26,7 +26,8 @@
 // The syntax layer is shared with the parser's own `include "x.properties"`
 // handling, so the two cannot drift apart.
 //
-// See docs/specs/format-ingestion-mapping.md items F2.x in the hocon scope.
+// See the F2.x items in the format-ingestion mapping spec:
+// https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
 package properties
 
 import (

--- a/adapters/testdata-format-ingestion/manifest.json
+++ b/adapters/testdata-format-ingestion/manifest.json
@@ -1,6 +1,6 @@
 {
   "about": [
-    "Fixtures for the format adapters (docs/specs/format-ingestion-mapping.md, F-items).",
+    "Fixtures for the format adapters (docs/format-ingestion-mapping.md, F-items).",
     "",
     "Unlike expected/hocon/, these expectations are NOT generated from Lightbend.",
     "Lightbend has no equivalent of these adapters, so there is no oracle: the",

--- a/adapters/toml/toml.go
+++ b/adapters/toml/toml.go
@@ -17,7 +17,8 @@
 // so all four TOML date-time types become their RFC 3339 string forms, which
 // is the honest representation rather than a lossy number (spec F4.2).
 //
-// See docs/specs/format-ingestion-mapping.md items F4.x in the hocon scope.
+// See the F4.x items in the format-ingestion mapping spec:
+// https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
 package toml
 
 import (

--- a/adapters/yaml/yaml.go
+++ b/adapters/yaml/yaml.go
@@ -36,7 +36,8 @@
 // is versioned separately from the parser: see the module README for the
 // go get line and the core-version requirement.
 //
-// See docs/specs/format-ingestion-mapping.md items F5.x in the hocon scope.
+// See the F5.x items in the format-ingestion mapping spec:
+// https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
 package yaml
 
 import (


### PR DESCRIPTION
Part of o3co/xx.hocon#81. Depends on o3co/xx.hocon#82 — the URL resolves once
that is on `main`.

## The problem

Eight places here cited `docs/specs/format-ingestion-mapping.md`:

| Where | Count |
|---|---:|
| package doc comments (`env`, `properties`, `jsonc`, `toml`, `yaml`) | 5 |
| `adapters/internal/pathmap/pathmap.go` | 1 |
| `adapters/README.md` | 1 |
| `adapters/testdata-format-ingestion/manifest.json` | 1 |

**That file is not in this repository.** It lived only in a private working
scope, and the `in the hocon scope` qualifier named a place the reader still
could not reach. The adapters raise errors that cite items from it — `(spec
F0.5)`, `(spec F1.6)`, `(spec F3.5)` — so following one led nowhere.

## The change

All eight now point at
<https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md>.

The manifest's `about` line is updated to the same relative path xx.hocon now
uses, so it matches what `make testdata` will fetch rather than drifting back on
the next sync.

**Error text is unchanged** — the items were always cited by number, never by
path, so nothing user-visible moves except where the number resolves.

## Test plan

- `go build ./...` + `go vet ./...` in `adapters/` — clean
- `gofmt -l ./adapters/` — empty
- `go test ./...` in `adapters/` — pass

The root module's `TestSubstTokenizeErrors` fails in a fresh checkout without
`make testdata` (the fixtures are gitignored and downloaded); unrelated to this
change and green in CI, which runs the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)