### PR TITLE
docs(adapters): the fixture manifest cites the spec by URL

### DIFF
--- a/adapters/testdata-format-ingestion/manifest.json
+++ b/adapters/testdata-format-ingestion/manifest.json
@@ -1,6 +1,7 @@
 {
   "about": [
-    "Fixtures for the format adapters (docs/format-ingestion-mapping.md, F-items).",
+    "Fixtures for the format adapters (F-items). The mapping spec:",
+    "https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md",
     "",
     "Unlike expected/hocon/, these expectations are NOT generated from Lightbend.",
     "Lightbend has no equivalent of these adapters, so there is no oracle: the",


### PR DESCRIPTION
Follow-up to the merged reference PR, from a Copilot review on [rs.hocon#166](https://github.com/o3co/rs.hocon/pull/166).

That PR set the vendored manifest's `about` line to `docs/format-ingestion-mapping.md` — correct relative to xx.hocon, and **unresolvable from here**, which is where a reader actually opens this file. Same defect as o3co/xx.hocon#81, one level down.

Fixed upstream in [xx.hocon#83](https://github.com/o3co/xx.hocon/pull/83) (absolute URL) and mirrored here so the next `make testdata` is a no-op instead of a revert.

## Test plan

`json.load` on the manifest — valid. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)