### PR TITLE
test(adapters/env): pin F1.7 name whitespace to Unicode White_Space

### DIFF
--- a/adapters/env/env_test.go
+++ b/adapters/env/env_test.go
@@ -485,6 +485,35 @@ func TestDotEnvExportTakesSpacesAndTabs(t *testing.T) {
 	}
 }
 
+// F1.7 pins "whitespace" in a name to the Unicode White_Space property rather
+// than to whichever predicate a stdlib offers, because the four do not agree.
+// Enumerated over the whole codepoint space on 2026-07-31:
+//
+//	Go unicode.IsSpace   == White_Space
+//	Rust is_whitespace   == White_Space
+//	Python str.isspace   == White_Space + U+001C..U+001F
+//	JS regex \\s          == White_Space - U+0085 + U+FEFF
+//
+// Go is already exactly right, so this test exists to keep it that way — the
+// two codepoints below are the ones that separate the four, and swapping
+// unicode.IsSpace for a hand-rolled ASCII check or a wider set would move one.
+func TestDotEnvNameWhitespaceIsUnicodeWhiteSpace(t *testing.T) {
+	// U+0085 NEL is White_Space, so it is a mis-parse and refused. ts.hocon
+	// accepted it until the same spec item was pinned.
+	if _, err := env.Parse([]byte("FOO\u0085BAR=baz\n"), env.Options{}); err == nil {
+		t.Error("a name containing U+0085 was accepted; White_Space includes it")
+	}
+
+	// U+001F UNIT SEPARATOR is not White_Space, so it is an ordinary name
+	// character. Python's str.isspace disagrees, which is why the set is
+	// pinned here rather than inherited.
+	cfg, err := env.Parse([]byte("FOO\u001fBAR=baz\n"), env.Options{})
+	if err != nil {
+		t.Fatalf("a name containing U+001F must parse: %v", err)
+	}
+	wantString(t, cfg, "foo\u001fbar", "baz")
+}
+
 // F1.7's rule for values — an error naming the fix rather than a guess about
 // the author's intent — applies to names too. These used to become the keys
 // "foo bar" and "foo#x".

--- a/adapters/format_ingestion_test.go
+++ b/adapters/format_ingestion_test.go
@@ -38,6 +38,7 @@ type manifest struct {
 		Format   string `json:"format"`
 		Input    string `json:"input"`
 		Kind     string `json:"kind"`
+		Prefix   string `json:"prefix"`
 		Expect   string `json:"expect"`
 		Expected string `json:"expected"`
 		Cites    string `json:"cites"`
@@ -72,7 +73,7 @@ func TestFormatIngestionFixtures(t *testing.T) {
 				t.Fatalf("read input: %v", err)
 			}
 
-			cfg, err := ingest(c.Format, c.Kind, data, c.ID)
+			cfg, err := ingest(c.Format, c.Kind, c.Prefix, data, c.ID)
 
 			if c.Expect == "error" {
 				if err == nil {
@@ -109,7 +110,10 @@ func TestFormatIngestionFixtures(t *testing.T) {
 	}
 }
 
-func ingest(format, kind string, data []byte, origin string) (*hocon.Config, error) {
+// ingest dispatches a case to its adapter. prefix is the manifest's optional
+// `prefix`, which only `dotenv` cases carry — an `env-vars` input names its own
+// prefix inside the JSON document.
+func ingest(format, kind, prefix string, data []byte, origin string) (*hocon.Config, error) {
 	switch format {
 	case "jsonc":
 		return jsonc.Parse(data, origin)
@@ -121,7 +125,7 @@ func ingest(format, kind string, data []byte, origin string) (*hocon.Config, err
 		return yaml.Parse(data, origin)
 	case "env":
 		if kind == "dotenv" {
-			return env.Parse(data, env.Options{Origin: origin})
+			return env.Parse(data, env.Options{Prefix: prefix, Origin: origin})
 		}
 		var f envFixture
 		if err := json.Unmarshal(data, &f); err != nil {


### PR DESCRIPTION
## What the cross-check found

The four `.env` name checks each used their host stdlib's whitespace predicate. Enumerated over the whole codepoint space (2026-07-31), those four are **not the same set**:

| implementation | predicate | set |
|---|---|---|
| go.hocon | `unicode.IsSpace` | `White_Space` |
| rs.hocon | `char::is_whitespace` | `White_Space` |
| py.hocon | `str.isspace` | `White_Space` **+ U+001C–U+001F** |
| ts.hocon | `/\s/` | `White_Space` **− U+0085** **+ U+FEFF** |

So the same `.env` got different answers:

- `FOO<NEL>BAR=baz` — an error in go / rs / py, the key `foo<NEL>bar` in ts.
- `FOO<US>BAR=baz` — an error in py only.

F1.7 said "a name containing whitespace … is an error" without saying what whitespace is, which is exactly the hole F1.3 exists to close for case folding: **whether a name is refused must not depend on which stdlib helper the implementation reached for.**

## The fix

F1.7 now pins the Unicode `White_Space` property (spec amended in the sibling xx.hocon PR). U+FEFF is deliberately *not* whitespace — F0.9 already removes the realistic case, a leading BOM, and a citable definition beats hand-listing invisible codepoints.

**This is not a released behaviour.** The name rule itself landed in this same unreleased 1.12.0 window, so pinning its edge now costs users nothing; after the tag it would be a second breaking change.

## Also here

The fixture runner now reads a `dotenv` case's optional `prefix`. xx.hocon's new `fi18-dotenv-prefix` needs it, and a runner that ignores it **fails** that case rather than passing it vacuously — the line the case expects to be filtered away is one the dialect otherwise refuses.

## go specifically

**No behaviour change** — `unicode.IsSpace` is already exactly `White_Space`. The test exists so it stays that way: the two codepoints it uses are the ones that separate the four, so swapping in a hand-rolled ASCII check or a wider set moves one of them.

## Test plan

- `go test ./env/ -run TestDotEnvNameWhitespaceIsUnicodeWhiteSpace -v` — PASS
- fixture runner against the unmerged xx.hocon fixtures (copied in locally, then reverted): `fi18-dotenv-prefix` and `fi19-dotenv-name-nel` both PASS
- `gofmt -l ./adapters/` empty, `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)