### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-31
+
+Cross-impl release, coordinated to land at v1.12.0 across go.hocon / ts.hocon /
+rs.hocon / py.hocon so the ecosystem stays on one version line.
+
+**Minor, not patch, and one change is BREAKING in both directions**: the `.env`
+adapter now runs the prefix filter before validation (a file that used to fail
+may now load) and refuses a variable name containing whitespace or `#` (a file
+that used to load may now fail). Both follow from a spec amendment made after a
+cross-check found all four implementations behaving identically *by accident*
+— see [xx.hocon#78](https://github.com/o3co/xx.hocon/issues/78).
+
+The rest is adapter hardening: a silent U+FFFD substitution stopped, a
+depth limit that the siblings had and this one did not, a YAML stream whose
+first document was empty discarding the whole file, and error-message paths
+pinned to one rendering across the four implementations.
+
+The F-item spec these errors cite is now public at
+[`xx.hocon/docs/format-ingestion-mapping.md`](https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md);
+it previously lived in a private working scope, so every `(spec F0.5)`-style
+citation pointed at a document the reader could not open.
+
+Go modules take the version from the tag; there is no version file to bump.
+
 ### Changed — `.env`: the prefix filter runs first, and names are validated (F1.7)
 
 **BREAKING both ways**: a line the prefix discards is no longer validated (so a


### PR DESCRIPTION
Release-prep for **1.12.0**, the cross-impl minor covering this window's 39 merged PRs. CHANGELOG only — no code, no version file.

## What this does

`## [Unreleased]` → `## [1.12.0] - 2026-07-31`, with a lead paragraph naming the breaking change. `[Unreleased]` is left empty, matching how 1.11.0 was cut.

**Minor, not patch, and `.env` is BREAKING in both directions:**

- the prefix filter now runs **before** validation — a `.env` that used to fail may now load
- a variable name containing whitespace or `#` is **refused** — one that used to load may now fail

Both follow from a spec amendment made after a cross-check found all four implementations behaving identically *by accident* ([xx.hocon#78](https://github.com/o3co/xx.hocon/issues/78)).

## Verified, not assumed

The release workflow extracts the section with

```awk
index($0, "## [" ver "]") == 1 { flag=1; next }
flag && index($0, "## [") == 1 { flag=0 }
flag
```

and **aborts the release if the result is empty** — deliberately, because none of npm / crates.io / PyPI allow republishing a version, so a publish followed by a failed release step would leave a half-shipped tag.

I ran that exact awk against this file at `ver=1.12.0`. It finds the section and every `###` subsection under it.

## Not in this PR

- **No version file.** All four take the published version from the tag: go modules have none, `package.json` stays `0.0.0-snapshot`, `pyproject.toml` stays `0.0.0`, and rs's release workflow runs `cargo set-version` from the tag.
- **The go `adapters` module require bump is a post-tag step**, not this PR — `adapters/go.mod` cannot require `go.hocon v1.12.0` before that tag exists. Same shape as v1.11.0 (`b7e661e` came after `4d4ad88`).
- **hocon2's dependency bump** likewise waits for the go tags.
- **Tagging and publishing are not part of this PR** and need separate explicit authorization per the project's release rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
