### PR TITLE
chore(adapters): require core v1.12.0

### DIFF
--- a/adapters/go.mod
+++ b/adapters/go.mod
@@ -3,7 +3,7 @@ module github.com/o3co/go.hocon/adapters
 go 1.23.0
 
 require (
-	github.com/o3co/go.hocon v1.11.0
+	github.com/o3co/go.hocon v1.12.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 )
 


### PR DESCRIPTION
One line in `adapters/go.mod`. Core [v1.12.0](https://github.com/o3co/go.hocon/releases/tag/v1.12.0) is tagged and on the proxy (`bb149fad`), so the adapters module can require it and `adapters/v1.12.0` becomes taggable.

## Why the order matters

`release.yml` builds an adapters tag the way `go get` delivers it — **no checkout, no `replace`** — so a tag whose core requirement the proxy cannot satisfy fails there rather than at a user's build. Core first, adapters second.

## Why this bump is cosmetic, and why it is still here

**The core module had no source change in this window.** Everything in the 1.12.0 CHANGELOG lives under `adapters/`; the root module saw only workflows, CHANGELOG, README and `docs_test.go`. So adapters v1.12.0 would have worked correctly requiring core v1.11.0.

It is bumped anyway so the pairing stays legible — `adapters/vX.Y.Z` requires core `vX.Y.Z`, which is what CONTRIBUTING tells a reader to expect. Same shape as `b7e661e` for v1.11.0, which also touched only this one line (no `go.sum` entry, because the `replace` means the core is never fetched in-repo).

## Test plan

`go mod tidy`, `go build ./...`, `go test ./...` in `adapters/` — clean.

Then the consumer view from CONTRIBUTING, run for real against the published core:

```text
$ go mod edit -dropreplace=github.com/o3co/go.hocon
$ GOFLAGS=-mod=mod go test -count=1 ./...
go: downloading github.com/o3co/go.hocon v1.12.0
ok  github.com/o3co/go.hocon/adapters                   0.874s
ok  github.com/o3co/go.hocon/adapters/env               1.245s
ok  github.com/o3co/go.hocon/adapters/internal/keypath  0.522s
ok  github.com/o3co/go.hocon/adapters/internal/pathmap  1.923s
ok  github.com/o3co/go.hocon/adapters/jsonc             1.620s
ok  github.com/o3co/go.hocon/adapters/properties        2.636s
ok  github.com/o3co/go.hocon/adapters/toml              2.296s
ok  github.com/o3co/go.hocon/adapters/yaml              2.952s
```

That is the check the CI job skips when the required version is not yet on the proxy; it is real now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)