### PR TITLE
fix(ci): make the adapters release verification actually pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,36 @@ jobs:
           MODULE="github.com/o3co/go.hocon/adapters"
           mkdir -p /tmp/adapters-consumer && cd /tmp/adapters-consumer
           go mod init consumer
-          go get "${MODULE}@${VERSION}"
           for pkg in env jsonc properties toml yaml; do
             printf 'package main\nimport _ "%s/%s"\n' "$MODULE" "$pkg" > "use_${pkg}.go"
           done
           printf 'package main\nfunc main() {}\n' > main.go
+
+          # Retry, because this workflow races the tag that triggered it. Until
+          # the proxy has indexed the nested module, `go get` does not fail —
+          # it falls back to the parent module and reports that
+          # github.com/o3co/go.hocon does not contain package .../adapters,
+          # which reads like a packaging mistake and is not one. Runs 1 and 2
+          # of adapters/v1.12.0 failed exactly that way; run 3, six minutes
+          # later, resolved the module.
+          for attempt in 1 2 3 4 5 6; do
+            if go get "${MODULE}@${VERSION}"; then
+              break
+            fi
+            if [ "$attempt" = 6 ]; then
+              echo "::error::${MODULE}@${VERSION} did not become resolvable; the tag may be missing or the module broken"
+              exit 1
+            fi
+            echo "not resolvable yet (attempt ${attempt}/6) — the proxy is probably still indexing; retrying in 60s"
+            sleep 60
+          done
+
+          # Required, and the reason this job has failed since
+          # adapters/v1.11.0. `go get MODULE@VERSION` records that module and
+          # nothing else: the go.sum entries for the packages it imports —
+          # the core module, go-toml, go-yaml — are never written, so the
+          # build below fails on every one of them. Creating the import files
+          # first does not help; only resolving the graph does.
+          go mod tidy
+
           go build ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,13 @@ job. When the require names a version the proxy does not have yet — which is
 the normal state of a PR that bumps it ahead of the tag — the job warns and
 skips, and the release workflow runs the check for real once the tag exists.
 
+Run `go mod tidy` before the build if you reproduce it by hand. `go get
+MODULE@VERSION` records that module and nothing else, so the go.sum entries for
+what it imports — the core module, go-toml, go-yaml — are missing and the build
+fails on every one of them. The snippet above avoids this by copying a checkout
+that already has a complete `go.sum`; a scratch consumer built from `go mod
+init` does not.
+
 So the rule is: **a core change that the adapters use means bumping the core
 version in `adapters/go.mod` in the same PR**, to the version that will be
 tagged. See [Releasing](#releasing) for the tag order that makes that
@@ -128,6 +135,14 @@ The two modules are released together, in this order:
 module was tagged, and for an adapters tag it also builds the published module
 the way `go get` delivers it — no checkout, no `replace` — so a tag whose core
 requirement cannot be satisfied fails there rather than at a user's build.
+
+That job **retries** the `go get`, because the workflow races the tag that
+triggered it. Until the proxy has indexed the nested module, `go get` does not
+report it as missing — it falls back to the parent module and says
+`github.com/o3co/go.hocon@vX.Y.Z found, but does not contain package
+github.com/o3co/go.hocon/adapters`. That reads like a packaging mistake and is
+not one; it means "not indexed yet". For `adapters/v1.12.0` it cleared about six
+minutes after the tag.
 
 The adapters version tracks the core version it pairs with (the first tag will
 be `adapters/v1.10.x`), so a reader can tell at a glance which parser a given

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,12 +77,12 @@ job. When the require names a version the proxy does not have yet — which is
 the normal state of a PR that bumps it ahead of the tag — the job warns and
 skips, and the release workflow runs the check for real once the tag exists.
 
-Run `go mod tidy` before the build if you reproduce it by hand. `go get
-MODULE@VERSION` records that module and nothing else, so the go.sum entries for
-what it imports — the core module, go-toml, go-yaml — are missing and the build
-fails on every one of them. The snippet above avoids this by copying a checkout
-that already has a complete `go.sum`; a scratch consumer built from `go mod
-init` does not.
+Run `go mod tidy` before the build if you reproduce it by hand.
+`go get MODULE@VERSION` records that module and nothing else, so the go.sum
+entries for what it imports — the core module, go-toml, go-yaml — are missing
+and the build fails on every one of them. The snippet above avoids this by
+copying a checkout that already has a complete `go.sum`; a scratch consumer
+built from `go mod init` does not.
 
 So the rule is: **a core change that the adapters use means bumping the core
 version in `adapters/go.mod` in the same PR**, to the version that will be
@@ -138,11 +138,17 @@ requirement cannot be satisfied fails there rather than at a user's build.
 
 That job **retries** the `go get`, because the workflow races the tag that
 triggered it. Until the proxy has indexed the nested module, `go get` does not
-report it as missing — it falls back to the parent module and says
-`github.com/o3co/go.hocon@vX.Y.Z found, but does not contain package
-github.com/o3co/go.hocon/adapters`. That reads like a packaging mistake and is
-not one; it means "not indexed yet". For `adapters/v1.12.0` it cleared about six
-minutes after the tag.
+report it as missing — it falls back to the parent module and says:
+
+```text
+go: module github.com/o3co/go.hocon@vX.Y.Z found,
+    but does not contain package github.com/o3co/go.hocon/adapters
+```
+
+That reads like a packaging mistake and is not one; it means "not indexed yet",
+and the parent genuinely does not contain that package because `adapters/` is a
+nested module. For `adapters/v1.12.0` it cleared about six minutes after the
+tag.
 
 The adapters version tracks the core version it pairs with (the first tag will
 be `adapters/v1.10.x`), so a reader can tell at a glance which parser a given


### PR DESCRIPTION
The `Trigger Go module proxy indexing (adapters)` job has **never passed** — it failed for `adapters/v1.11.0` on 2026-07-26 and again for `adapters/v1.12.0` today. Both modules published correctly; only the verification script is broken, which is why nobody noticed.

Two independent causes, both reproduced with a cold module cache before fixing.

## 1. `go.sum` is never populated

This is the `v1.11.0` failure and the third `v1.12.0` attempt.

```bash
go get MODULE@VERSION   # records that module and nothing else
go build ./...          # needs go.sum for everything it imports
```

```text
missing go.sum entry for go.mod file: github.com/o3co/go.hocon@v1.12.0
missing go.sum entry for module providing package github.com/pelletier/go-toml/v2
missing go.sum entry for module providing package github.com/goccy/go-yaml
```

**Creating the import files before `go get` does not fix it** — I tried that first, since the ordering looks like the obvious culprit:

```text
files first → go get → go build
../mod/.../adapters@v1.12.0/env/env.go:40:2: missing go.sum entry for go.mod file
```

It is not an ordering problem. `go get MODULE@VERSION` resolves the named module, full stop. `go mod tidy` is what resolves the graph, and with it all five packages build.

## 2. The job races the tag that triggered it

This is why attempts 1 and 2 for `adapters/v1.12.0` failed differently:

```text
attempt 1, 2:  go: downloading github.com/o3co/go.hocon v1.12.0          ← parent
               go: module github.com/o3co/go.hocon@v1.12.0 found,
                   but does not contain package .../adapters
attempt 3:     go: downloading github.com/o3co/go.hocon/adapters v1.12.0 ← nested
               go: added github.com/o3co/go.hocon/adapters v1.12.0
```

Before the proxy indexes the nested module, `go get` **does not fail** — it falls back to the parent and reports that the parent lacks the package. That message reads like a packaging mistake and is not one; it means "not indexed yet". The parent genuinely does not contain that package, by design, because `adapters/` is a nested module.

It cleared about six minutes after the tag. The fix retries six times at 60s.

## Verified

The fixed script, run end to end against `adapters@v1.12.0` with an isolated `GOMODCACHE`, Go 1.25 (matching CI), through the proxy with sumdb verification:

```text
go get ok (attempt 1)
=== FIXED SCRIPT: build succeeded ===
```

`release.yml` parses as valid YAML; both jobs still present.

## `adapters/v1.12.0` stays red

Re-running executes the workflow **as it exists in the tagged commit**. Making the fix apply would mean changing that commit, which means moving the tag — and the proxy has already cached `adapters/v1.12.0` at `3c1c3eab`. Moving a published tag is the one thing not to do here. The job is red; the module is verified by hand and consumable.

## Also

`CONTRIBUTING.md` gains both facts: `go mod tidy` when reproducing by hand, and what the misleading "does not contain package" message actually means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
