### PR TITLE
fix(resolver): env-var fallback tries the full base before the bare one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Behavior
+
+- **Env-var fallback for a relativized substitution now tries the full base
+  before the bare one, matching `${X[]}` and the three sibling implementations.**
+  A substitution written in an included file is relativized, so `${a.b}` inside a
+  file mounted at `foo` has two candidate env-var names: `foo.a.b` (full) and
+  `a.b` (bare). This resolver consulted the bare one first for `${X}` — the
+  lookup sat inside the S14c.2 original-path block, which runs before the
+  env-var stage at the bottom of `resolveSubst` — while `${X[]}` went through
+  `resolveEnvList` and tried full first. The two forms therefore disagreed with
+  each other, and the scalar form disagreed with ts.hocon / rs.hocon / py.hocon,
+  which all try full first. The bare lookup now sits after the full one; config
+  exhaustion (prefixed + original-path, S14c.2) is unchanged and still runs
+  before either.
+
+  Reaching a behavior difference requires both names to be set, and neither can
+  be set from a shell — POSIX env-var names cannot contain a dot — so this is
+  observable only through a programmatic `os.Setenv` with a dotted name. Pinned
+  by `issue55_env_base_order_test.go`.
+
+  Consulting the full base at all remains a deliberate divergence from Lightbend
+  1.4.6, which consults only the bare one; it is documented as
+  [xx.hocon E17](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md)
+  ([xx.hocon#55](https://github.com/o3co/xx.hocon/issues/55)). Only the ordering
+  changed here.
+
 ## [1.12.0] - 2026-07-31
 
 Cross-impl release, coordinated to land at v1.12.0 across go.hocon / ts.hocon /

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -982,16 +982,11 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 			}
 			return resolved, nil
 		}
-		// Also try env var with original path (raw dot-join, no quoting).
-		// Skip for listSuffix substitutions: env-var access for ${X[]} is handled
-		// exclusively by resolveEnvList below (S13c.5 invariant: scalar env must
-		// not be consulted for list-suffix substitutions). Returning ScalarVal here
-		// would violate S13c.5 and produce the wrong type.
-		if !s.listSuffix && r.opts.UseSystemEnvironment {
-			if ev, ok := os.LookupEnv(strings.Join(originalStrs, ".")); ok {
-				return &ScalarVal{Raw: ev, Type: ScalarString}, nil
-			}
-		}
+		// The env-var lookup for this bare base does NOT happen here — see the
+		// scalar env fallback below. Keeping it in this block put bare before
+		// full for `${X}` while resolveEnvList put full before bare for
+		// `${X[]}`, so the two forms disagreed with each other and with the
+		// three sibling impls (xx.hocon#55, E17).
 	}
 
 	// S13c: env-var list expansion — when '[]' suffix is present, delegate to
@@ -1023,10 +1018,23 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		return r.resolveEnvList(s, segStrs, n)
 	}
 
-	// env var fallback — use raw dot-join (no quoting) to match Lightbend behavior
+	// env var fallback — use raw dot-join (no quoting) to match Lightbend behavior.
+	//
+	// Candidate order for a relativized substitution (prefixLen > 0) is the full
+	// base first, then the bare one — xx.hocon E17. Lightbend consults only the
+	// bare base; consulting the full one as well is the accepted o3co divergence,
+	// but the ORDER is cross-impl normative and must match ts/rs/py and this
+	// resolver's own `${X[]}` handling in resolveEnvList. Config exhaustion
+	// (prefixed + original-path, S14c.2) has already run above, so this stage is
+	// reached only when both config lookups missed.
 	if r.opts.UseSystemEnvironment {
 		if ev, ok := os.LookupEnv(strings.Join(segStrs, ".")); ok {
 			return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+		}
+		if s.prefixLen > 0 && len(segStrs) > s.prefixLen {
+			if ev, ok := os.LookupEnv(strings.Join(segStrs[s.prefixLen:], ".")); ok {
+				return &ScalarVal{Raw: ev, Type: ScalarString}, nil
+			}
 		}
 	}
 	if n.Optional {

--- a/issue55_env_base_order_test.go
+++ b/issue55_env_base_order_test.go
@@ -76,7 +76,6 @@ func TestIssue55EnvBaseOrderScalar(t *testing.T) {
 			for name, val := range map[string]string{fullName: tc.full, bareName: tc.bare} {
 				if val == "" {
 					unsetEnvForTest(t, name)
-					_ = os.Unsetenv(name)
 					continue
 				}
 				t.Setenv(name, val)

--- a/issue55_env_base_order_test.go
+++ b/issue55_env_base_order_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package hocon_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/o3co/go.hocon"
+)
+
+// xx.hocon#55 / E17: a substitution that originates in an included file is
+// relativized, so `${a.b}` inside a file mounted at `foo` carries prefixLen=1
+// and has two candidate env-var names — the full base `foo.a.b` and the bare
+// base `a.b`.
+//
+// Lightbend 1.4.6 consults only the bare base. All four o3co implementations
+// consult both; that is the accepted divergence recorded as E17. What E17 makes
+// normative is the ORDER: full base first, then bare.
+//
+// Before this fix go.hocon was the odd one out for the scalar form only — the
+// bare lookup lived inside the S14c.2 original-path block and therefore ran
+// before the full-base lookup at the bottom of resolveSubst. The list form
+// (`${a.b[]}`, resolveEnvList) already tried full first, so the two forms
+// disagreed with each other as well as with ts/rs/py.
+//
+// These names cannot be set from a shell (POSIX env names are
+// [A-Za-z_][A-Za-z0-9_]*), which is why the divergence is not user-surfaced and
+// why the regression has to be pinned through os.Setenv rather than a fixture.
+
+// writeEnvBaseFixture writes the two-file include tree the E17 cases share and
+// returns the path of the entry point. `subst` is the child's value expression.
+func writeEnvBaseFixture(t *testing.T, subst string) string {
+	t.Helper()
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child.conf")
+	if err := os.WriteFile(child, []byte("v = "+subst+"\n"), 0o600); err != nil {
+		t.Fatalf("write child.conf: %v", err)
+	}
+	main := filepath.Join(dir, "main.conf")
+	if err := os.WriteFile(main, []byte("foo {\n  include \"child.conf\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write main.conf: %v", err)
+	}
+	return main
+}
+
+func TestIssue55EnvBaseOrderScalar(t *testing.T) {
+	const fullName, bareName = "foo.a.b", "a.b"
+
+	tests := []struct {
+		name string
+		full string // "" = leave unset
+		bare string
+		want string
+	}{
+		// The load-bearing case: both bases resolvable, full must win. Pre-fix
+		// go.hocon returned "BARE" here while ts/rs/py returned "FULL".
+		{name: "both set — full base wins", full: "FULL", bare: "BARE", want: "FULL"},
+		// Guards against "fixed" by simply dropping the bare lookup: with only
+		// the bare base set it must still resolve (this is the candidate
+		// Lightbend uses, so removing it would diverge further, not less).
+		{name: "bare base only", full: "", bare: "BARE", want: "BARE"},
+		// The divergence E17 accepts: Lightbend would leave this unresolved.
+		{name: "full base only", full: "FULL", bare: "", want: "FULL"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for name, val := range map[string]string{fullName: tc.full, bareName: tc.bare} {
+				if val == "" {
+					unsetEnvForTest(t, name)
+					_ = os.Unsetenv(name)
+					continue
+				}
+				t.Setenv(name, val)
+			}
+
+			cfg, err := hocon.ParseFile(writeEnvBaseFixture(t, "${a.b}"))
+			if err != nil {
+				t.Fatalf("ParseFile: %v", err)
+			}
+			if got := cfg.GetString("foo.v"); got != tc.want {
+				t.Errorf("foo.v = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The list form was already full-first; pin it so the two forms cannot drift
+// apart again from the other side.
+func TestIssue55EnvBaseOrderList(t *testing.T) {
+	const fullName, bareName = "foo.a.b_0", "a.b_0"
+
+	t.Setenv(fullName, "FULL0")
+	t.Setenv(bareName, "BARE0")
+
+	cfg, err := hocon.ParseFile(writeEnvBaseFixture(t, "${a.b[]}"))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	got := cfg.GetStringSlice("foo.v")
+	if len(got) != 1 || got[0] != "FULL0" {
+		t.Errorf("foo.v = %v, want [FULL0]", got)
+	}
+}


### PR DESCRIPTION
Closes the half of [xx.hocon#55](https://github.com/o3co/xx.hocon/issues/55) that is a bug rather than an interpretation.

## The asymmetry

A substitution written in an included file is relativized, so `${a.b}` inside a file mounted at `foo` has two candidate env-var names — the full base `foo.a.b` and the bare base `a.b`. This resolver consulted them in a different order depending on the form:

| form | this resolver (before) | rs / ts / py |
|---|---|---|
| `${a.b}` | `[bare, full]` | `[full, bare]` |
| `${a.b[]}` | `[full, bare]` | `[full, bare]` |

The scalar lookup sat inside the S14c.2 original-path block, which runs *before* the env-var stage at the bottom of `resolveSubst`, so bare won. `${X[]}` goes through `resolveEnvList`, which tries full first. So the two forms disagreed with each other, and the scalar form was the only one of eight cells that disagreed across the four implementations.

Measured with the xx.hocon differential adapters (registry builds at v1.12.0), setting both names on `foo { include "child.conf" }` + `child.conf` = `v = ${a.b}`:

```
scalar, both set    go=BARE    rs=FULL    ts=FULL    py=FULL
list,   both set    go=FULL0   rs=FULL0   ts=FULL0   py=FULL0
```

## The change

The bare-base lookup moves out of the S14c.2 block and sits after the full-base lookup in the env-var stage. Config exhaustion (prefixed + original-path) is unchanged and still runs before either — this reorders only within the env stage, so E6 and S13c.5 are untouched.

## What is *not* changed

Consulting the full base at all stays a deliberate divergence from Lightbend 1.4.6, which consults only the bare one. That is now recorded as **E17** in xx.hocon (see the companion PR); the argument for keeping it is that removing a lookup has no shell-reachable beneficiary. Only the ordering is normative, and this brings go into line with it.

## Testing

`issue55_env_base_order_test.go` pins three scalar cases (both set → full wins; bare only → still resolves; full only → resolves, the accepted divergence) and the list form, so the two forms cannot drift apart again from either side.

Verified the test actually fails without the resolver change — `foo.v = "BARE", want "FULL"` — rather than passing vacuously.

`go test ./...` all green, `go vet` clean.

Reaching any behavior difference needs both names set, and POSIX env-var names cannot contain a dot, so this is observable only via a programmatic `os.Setenv` with a dotted name. That is also why it is pinned by a test rather than a conformance fixture: the runners resolve against the ambient process environment, so a fixture depending on dotted env names would not reproduce.

Refs o3co/xx.hocon#55

🤖 Generated with [Claude Code](https://claude.com/claude-code)