### PR TITLE
docs(readme): restructure Quick Start around Unmarshal + Get*E

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -31,6 +31,13 @@ Go 1.21 以上が必要。
 ```go
 import "github.com/o3co/go.hocon"
 
+type App struct {
+    Server struct {
+        Host string `hocon:"host"`
+        Port int    `hocon:"port"`
+    } `hocon:"server"`
+}
+
 cfg, err := hocon.ParseString(`
   server {
     host = "localhost"
@@ -41,9 +48,20 @@ if err != nil {
     log.Fatal(err)
 }
 
-host := cfg.GetString("server.host")  // "localhost"
-port := cfg.GetInt("server.port")     // 8080
+var app App
+if err := cfg.Unmarshal(&app); err != nil {
+    log.Fatal(err) // フィールド欠落・型違いは起動時に fail する
+}
+// app.Server.Host == "localhost", app.Server.Port == 8080
+
+// 単一の値は Get*E が (T, error) を返す
+host, err := cfg.GetStringE("server.host")
 ```
+
+既定では `Unmarshal` (struct 丸ごと、起動時に fail fast) か、error を返す
+`Get*E` ゲッターを使ってください。panic する `Get*` と `Option` を返す
+`Get*Option` は、その意味論が合う場面向けの variant です —
+[スカラーゲッター](#スカラーゲッター) を参照。
 
 ## なぜ HOCON？
 
@@ -88,18 +106,25 @@ hocon.ParseFile(path string)    (*Config, error)
 
 ### スカラーゲッター
 
-| メソッド | 戻り値 | パニック条件 |
-|---------|-------|------------|
-| `GetString(path)` | `string` | missing・null・型違い |
-| `GetInt(path)` | `int` | missing・null・型違い |
-| `GetInt64(path)` | `int64` | missing・null・型違い |
-| `GetFloat64(path)` | `float64` | missing・null・型違い |
-| `GetFloat32(path)` | `float32` | missing・null・型違い |
-| `GetBool(path)` | `bool` | missing・null・型違い |
-| `GetDuration(path)` | `time.Duration` | missing・null・不正フォーマット |
-| `GetBytes(path)` | `int64` | missing・null・不正フォーマット |
+3 系列は同じパス解決・型変換を共有し、違いは「missing / null / 型違い」の
+返し方だけです。**アプリケーションコードでは error を返す `Get*E` 系列を
+既定に**してください。panic 系列は検証済みの config (例: `main` で
+`Unmarshal` 直後) 向け、`Option` 系列は default 付きの任意キー
+(`OrElse`) 向けです。
 
-それぞれに `GetXxxOption(path) Option[T]` 版があり、パニックの代わりに `None` を返す。
+| Error 返却 (推奨) | Panic | Option |
+|---|---|---|
+| `GetStringE(path) (string, error)` | `GetString(path) string` | `GetStringOption(path) Option[string]` |
+| `GetIntE` / `GetInt64E` | `GetInt` / `GetInt64` | `GetIntOption` / `GetInt64Option` |
+| `GetFloat64E` / `GetFloat32E` | `GetFloat64` / `GetFloat32` | `GetFloat64Option` / `GetFloat32Option` |
+| `GetBoolE` | `GetBool` | `GetBoolOption` |
+| `GetDurationE` | `GetDuration` | `GetDurationOption` |
+| `GetBytesE` | `GetBytes` | `GetBytesOption` |
+
+`Get*E` は型付き `*ConfigError` を返します (missing / null / 型違い /
+duration・byte の不正フォーマット)。未解決 placeholder 起因の失敗は
+`errors.Is(err, hocon.ErrNotResolved)` で判定できます。panic 系列は同じ
+`*ConfigError` を payload に panic し、`Get*Option` は `None` を返します。
 
 ### スライスゲッター
 
@@ -110,12 +135,13 @@ cfg.GetIntSlice(path)      []int
 cfg.GetConfigSlice(path)   []*Config
 ```
 
-それぞれに `GetXxxSliceOption` 版あり。
+それぞれに `GetXxxSliceE` (error 返却) と `GetXxxSliceOption` 版あり。
 
 ### オブジェクトアクセス
 
 ```go
-sub := cfg.GetConfig("server")        // "server" スコープの *Config
+sub, err := cfg.GetConfigE("server")  // (*Config, error)、"server" スコープ
+sub := cfg.GetConfig("server")        // panic 版
 opt := cfg.GetConfigOption("server")  // Option[*Config]
 ```
 
@@ -159,6 +185,10 @@ err := cfg.Unmarshal(&s)
 // map[string]any も対応
 m := make(map[string]any)
 err = cfg.Unmarshal(&m)
+
+// UnmarshalPath はパス上の任意ノード (オブジェクト・配列・スカラー) を decode する:
+var servers []ServerConfig
+err = cfg.UnmarshalPath("servers", &servers)
 ```
 
 `hocon` タグがないフィールドはフィールド名を小文字化したキーで検索する。`omitempty` はキーが存在しないとき、フィールドの既存値を保持する。
@@ -168,7 +198,7 @@ err = cfg.Unmarshal(&m)
 ```go
 var pe *hocon.ParseError   // 字句解析・構文解析エラー — Line, Col, FilePath を持つ
 var re *hocon.ResolveError // 代入・include 解決エラー — Path を持つ
-var ce *hocon.ConfigError  // GetXxx パニックのペイロード — Path を持つ
+var ce *hocon.ConfigError  // Get*E の返却エラー / GetXxx パニックのペイロード — Path を持つ
 ```
 
 ## HOCON の例

--- a/README.ja.md
+++ b/README.ja.md
@@ -56,6 +56,9 @@ if err := cfg.Unmarshal(&app); err != nil {
 
 // 単一の値は Get*E が (T, error) を返す
 host, err := cfg.GetStringE("server.host")
+if err != nil {
+    log.Fatal(err)
+}
 ```
 
 既定では `Unmarshal` (struct 丸ごと、起動時に fail fast) か、error を返す
@@ -141,7 +144,7 @@ cfg.GetConfigSlice(path)   []*Config
 
 ```go
 sub, err := cfg.GetConfigE("server")  // (*Config, error)、"server" スコープ
-sub := cfg.GetConfig("server")        // panic 版
+mustSub := cfg.GetConfig("server")    // panic 版
 opt := cfg.GetConfigOption("server")  // Option[*Config]
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Requires Go 1.23+.
 ```go
 import "github.com/o3co/go.hocon"
 
+type App struct {
+    Server struct {
+        Host string `hocon:"host"`
+        Port int    `hocon:"port"`
+    } `hocon:"server"`
+}
+
 cfg, err := hocon.ParseString(`
   server {
     host = "localhost"
@@ -45,9 +52,20 @@ if err != nil {
     log.Fatal(err)
 }
 
-host := cfg.GetString("server.host")  // "localhost"
-port := cfg.GetInt("server.port")     // 8080
+var app App
+if err := cfg.Unmarshal(&app); err != nil {
+    log.Fatal(err) // fails fast: missing field, wrong type
+}
+// app.Server.Host == "localhost", app.Server.Port == 8080
+
+// Single values: Get*E returns (T, error)
+host, err := cfg.GetStringE("server.host")
 ```
+
+Prefer `Unmarshal` (whole-struct, fails fast at startup) or the
+error-returning `Get*E` getters. Panicking `Get*` and `Option`-returning
+`Get*Option` variants exist for code where those semantics fit — see
+[Scalar Getters](#scalar-getters).
 
 ## Why HOCON?
 
@@ -127,18 +145,25 @@ Use `ResolveOptions.WithUseSystemEnvironment(false)` for hermetic resolution
 
 ### Scalar Getters
 
-| Method | Returns | Panics if |
-|--------|---------|-----------|
-| `GetString(path)` | `string` | missing, null, wrong type |
-| `GetInt(path)` | `int` | missing, null, wrong type |
-| `GetInt64(path)` | `int64` | missing, null, wrong type |
-| `GetFloat64(path)` | `float64` | missing, null, wrong type |
-| `GetFloat32(path)` | `float32` | missing, null, wrong type |
-| `GetBool(path)` | `bool` | missing, null, wrong type |
-| `GetDuration(path)` | `time.Duration` | missing, null, invalid format |
-| `GetBytes(path)` | `int64` | missing, null, invalid format |
+Three families share the same path and coercion semantics; they differ only
+in how a missing key / null / type mismatch comes back. **Default to the
+error-returning `Get*E` family** in application code. The panicking family
+suits config already validated (e.g. right after `Unmarshal` in `main`); the
+`Option` family suits optional keys with a fallback (`OrElse`).
 
-Each has a corresponding `GetXxxOption(path) Option[T]` variant that returns `None` instead of panicking.
+| Error-returning (recommended) | Panicking | Option |
+|---|---|---|
+| `GetStringE(path) (string, error)` | `GetString(path) string` | `GetStringOption(path) Option[string]` |
+| `GetIntE` / `GetInt64E` | `GetInt` / `GetInt64` | `GetIntOption` / `GetInt64Option` |
+| `GetFloat64E` / `GetFloat32E` | `GetFloat64` / `GetFloat32` | `GetFloat64Option` / `GetFloat32Option` |
+| `GetBoolE` | `GetBool` | `GetBoolOption` |
+| `GetDurationE` | `GetDuration` | `GetDurationOption` |
+| `GetBytesE` | `GetBytes` | `GetBytesOption` |
+
+`Get*E` returns a typed `*ConfigError` (missing path, null, wrong type, or
+invalid duration/byte format); unresolved-placeholder failures satisfy
+`errors.Is(err, hocon.ErrNotResolved)`. The panicking getters panic with the
+same `*ConfigError` as payload. `Get*Option` returns `None` instead.
 
 ### Slice Getters
 
@@ -149,12 +174,13 @@ cfg.GetIntSlice(path)      []int
 cfg.GetConfigSlice(path)   []*Config
 ```
 
-Each has a `GetXxxSliceOption` variant.
+Each has `GetXxxSliceE` (error-returning) and `GetXxxSliceOption` variants.
 
 ### Object Access
 
 ```go
-sub := cfg.GetConfig("server")          // *Config scoped to "server"
+sub, err := cfg.GetConfigE("server")    // (*Config, error), scoped to "server"
+sub := cfg.GetConfig("server")          // panicking variant
 opt := cfg.GetConfigOption("server")    // Option[*Config]
 ```
 
@@ -198,6 +224,10 @@ err := cfg.Unmarshal(&s)
 // map[string]any also supported
 m := make(map[string]any)
 err = cfg.Unmarshal(&m)
+
+// UnmarshalPath decodes any node at a path — object, array, or scalar:
+var servers []ServerConfig
+err = cfg.UnmarshalPath("servers", &servers)
 ```
 
 Fields without a `hocon` tag use the lowercased field name. `omitempty` preserves the pre-populated value when the key is missing.
@@ -207,7 +237,7 @@ Fields without a `hocon` tag use the lowercased field name. `omitempty` preserve
 ```go
 var pe *hocon.ParseError   // lexing/parsing failure — has Line, Col, FilePath
 var re *hocon.ResolveError // substitution/include failure — has Path
-var ce *hocon.ConfigError  // GetXxx panic payload — has Path
+var ce *hocon.ConfigError  // Get*E returned error / GetXxx panic payload — has Path
 ```
 
 ## HOCON Examples

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ if err := cfg.Unmarshal(&app); err != nil {
 
 // Single values: Get*E returns (T, error)
 host, err := cfg.GetStringE("server.host")
+if err != nil {
+    log.Fatal(err)
+}
 ```
 
 Prefer `Unmarshal` (whole-struct, fails fast at startup) or the
@@ -180,7 +183,7 @@ Each has `GetXxxSliceE` (error-returning) and `GetXxxSliceOption` variants.
 
 ```go
 sub, err := cfg.GetConfigE("server")    // (*Config, error), scoped to "server"
-sub := cfg.GetConfig("server")          // panicking variant
+mustSub := cfg.GetConfig("server")      // panicking variant
 opt := cfg.GetConfigOption("server")    // Option[*Config]
 ```
 


### PR DESCRIPTION
## Summary

Priority 3 of the UX evaluation (2026-08-17). The Quick Start opened with the panic-family getters (`GetString` / `GetInt`), forcing users to pick between the three families (panic / error / Option) right at the entry point. On top of that, **the `Get*E` family was not mentioned in the README at all** (even though config_e.go has it for every type).

## Changes (docs-only, no behavior change)

- **Quick Start**: leads with `Unmarshal` (whole-struct, fail fast at startup — a USP the competing gurkankaymak/hocon lacks), and presents single values with `GetStringE`. Adds one paragraph of guidance on choosing between the families
- **Scalar Getters**: what used to be a panic table + a single sentence on Option is consolidated into one table covering all three families (explicitly recommending the error-returning ones). Also documents `errors.Is(err, hocon.ErrNotResolved)`
- **Slice / Object Access**: adds `Get*SliceE` / `GetConfigE`
- **Unmarshal**: adds an `UnmarshalPath` example
- **Error Types**: states that `ConfigError` is also the error returned by `Get*E`
- README.ja.md follows the same structure

## Verification

- `go test -run TestDocs ./...` green (all the guards: compliance numbers / Go version / Unreleased marker)
- `golangci-lint run` 0 issues
- CHANGELOG: not applicable, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
