### PR TITLE
fix(parser): S1.1 — make invalid UTF-8 a parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Behavior
 
+- **BREAKING (spec fix, S1.1): invalid UTF-8 input is now a parse error.** A
+  Go `string` is not language-guaranteed UTF-8, so arbitrary bytes reach the
+  parser via `ParseString` and file reads; they were silently decoded with
+  U+FFFD substitution, so `key = "a<0xff>b"` yielded `"a�b"` and the
+  corruption surfaced arbitrarily far from the parse that admitted it.
+  `parser.Parse` — the single boundary every document (top-level and include)
+  funnels through — now rejects the input with a parse error carrying the
+  line/col of the first invalid sequence (HOCON.md L117). A properly encoded
+  U+FFFD literal still parses. A caller that relied on the substitution can
+  sanitize up front with `strings.ToValidUTF8(input, "�")`. This aligns
+  go.hocon with rs.hocon (valid UTF-8 by language guarantee); ts.hocon / 
+  py.hocon receive pre-decoded strings at their I/O boundaries.
+
 - **Env-var fallback for a relativized substitution now tries the full base
   before the bare one, matching `${X[]}` and the three sibling implementations.**
   A substitution written in an included file is relativized, so `${a.b}` inside a

--- a/README.ja.md
+++ b/README.ja.md
@@ -239,12 +239,12 @@ max-size  = "512MiB"
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-13 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しており、以下の表はそこから計算されます — `docs_test.go` が再計算し、表がずれるとビルドが fail します。実装横断のロールアップは [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **71.8%** |
-| In-scope のみ | **80.2%** |
+| 仕様全体（out-of-scope を含む） | **89.5%** |
+| In-scope のみ | **98.9%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **89.0%** |
-| In-scope only | **98.4%** |
+| Spec total (incl. out-of-scope) | **89.5%** |
+| In-scope only | **98.9%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | passing (`TestLightbendEquiv` / `TestLightbendSuite`; three `*-expected.json` comparisons carry documented environment-dependent exclusions) |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | passing |
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -13,8 +13,14 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
 ## S1. Unchanged from JSON
 
 - **S1.1** Files must be valid UTF-8 — §Unchanged from JSON (L117)
-  tests: spec_phase5_test.go (TestSpec_S1_1_InvalidUTF8_Pin, TestSpec_S1_1_InvalidUTF8_Spec)
-  status: ❌ — Go's `string` is a `[]byte` that is **not** guaranteed to be valid UTF-8 (arbitrary bytes are reachable via `ParseString(string([]byte{0xff}))` and via `ParseFile` reading non-UTF-8 files). The current impl silently substitutes invalid byte sequences with U+FFFD (REPLACEMENT CHARACTER) instead of rejecting them per spec L117. Pinned via `_Pin` test asserting current substitution behavior, with `_Spec` skipped until the parse boundary rejects invalid UTF-8.
+  tests: spec_phase5_test.go (TestSpec_S1_1_InvalidUTF8_Spec, TestSpec_S1_1_InvalidUTF8_FileAndInclude)
+  status: ✅ — Fixed 2026-08-17. Go's `string` is a `[]byte` that is **not** guaranteed to be
+  valid UTF-8, so arbitrary bytes reach the parser via `ParseString` and via file reads.
+  `parser.Parse` — the single choke point every document (top-level and include) funnels
+  through — now rejects invalid byte sequences with a parse error carrying the line/col of
+  the first offending sequence, instead of the former silent U+FFFD substitution. A
+  properly encoded U+FFFD literal is unaffected. ts stays ➖ (JS strings are pre-decoded);
+  rs was ✅ by language guarantee; py is at its own I/O boundary.
 
 - **S1.2.1** Quoted strings accept valid JSON escape sequences (`\" \\ \/ \b \f \n \r \t`) — §Unchanged from JSON (L118)
   tests: internal/lexer/lexer_test.go:212 (TestUnicodeEscape); testdata/hocon/subst-tokenize/st10-escape-newline.conf (fixture); testdata/hocon/subst-tokenize/st12-escape-backslash.conf (fixture); testdata/hocon/subst-tokenize/st13-escape-quote.conf (fixture); testdata/hocon/subst-tokenize/st20-quoted-escape-backspace-formfeed.conf (fixture)

--- a/docs_test.go
+++ b/docs_test.go
@@ -177,6 +177,41 @@ func TestDocs_ReadmeComplianceRates(t *testing.T) {
 	}
 }
 
+// TestDocs_ReadmeJaComplianceRates gates README.ja.md's table with the same
+// recomputation. It was not covered before and drifted 17+ points (found
+// 2026-08-17 still showing a 2026-05-13 snapshot).
+func TestDocs_ReadmeJaComplianceRates(t *testing.T) {
+	counts := countCompliance(t)
+	data, err := os.ReadFile("README.ja.md")
+	if err != nil {
+		t.Fatalf("read README.ja.md: %v", err)
+	}
+	readme := string(data)
+
+	for _, tc := range []struct {
+		what string
+		re   *regexp.Regexp
+		want float64
+	}{
+		{
+			what: "spec-total compliance rate (ja)",
+			re:   regexp.MustCompile(`\| 仕様全体（out-of-scope を含む） \| \*\*([0-9.]+)%\*\* \|`),
+			want: counts.specTotalRate(),
+		},
+		{
+			what: "in-scope compliance rate (ja)",
+			re:   regexp.MustCompile(`\| In-scope のみ \| \*\*([0-9.]+)%\*\* \|`),
+			want: counts.inScopeRate(),
+		},
+	} {
+		got := findOne(t, "README.ja.md", readme, tc.re, tc.what)
+		if want := fmt.Sprintf("%.1f", tc.want); got != want {
+			t.Errorf("README.ja %s is %s%%, recomputed from docs/spec-compliance.md it is %s%% (✅%d ⚠️%d ❌%d ➖%d)",
+				tc.what, got, want, counts.pass, counts.partial, counts.fail, counts.outOfScope)
+		}
+	}
+}
+
 func TestDocs_ReadmeGoVersionMatchesGoMod(t *testing.T) {
 	data, err := os.ReadFile("go.mod")
 	if err != nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/o3co/go.hocon/internal/lexer"
 )
@@ -74,9 +75,39 @@ var ErrArrayAtRoot = errors.New("document has type array rather than object at f
 // Parse parses a HOCON string and returns the root ObjectNode.
 // The input may omit outer braces (root object shorthand).
 func Parse(src string) (*ObjectNode, error) {
+	// S1.1 (HOCON.md L117): files must be valid UTF-8. A Go string is not
+	// language-guaranteed UTF-8, so arbitrary bytes reach this boundary via
+	// ParseString and file reads; reject them here rather than letting rune
+	// decoding silently substitute U+FFFD. Every HOCON document — top-level
+	// or include — funnels through Parse, so this is the single choke point.
+	if !utf8.ValidString(src) {
+		line, col := invalidUTF8Position(src)
+		return nil, newError(line, col, "invalid UTF-8 byte sequence: HOCON input must be valid UTF-8 (S1.1)")
+	}
 	p := &parser{lex: lexer.New(src)}
 	p.advance()
 	return p.parseRoot()
+}
+
+// invalidUTF8Position returns the 1-based line/col of the first invalid UTF-8
+// byte sequence in src. Call only when utf8.ValidString(src) is false; a
+// properly encoded U+FFFD decodes with size 3 and is never reported.
+func invalidUTF8Position(src string) (line, col int) {
+	line, col = 1, 1
+	for i := 0; i < len(src); {
+		r, size := utf8.DecodeRuneInString(src[i:])
+		if r == utf8.RuneError && size == 1 {
+			return line, col
+		}
+		if r == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+		i += size
+	}
+	return line, col
 }
 
 // ParseBytes is like Parse but accepts a byte slice.

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -64,32 +64,46 @@ const specIssueS10_15_QuotedWS = 83
 // invalid UTF-8 to be rejected; the current impl silently substitutes invalid
 // byte sequences with U+FFFD (REPLACEMENT CHARACTER) instead. Pinned ❌.
 
-// TestSpec_S1_1_InvalidUTF8_Pin pins the current (non-conformant) behaviour:
-// invalid UTF-8 bytes are silently replaced with U+FFFD instead of producing a
-// parse error. The probed input `key = " hello<0xff>world "` parses without
-// error and yields key = "hello�world".
-func TestSpec_S1_1_InvalidUTF8_Pin(t *testing.T) {
-	// pin: see spec L117 — impl currently accepts and replaces invalid UTF-8
-	input := "key = \"hello" + string([]byte{0xff}) + "world\""
-	cfg, err := hocon.ParseString(input)
-	if err != nil {
-		t.Errorf("[pin] expected current impl to accept invalid UTF-8 (silent replacement), got err: %v", err)
-		return
-	}
-	got := cfg.GetString("key")
-	want := "hello�world"
-	if got != want {
-		t.Errorf("[pin] expected silently-replaced value %q, got %q", want, got)
-	}
-}
-
-// TestSpec_S1_1_InvalidUTF8_Spec is the spec-correct assertion: invalid UTF-8
-// in the input must be rejected with a parse error.
+// TestSpec_S1_1_InvalidUTF8_Spec asserts the spec behaviour (HOCON.md L117):
+// invalid UTF-8 in the input is rejected with a parse error at the parse
+// boundary, instead of the pre-fix silent U+FFFD substitution. A properly
+// encoded U+FFFD literal stays accepted — only invalid byte sequences error.
 func TestSpec_S1_1_InvalidUTF8_Spec(t *testing.T) {
-	t.Skipf("[skip] spec violation per S1.1 (HOCON.md L117) — invalid UTF-8 is currently accepted with U+FFFD substitution; should be rejected at the parse boundary")
 	input := "key = \"hello" + string([]byte{0xff}) + "world\""
 	if _, err := hocon.ParseString(input); err == nil {
 		t.Error("expected parse error for invalid UTF-8 input, got nil")
+	}
+
+	// control: a validly-encoded U+FFFD is an ordinary character, not an error
+	cfg, err := hocon.ParseString("key = \"hello�world\"")
+	if err != nil {
+		t.Fatalf("validly-encoded U+FFFD must parse: %v", err)
+	}
+	if got, want := cfg.GetString("key"), "hello�world"; got != want {
+		t.Errorf("expected literal U+FFFD preserved, got %q want %q", got, want)
+	}
+}
+
+// TestSpec_S1_1_InvalidUTF8_FileAndInclude covers the two file-read routes to
+// the parse boundary: ParseFile on a non-UTF-8 file, and an include of one.
+func TestSpec_S1_1_InvalidUTF8_FileAndInclude(t *testing.T) {
+	dir := t.TempDir()
+	bad := []byte("key = \"a\xffb\"\n")
+
+	badPath := filepath.Join(dir, "bad.conf")
+	if err := os.WriteFile(badPath, bad, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hocon.ParseFile(badPath); err == nil {
+		t.Error("ParseFile: expected parse error for invalid UTF-8 file, got nil")
+	}
+
+	mainPath := filepath.Join(dir, "main.conf")
+	if err := os.WriteFile(mainPath, []byte("include \"bad.conf\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hocon.ParseFile(mainPath); err == nil {
+		t.Error("include: expected parse error for invalid UTF-8 include file, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves S1.1, one of go's 3 remaining cells in "Top spec violations" (remaining: S8.2 / S13a.12 — follow-up PRs).

Go's `string` carries no language-level UTF-8 guarantee, so arbitrary bytes reach the parser via `ParseString` / file reads. Previously they were silently accepted with U+FFFD substitution, surfacing the corruption far away from the parse. We now reject at `parser.Parse`, the single boundary every document (top-level / include) passes through, and put the line/col of the first invalid sequence in the error (HOCON.md L117).

- **BREAKING (spec fix)**: accept → reject. Recorded in the CHANGELOG with a workaround (pre-sanitizing with `strings.ToValidUTF8`). Shipping this in a minor follows the S19.8 precedent
- A correctly encoded U+FFFD literal is still accepted (pinned with a control test)
- rs was already ✅ by language guarantee; ts/py are out of scope because they pre-decode at the I/O boundary (ts is ➖)

## Tests

- Removed `_Pin` (which pinned the old behavior), unskipped + extended `_Spec`: the 3 paths ParseString / ParseFile / include + the U+FFFD literal control
- `go test -race ./...` + adapters (`make test-all`) green, `golangci-lint` 0 issues
- Because of codeload 429s, fixtures were verified by local-archiving the same sha from a canonical xx.hocon clone (**the tracked adapters/testdata-format-ingestion was excluded from replication**, confirmed zero git status pollution)

## Also in this PR

The compliance-rate table in README.ja.md was still the 2026-05-13 snapshot (71.8% / 80.2%), **off by more than 17pp**, so it was updated to the current values (89.5% / 98.9%), and the rate gate in `docs_test.go` was extended to cover README.ja.md as well (the same structural recurrence prevention as ts#186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
