### PR TITLE
fix(lexer): S8.2 — treat // inside an unquoted run as a comment start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Behavior
 
+- **BREAKING (spec fix, S8.2): `//` now starts a comment inside an unquoted
+  run.** `foo = bar//baz` used to produce the value `"bar//baz"`; per
+  HOCON.md L248 `//` begins a comment anywhere outside a quoted string, so it
+  now produces `"bar"` with `//baz` discarded to end of line — matching
+  ts.hocon and rs.hocon (#76). A single `/` is unaffected (`/etc/x` paths
+  still parse), and quoted strings remain opaque (`"bar//baz"` keeps the
+  slashes). A value that needs a literal `//` must be quoted.
 - **BREAKING (spec fix, S1.1): invalid UTF-8 input is now a parse error.** A
   Go `string` is not language-guaranteed UTF-8, so arbitrary bytes reach the
   parser via `ParseString` and file reads; they were silently decoded with

--- a/README.ja.md
+++ b/README.ja.md
@@ -243,8 +243,8 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **89.5%** |
-| In-scope のみ | **98.9%** |
+| 仕様全体（out-of-scope を含む） | **90.0%** |
+| In-scope のみ | **99.5%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **89.5%** |
-| In-scope only | **98.9%** |
+| Spec total (incl. out-of-scope) | **90.0%** |
+| In-scope only | **99.5%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | passing (`TestLightbendEquiv` / `TestLightbendSuite`; three `*-expected.json` comparisons carry documented environment-dependent exclusions) |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | passing |
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -188,8 +188,11 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅ (backtick was accepted until xx.hocon#68 — the ✅ predating that fix was unverified for this member of the forbidden set)
 
 - **S8.2** `//` inside an unquoted string starts a comment — §Unquoted strings (L248)
-  tests: spec_phase5_test.go (TestSpec_S8_2_SlashSlashInUnquoted_Pin, TestSpec_S8_2_SlashSlashInUnquoted_Spec)
-  status: ❌ ([#76](https://github.com/o3co/go.hocon/issues/76)) — `foo = bar//baz` produces "bar//baz" instead of "bar"; `//` inside an unquoted token run is not treated as comment start
+  tests: spec_phase5_test.go (TestSpec_S8_2_SlashSlashInUnquoted_Spec)
+  status: ✅ — Fixed 2026-08-17 ([#76](https://github.com/o3co/go.hocon/issues/76)): the
+  unquoted-token scan stops at `//`, so `foo = bar//baz` is the value "bar" followed by a
+  comment (mirrors ts.hocon's `isUnquotedContinue`). A single `/` stays part of the token
+  (`/etc/x` paths unaffected); quoted strings remain opaque to comment syntax.
 
 - **S8.3** Initial token `true`/`false`/`null` parsed as keyword — §Unquoted strings (L250)
   tests: internal/parser/parser_test.go:148 (TestParser_NullBoolNumbers)

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -896,6 +896,15 @@ func (l *Lexer) readUnquoted(prefix string, line, col int) Token {
 		if !ok || isUnquotedForbidden(ch) {
 			break
 		}
+		// S8.2 (HOCON.md L248): `//` starts a comment anywhere outside a
+		// quoted string, including mid-run in an unquoted token — `bar//baz`
+		// is the value "bar" followed by a comment. A single '/' remains part
+		// of the token (paths like `/etc/x` are unaffected). The unconsumed
+		// `//...` is eaten by the next skipWhitespaceAndComments. Mirrors
+		// ts.hocon's isUnquotedContinue.
+		if ch == '/' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '/' {
+			break
+		}
 		sb.WriteRune(l.advance())
 	}
 	return Token{Type: TokenString, Value: sb.String(), Line: line, Col: col}

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -160,27 +160,41 @@ func TestSpec_S6_5_NewlineMeansLF(t *testing.T) {
 
 // ── S8.2: // inside unquoted string starts a comment ─────────────────────────
 
-// TestSpec_S8_2_SlashSlashInUnquoted_Pin pins the current (non-conformant)
-// behaviour: `//` embedded in an unquoted token without preceding whitespace
-// is treated as literal text rather than starting a comment.
-// Spec HOCON.md L248: "//" starts a comment anywhere outside a quoted string.
-func TestSpec_S8_2_SlashSlashInUnquoted_Pin(t *testing.T) {
-	// pin: see #76 — "bar//baz" is treated as unquoted string "bar//baz"
-	_ = specIssueS8_2_SlashSlash
-	cfg := mustParseCfg(t, "foo = bar//baz")
-	got := cfg.GetString("foo")
-	if got != "bar//baz" {
-		t.Errorf("[pin] expected current value %q, got %q", "bar//baz", got)
-	}
-}
-
-// TestSpec_S8_2_SlashSlashInUnquoted_Spec is the spec-correct assertion:
-// `foo = bar//baz` → `//baz` starts a comment, so foo = "bar".
+// TestSpec_S8_2_SlashSlashInUnquoted_Spec asserts the spec behaviour
+// (HOCON.md L248, fixed via #76): `//` starts a comment anywhere outside a
+// quoted string, including mid-run in an unquoted token.
 func TestSpec_S8_2_SlashSlashInUnquoted_Spec(t *testing.T) {
-	t.Skipf("[skip] spec violation per S8.2 — //baz not treated as comment in unquoted run; see #%d", specIssueS8_2_SlashSlash)
+	_ = specIssueS8_2_SlashSlash
 	cfg := mustParseCfg(t, "foo = bar//baz")
 	if got := cfg.GetString("foo"); got != "bar" {
 		t.Errorf("expected foo=%q (// starts comment), got %q", "bar", got)
+	}
+
+	// A single '/' stays part of the unquoted token — paths are unaffected.
+	cfg = mustParseCfg(t, "foo = /etc/app.conf")
+	if got := cfg.GetString("foo"); got != "/etc/app.conf" {
+		t.Errorf("expected single-slash path preserved, got %q", got)
+	}
+
+	// Quoted strings are opaque to comment syntax.
+	cfg = mustParseCfg(t, `foo = "bar//baz"`)
+	if got := cfg.GetString("foo"); got != "bar//baz" {
+		t.Errorf("expected quoted // preserved, got %q", got)
+	}
+
+	// The comment runs to end of line only; the next line still parses.
+	cfg = mustParseCfg(t, "foo = bar//baz\nqux = 1")
+	if got := cfg.GetString("foo"); got != "bar" {
+		t.Errorf("expected foo=%q, got %q", "bar", got)
+	}
+	if got := cfg.GetInt("qux"); got != 1 {
+		t.Errorf("expected qux=1 on the following line, got %d", got)
+	}
+
+	// Concat context: the comment terminates the whole value at that point.
+	cfg = mustParseCfg(t, "foo = a b//c d")
+	if got := cfg.GetString("foo"); got != "a b" {
+		t.Errorf("expected concat cut at //, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Resolves S8.2 among go's remaining "Top spec violations" cells (the 2nd, after S1.1 in #190. The remaining one, S13a.12, turned out on investigation to be a **gap shared by all 4 implementations**, so it will be handled in a separate window with xx.hocon fixtures + all 4 implementations in lockstep — details in the scope TODO).

`foo = bar//baz` was becoming `"bar//baz"`. HOCON.md L248 defines `//` as starting a comment anywhere outside a quoted string, so the scan of an unquoted token now stops at `//` (same shape as ts.hocon's `isUnquotedContinue`, #76).

- **BREAKING (spec fix)**: `bar//baz` → `"bar"` + comment. The behavior now matches ts/rs. Workaround (quote a literal `//`) recorded in the CHANGELOG
- A lone `/` is unchanged (paths like `/etc/x`), and quoted strings remain opaque

## Tests

- Removed `_Pin`, unskipped + extended `_Spec` (basic / lone slash / quoted unchanged / to end of line / cut off mid-concat)
- `go test -race ./...` green (including the conformance corpus — no corpus case depended on the old behavior), `golangci-lint` 0 issues
- Combined with S1.1: **in-scope 99.5% / spec-total 90.0%** (verified by the en/ja gates in docs_test)

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
