### PR TITLE
fix(resolver): S13a.12 — resolve prefix self-refs to below (reaching in-scope 100%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Behavior
 
+- **BREAKING (spec fix, S13a.12): a substitution whose target lies inside the
+  field being defined (`foo : ${foo.a}`) now resolves against the field's
+  "below" value — the merge of the stack beneath the substitution — instead of
+  the final tree.** The spec example `foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2}`
+  now yields `{a:2, c:1}` (was `{a:2}`, dropping `c`), and the two-layer form
+  now resolves instead of erroring. A required prefix self-ref with nothing
+  below at the navigated path errors as an unresolved substitution; an
+  optional one vanishes transparently, leaving the below layer as the
+  surviving prior (#79). Found by a cross-impl probe — all four sibling
+  implementations shared the gap and the fixes land in lockstep.
+
 - **BREAKING (spec fix, S8.2): `//` now starts a comment inside an unquoted
   run.** `foo = bar//baz` used to produce the value `"bar//baz"`; per
   HOCON.md L248 `//` begins a comment anywhere outside a quoted string, so it

--- a/README.ja.md
+++ b/README.ja.md
@@ -243,8 +243,8 @@ max-size  = "512MiB"
 
 | 指標 | 状況 |
 | --- | --- |
-| 仕様全体（out-of-scope を含む） | **90.0%** |
-| In-scope のみ | **99.5%** |
+| 仕様全体（out-of-scope を含む） | **90.5%** |
+| In-scope のみ | **100.0%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | 13/13 合格 |
 | [hocon2](https://github.com/o3co/hocon2) 準拠テスト（JSON/YAML/TOML/Properties 出力） | 77/77 合格 |
 

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric | Status |
 | --- | --- |
-| Spec total (incl. out-of-scope) | **90.0%** |
-| In-scope only | **99.5%** |
+| Spec total (incl. out-of-scope) | **90.5%** |
+| In-scope only | **100.0%** |
 | Lightbend `equiv01`–`equiv05` + `test01`–`test13` | passing (`TestLightbendEquiv` / `TestLightbendSuite`; three `*-expected.json` comparisons carry documented environment-dependent exclusions) |
 | [hocon2](https://github.com/o3co/hocon2) conformance (JSON/YAML/TOML/Properties output) | passing |
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -514,8 +514,15 @@ This file extends [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx
   status: ✅
 
 - **S13a.12** Self-ref in path expression `${foo.a}` resolves to "below" — §Self-Referential (L791)
-  tests: spec_phase5_test.go (TestSpec_S13a_12_SelfRefInPathResolvesBelow_Pin, TestSpec_S13a_12_SelfRefInPathResolvesBelow_Spec)
-  status: ❌ ([#79](https://github.com/o3co/go.hocon/issues/79)) — spec example `foo:{a:{c:1}};foo:${foo.a};foo:{a:2}` should yield {a:2,c:1} but c is lost in the merge
+  tests: spec_phase5_test.go (TestSpec_S13a_12_SelfRefInPathResolvesBelow_Spec, TestSpec_S13a_12_PrefixSelfRefEdges)
+  status: ✅ — Fixed 2026-08-18 ([#79](https://github.com/o3co/go.hocon/issues/79)): the
+  prefix direction (`foo` ⊏ `foo.a`) was missing from self-reference detection in ALL
+  FOUR siblings (a 2026-08-18 cross-impl probe reclassified this from go-only), so the
+  substitution resolved against the final tree instead of the stack "below". Fixed in
+  the fold (prefix self-refs fold at prior-save time; standalone occurrences form a
+  merge layer keeping the below layer's other keys) and in resolveSubst (standing
+  prefix self-refs resolve via the field's prior + remainder navigation, undefined
+  classification on a miss). Landed in lockstep with ts.hocon / py.hocon / rs.hocon.
 
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
   tests: internal/resolver/resolver_test.go (TestSpecS13a_13_OptionalSelfRefUndefinedBecomesEmpty, TestSpecS13a_13_SelfRefLookback), s13a13_self_ref_lookback_test.go (TestS13a13_SelfRefLookback_Success, TestS13a13_SelfRefLookback_Errors)

--- a/internal/resolver/foldselfref.go
+++ b/internal/resolver/foldselfref.go
@@ -166,18 +166,6 @@ func foldSelfRefInner(v Val, fullKey string, replacement Val, allowPrefix bool) 
 	}
 }
 
-// foldOrSkipPrior decides how to save a self-reference-aware prior at one
-// of the three prior-save sites (direct assignment, include-merge non-object
-// override, setPath nested assignment). Cases:
-//
-//   - prior has no self-ref to fullKey         → save prior as-is  → (prior,  true)
-//   - prior has self-ref AND old != nil        → fold against old  → (folded, true)
-//   - optional self-ref AND old == nil         → fold to absent    → (folded, true)
-//   - required self-ref AND old == nil         → skip save         → (nil,    false)
-//
-// The no-prior optional case preserves S13a.13's "optional self-ref with no
-// prior resolves to undefined" rule while still saving concat literal pieces
-// for the next overwrite.
 // substPrefixRemainder returns the remainder segment texts when fullKey is a
 // PROPER segment-wise prefix of the subst's path (`foo` ⊏ `foo.a` → ["a"]),
 // else nil. Boundary-safe on the dotted keys because both sides share
@@ -252,6 +240,11 @@ func mergePriorLayers(base, top *ObjectVal) *ObjectVal {
 	for k, pv := range base.priorValues {
 		out.priorValues[k] = pv
 	}
+	// Carry BOTH layers' bookkeeping: top's priorValues (its keys' own
+	// delayed-merge chains) win per key over base's.
+	for k, pv := range top.priorValues {
+		out.priorValues[k] = pv
+	}
 	for _, k := range top.Keys() {
 		tv, _ := top.Get(k)
 		if bv, ok := out.Get(k); ok {
@@ -267,6 +260,18 @@ func mergePriorLayers(base, top *ObjectVal) *ObjectVal {
 	return out
 }
 
+// foldOrSkipPrior decides how to save a self-reference-aware prior at one
+// of the three prior-save sites (direct assignment, include-merge non-object
+// override, setPath nested assignment). Cases:
+//
+//   - prior has no self-ref to fullKey         → save prior as-is  → (prior,  true)
+//   - prior has self-ref AND old != nil        → fold against old  → (folded, true)
+//   - optional self-ref AND old == nil         → fold to absent    → (folded, true)
+//   - required self-ref AND old == nil         → skip save         → (nil,    false)
+//
+// The no-prior optional case preserves S13a.13's "optional self-ref with no
+// prior resolves to undefined" rule while still saving concat literal pieces
+// for the next overwrite.
 func foldOrSkipPrior(prior Val, fullKey string, old Val) (Val, bool) {
 	// S13a.12: a STANDALONE prefix self-ref in field-value position is a
 	// merge LAYER — an object it navigates to merges over the stack below,

--- a/internal/resolver/foldselfref.go
+++ b/internal/resolver/foldselfref.go
@@ -34,6 +34,17 @@ import "strings"
 // Rehydration of sentinels happens separately in rehydrateSentinel during
 // MergeUnresolved when a fallback prior is available.
 func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
+	return foldSelfRefInner(v, fullKey, replacement, true)
+}
+
+// foldSelfRefInner threads allowPrefix: the S13a.12 prefix rule applies only
+// in value-stack positions — it stays true through concat nodes and array
+// elements (the value chain of the field itself) but turns false when
+// descending into object interiors. A substitution nested inside an object
+// literal that references a sibling branch of the same field
+// (`a = { x = ${a.p.v} }`) is a lazy final-tree lookup (S13a.14), NOT a
+// below-lookback.
+func foldSelfRefInner(v Val, fullKey string, replacement Val, allowPrefix bool) (Val, bool) {
 	switch vv := v.(type) {
 	case *substPlaceholder:
 		if vv.knownAbsent {
@@ -48,18 +59,20 @@ func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 		// S13a.12: a substitution whose path has fullKey as a PROPER prefix
 		// (`${foo.a}` inside the stack of `foo`) is also a self-reference —
 		// it folds to the remainder navigated into the below value.
-		if rem := substPrefixRemainder(vv, fullKey); rem != nil {
-			if replacement == nil {
-				return v, true // detection-only pass
+		if allowPrefix {
+			if rem := substPrefixRemainder(vv, fullKey); rem != nil {
+				if replacement == nil {
+					return v, true // detection-only pass
+				}
+				return foldPrefixSelfRef(vv, replacement, rem), true
 			}
-			return foldPrefixSelfRef(vv, replacement, rem), true
 		}
 		return v, false
 	case *concatPlaceholder:
 		var newVals []Val
 		anyHit := false
 		for i, e := range vv.vals {
-			ne, hit := foldSelfRef(e, fullKey, replacement)
+			ne, hit := foldSelfRefInner(e, fullKey, replacement, allowPrefix)
 			if hit {
 				if !anyHit && replacement != nil {
 					// First hit — lazy-init the rewritten slice so the
@@ -85,7 +98,7 @@ func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 		var newEls []Val
 		anyHit := false
 		for i, e := range vv.Elements {
-			ne, hit := foldSelfRef(e, fullKey, replacement)
+			ne, hit := foldSelfRefInner(e, fullKey, replacement, allowPrefix)
 			if hit {
 				if !anyHit && replacement != nil {
 					newEls = make([]Val, len(vv.Elements))
@@ -112,7 +125,7 @@ func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 		anyHit := false
 		for _, k := range vv.keys {
 			val := vv.values[k]
-			nv, hit := foldSelfRef(val, fullKey, replacement)
+			nv, hit := foldSelfRefInner(val, fullKey, replacement, false)
 			if hit {
 				if !anyHit && replacement != nil {
 					newObj = newObjectVal()
@@ -285,10 +298,15 @@ func foldOrSkipPrior(prior Val, fullKey string, old Val) (Val, bool) {
 }
 
 func foldOptionalSelfRefAbsent(v Val, fullKey string) (Val, bool) {
+	return foldOptionalSelfRefAbsentInner(v, fullKey, true)
+}
+
+// See foldSelfRefInner for the allowPrefix narrowing rule.
+func foldOptionalSelfRefAbsentInner(v Val, fullKey string, allowPrefix bool) (Val, bool) {
 	switch vv := v.(type) {
 	case *substPlaceholder:
-		if vv.knownAbsent ||
-			(substFullKey(vv) != fullKey && substPrefixRemainder(vv, fullKey) == nil) {
+		prefixHit := allowPrefix && substPrefixRemainder(vv, fullKey) != nil
+		if vv.knownAbsent || (substFullKey(vv) != fullKey && !prefixHit) {
 			return v, true
 		}
 		if !vv.node.Optional {
@@ -300,7 +318,7 @@ func foldOptionalSelfRefAbsent(v Val, fullKey string) (Val, bool) {
 	case *concatPlaceholder:
 		newVals := make([]Val, len(vv.vals))
 		for i, e := range vv.vals {
-			folded, ok := foldOptionalSelfRefAbsent(e, fullKey)
+			folded, ok := foldOptionalSelfRefAbsentInner(e, fullKey, allowPrefix)
 			if !ok {
 				return nil, false
 			}
@@ -310,7 +328,7 @@ func foldOptionalSelfRefAbsent(v Val, fullKey string) (Val, bool) {
 	case *ArrayVal:
 		newEls := make([]Val, len(vv.Elements))
 		for i, e := range vv.Elements {
-			folded, ok := foldOptionalSelfRefAbsent(e, fullKey)
+			folded, ok := foldOptionalSelfRefAbsentInner(e, fullKey, allowPrefix)
 			if !ok {
 				return nil, false
 			}
@@ -329,7 +347,7 @@ func foldOptionalSelfRefAbsent(v Val, fullKey string) (Val, bool) {
 		// correct — the rebuilt object must preserve the full prior chain.
 		newObj := newObjectVal()
 		for _, k := range vv.keys {
-			folded, ok := foldOptionalSelfRefAbsent(vv.values[k], fullKey)
+			folded, ok := foldOptionalSelfRefAbsentInner(vv.values[k], fullKey, false)
 			if !ok {
 				return nil, false
 			}

--- a/internal/resolver/foldselfref.go
+++ b/internal/resolver/foldselfref.go
@@ -8,6 +8,8 @@
 
 package resolver
 
+import "strings"
+
 // foldSelfRef walks v and rewrites every substPlaceholder whose dotted-path
 // key equals fullKey by substituting replacement. The boolean return reports
 // whether at least one such self-reference was found in v (regardless of
@@ -37,13 +39,22 @@ func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 		if vv.knownAbsent {
 			return v, false
 		}
-		if substFullKey(vv) != fullKey {
-			return v, false
+		if substFullKey(vv) == fullKey {
+			if replacement != nil {
+				return replacement, true
+			}
+			return v, true
 		}
-		if replacement != nil {
-			return replacement, true
+		// S13a.12: a substitution whose path has fullKey as a PROPER prefix
+		// (`${foo.a}` inside the stack of `foo`) is also a self-reference —
+		// it folds to the remainder navigated into the below value.
+		if rem := substPrefixRemainder(vv, fullKey); rem != nil {
+			if replacement == nil {
+				return v, true // detection-only pass
+			}
+			return foldPrefixSelfRef(vv, replacement, rem), true
 		}
-		return v, true
+		return v, false
 	case *concatPlaceholder:
 		var newVals []Val
 		anyHit := false
@@ -154,7 +165,115 @@ func foldSelfRef(v Val, fullKey string, replacement Val) (Val, bool) {
 // The no-prior optional case preserves S13a.13's "optional self-ref with no
 // prior resolves to undefined" rule while still saving concat literal pieces
 // for the next overwrite.
+// substPrefixRemainder returns the remainder segment texts when fullKey is a
+// PROPER segment-wise prefix of the subst's path (`foo` ⊏ `foo.a` → ["a"]),
+// else nil. Boundary-safe on the dotted keys because both sides share
+// segmentsToKey's quoting — a literal dotted segment renders quoted and can
+// never string-prefix `foo.` (S13a.12).
+func substPrefixRemainder(sp *substPlaceholder, fullKey string) []string {
+	texts := segTexts(sp.segments)
+	if !strings.HasPrefix(segmentsToKey(texts), fullKey+".") {
+		return nil
+	}
+	for n := 1; n < len(texts); n++ {
+		if segmentsToKey(texts[:n]) == fullKey {
+			return texts[n:]
+		}
+	}
+	return nil
+}
+
+// navigateVal walks remainder into a resolver value structurally, following
+// ObjectVal fields. Returns (node, true) when reached, (nil, true) when a
+// segment is missing or the walk dead-ends in a scalar/array (path-absent),
+// and (nil, false) when it hits a node it cannot see through (a live
+// substitution or concat placeholder).
+func navigateVal(v Val, remainder []string) (Val, bool) {
+	cur := v
+	for _, seg := range remainder {
+		switch cv := cur.(type) {
+		case *substPlaceholder, *concatPlaceholder:
+			_ = cv
+			return nil, false
+		case *ObjectVal:
+			next, ok := cv.Get(seg)
+			if !ok {
+				return nil, true
+			}
+			cur = next
+		default:
+			return nil, true
+		}
+	}
+	return cur, true
+}
+
+// foldPrefixSelfRef folds one prefix self-reference against the below value.
+// A missing path folds to the undefined classification — a knownAbsent
+// placeholder that disappears when optional and errors at resolve time when
+// required. An unnavigable path leaves the subst unchanged for the
+// resolve-time guard.
+func foldPrefixSelfRef(sp *substPlaceholder, replacement Val, remainder []string) Val {
+	nav, navigable := navigateVal(replacement, remainder)
+	if !navigable {
+		return sp
+	}
+	if nav == nil {
+		absent := *sp
+		absent.knownAbsent = true
+		return &absent
+	}
+	return nav
+}
+
+// mergePriorLayers merges the navigated value (top) over the below layer
+// (base) for the standalone-prefix-self-ref save case (S13a.12). A local,
+// bookkeeping-free merge — deliberately NOT deepMerge, which re-runs
+// prior-save logic that has already happened for these layers.
+func mergePriorLayers(base, top *ObjectVal) *ObjectVal {
+	out := newObjectVal()
+	for _, k := range base.Keys() {
+		v, _ := base.Get(k)
+		out.set(k, v)
+	}
+	for k, pv := range base.priorValues {
+		out.priorValues[k] = pv
+	}
+	for _, k := range top.Keys() {
+		tv, _ := top.Get(k)
+		if bv, ok := out.Get(k); ok {
+			if bo, okB := bv.(*ObjectVal); okB {
+				if to, okT := tv.(*ObjectVal); okT {
+					out.set(k, mergePriorLayers(bo, to))
+					continue
+				}
+			}
+		}
+		out.set(k, tv)
+	}
+	return out
+}
+
 func foldOrSkipPrior(prior Val, fullKey string, old Val) (Val, bool) {
+	// S13a.12: a STANDALONE prefix self-ref in field-value position is a
+	// merge LAYER — an object it navigates to merges over the stack below,
+	// so the saved prior keeps the below layer's other keys. An optional one
+	// whose navigated path is absent vanishes transparently (the below layer
+	// itself survives as the prior). Nested occurrences substitute in place
+	// via the generic fold below.
+	if sp, ok := prior.(*substPlaceholder); ok && !sp.knownAbsent && old != nil {
+		if rem := substPrefixRemainder(sp, fullKey); rem != nil {
+			nav, navigable := navigateVal(old, rem)
+			if nav == nil && navigable && sp.node.Optional {
+				return old, true
+			}
+			if navObj, okN := nav.(*ObjectVal); okN {
+				if oldObj, okO := old.(*ObjectVal); okO {
+					return mergePriorLayers(oldObj, navObj), true
+				}
+			}
+		}
+	}
 	folded, hasSelfRef := foldSelfRef(prior, fullKey, old)
 	if !hasSelfRef {
 		return prior, true
@@ -168,7 +287,8 @@ func foldOrSkipPrior(prior Val, fullKey string, old Val) (Val, bool) {
 func foldOptionalSelfRefAbsent(v Val, fullKey string) (Val, bool) {
 	switch vv := v.(type) {
 	case *substPlaceholder:
-		if vv.knownAbsent || substFullKey(vv) != fullKey {
+		if vv.knownAbsent ||
+			(substFullKey(vv) != fullKey && substPrefixRemainder(vv, fullKey) == nil) {
 			return v, true
 		}
 		if !vv.node.Optional {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -475,6 +475,18 @@ type resolver struct {
 	priorValues   map[string]Val  // previous value before self-referential overwrite (first pass)
 	includeStack  *[]string       // shared stack for circular include detection (normalized paths)
 	lenient       bool            // when true, unresolved substitutions are left as placeholders instead of erroring
+
+	// resolvingFieldPath is the full dotted path of the field currently being
+	// resolved in phase 2 (S13a.12 prefix-self-ref owner gate). The push/pop
+	// span in resolveSubstitutions covers both the value and the prior-chain
+	// resolution of each field.
+	resolvingFieldPath []string
+	// resolvingPrefixPriors guards the S13a.12 prefix-self-ref branch against
+	// re-entry: saved priors are prefix-self-ref-free by the fold invariant,
+	// so re-entry only happens on a shape the fold could not see through — it
+	// is reported as unresolvable instead of recursing forever. Lazily
+	// initialized at first use.
+	resolvingPrefixPriors map[string]bool
 }
 
 func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, pathPrefix []string) (*ObjectVal, error) {
@@ -739,10 +751,33 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 	result := newObjectVal()
 	for _, k := range obj.Keys() {
 		v, _ := obj.Get(k)
-		resolved, err := r.resolveVal(v, root, k)
+		// The push/pop span covers BOTH the value resolution and the
+		// prior-chain resolution below: a prior belongs to this field's value
+		// stack, so a substitution inside it must see the full field path
+		// (S13a.12). With the field popped, a prior's reference into a
+		// sibling of this field would satisfy the prefix-self-ref test
+		// against the truncated path and mis-route to the parent's prior.
+		r.resolvingFieldPath = append(r.resolvingFieldPath, k)
+		err := func() error {
+			resolved, err := r.resolveVal(v, root, k)
+			if err != nil {
+				return err
+			}
+			return r.finishField(result, obj, root, k, resolved)
+		}()
+		r.resolvingFieldPath = r.resolvingFieldPath[:len(r.resolvingFieldPath)-1]
 		if err != nil {
 			return nil, err
 		}
+	}
+	return result, nil
+}
+
+// finishField applies the delayed-merge / prior-fallback tail of one field's
+// phase-2 resolution (split from resolveSubstitutions so the whole tail stays
+// inside the resolvingFieldPath span).
+func (r *resolver) finishField(result, obj, root *ObjectVal, k string, resolved Val) error {
+	{
 		if resolved != nil {
 			// Delayed merge (site 1): if both current and prior resolve to objects,
 			// deep-merge them (prior as base, current on top).
@@ -750,7 +785,7 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 				if prior, hasPrior := obj.priorValues[k]; hasPrior {
 					priorResolved, perr := r.resolveVal(prior, root, k)
 					if perr != nil {
-						return nil, perr
+						return perr
 					}
 					if priorResolved != nil {
 						if priorObj, pOk := priorResolved.(*ObjectVal); pOk {
@@ -768,7 +803,7 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 			// optional substitution resolved to nothing — fall back to prior value (per-object scope)
 			fallback, ferr := r.resolveVal(prior, root, k)
 			if ferr != nil {
-				return nil, ferr
+				return ferr
 			}
 			if fallback != nil {
 				result.set(k, fallback)
@@ -779,7 +814,7 @@ func (r *resolver) resolveSubstitutions(obj *ObjectVal, root *ObjectVal) (*Objec
 		}
 		// nil means the field was dropped (optional substitution resolved to nothing)
 	}
-	return result, nil
+	return nil
 }
 
 func (r *resolver) resolveVal(v Val, root *ObjectVal, path string) (Val, error) {
@@ -814,12 +849,61 @@ func (r *resolver) resolveSubst(s *substPlaceholder, root *ObjectVal) (Val, erro
 		// the `+=` chain bottom had nothing preceding it — collapse to absent.
 		// Rehydration (deepMerge / the include-merge stitch) replaces sentinels
 		// that DO have a predecessor before they ever reach here.
+		//
+		// S13a.12: a REQUIRED substitution folded to knownAbsent (prefix fold
+		// with no below value at the navigated path) is the spec's "undefined"
+		// classification — an error, not a silent disappearance. The `+=`
+		// sentinel is always `${?…}` and keeps the silent path.
+		if !s.node.Optional {
+			if r.lenient {
+				return s, nil
+			}
+			k := segmentsToKey(segTexts(s.segments))
+			return nil, &ResolveError{Message: "unresolved substitution", Path: k, Line: s.node.Line(), Col: s.node.Col()}
+		}
 		return nil, nil
 	}
 
 	n := s.node
 	segStrs := segTexts(s.segments)
 	key := segmentsToKey(segStrs)
+
+	// S13a.12 (HOCON.md L791): a substitution whose target lies INSIDE the
+	// field currently being resolved (the field path is a proper prefix of
+	// the target path, e.g. `foo : ${foo.a}` while resolving `foo`) is
+	// self-referential and resolves against the field's "below" value — its
+	// saved prior — never the final tree, which would see the layers ABOVE
+	// the substitution. Runs before the resolvedCache fast path: the cache
+	// holds final-tree values.
+	if rfp := r.resolvingFieldPath; len(rfp) > 0 && len(rfp) < len(segStrs) &&
+		segmentsToKey(segStrs[:len(rfp)]) == segmentsToKey(rfp) {
+		guardKey := segmentsToKey(rfp)
+		if !r.resolvingPrefixPriors[guardKey] {
+			if prior := r.findPrior(root, rfp, guardKey); prior != nil {
+				if r.resolvingPrefixPriors == nil {
+					r.resolvingPrefixPriors = make(map[string]bool)
+				}
+				r.resolvingPrefixPriors[guardKey] = true
+				priorResolved, perr := r.resolveVal(prior, root, guardKey)
+				delete(r.resolvingPrefixPriors, guardKey)
+				if perr != nil {
+					return nil, perr
+				}
+				if priorResolved != nil {
+					if nav := navigateResolvedVal(priorResolved, segStrs[len(rfp):]); nav != nil {
+						return nav, nil
+					}
+				}
+			}
+		}
+		if n.Optional {
+			return nil, nil
+		}
+		if r.lenient {
+			return s, nil
+		}
+		return nil, &ResolveError{Message: "unresolved substitution", Path: key, Line: n.Line(), Col: n.Col()}
+	}
 
 	// Fast path: if this key is already fully resolved (e.g. `b = ${a}` where
 	// `a` was processed first), return the cached value immediately.  This
@@ -1099,6 +1183,25 @@ func (r *resolver) resolveEnvList(s *substPlaceholder, segStrs []string, n *pars
 }
 
 // findPrior looks up the per-object priorValues for a given path in the tree.
+// navigateResolvedVal walks resolved ObjectVal fields by segment text
+// (S13a.12). A missing segment or a walk into a scalar/array is path-absent →
+// nil.
+func navigateResolvedVal(v Val, remainder []string) Val {
+	cur := v
+	for _, seg := range remainder {
+		obj, ok := cur.(*ObjectVal)
+		if !ok {
+			return nil
+		}
+		next, found := obj.Get(seg)
+		if !found {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}
+
 func (r *resolver) findPrior(root *ObjectVal, segments []string, pathStr string) Val {
 	// Check resolver-level priorValues first (top-level keys).
 	if prior, ok := r.priorValues[pathStr]; ok {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -215,6 +215,19 @@ func MergeUnresolved(receiver, fallback *ObjectVal) *ObjectVal {
 
 // deepMerge merges src into dst (dst values take precedence for non-objects).
 func deepMerge(dst, src *ObjectVal) *ObjectVal {
+	return deepMergeAt(dst, src, nil, false)
+}
+
+// deepMergeAt is deepMerge with optional path-aware prior bookkeeping
+// (S13a.12; ts/rs parity — their deep merges have been path-aware since
+// v1.5.1). When savePriors is true, a non-object collision records the
+// shadowed older (src) value as the prior for the child key, folded against
+// the running prior with the child's FULL dotted key — so self-references in
+// the newer value (exact or prefix, e.g. `${srv.foo.a}` inside srv's second
+// definition) can look back at it. Phase-2 merges of resolved values and
+// MergeUnresolved (which does its own prior bookkeeping) pass false and are
+// byte-for-byte unchanged.
+func deepMergeAt(dst, src *ObjectVal, pathPrefix []string, savePriors bool) *ObjectVal {
 	result := newObjectVal()
 	// add all dst keys first
 	for _, k := range dst.keys {
@@ -231,8 +244,14 @@ func deepMerge(dst, src *ObjectVal) *ObjectVal {
 			// both object → merge
 			if do, dok := dv.(*ObjectVal); dok {
 				if so, sok := sv.(*ObjectVal); sok {
-					result.values[k] = deepMerge(do, so)
+					result.values[k] = deepMergeAt(do, so, append(append([]string{}, pathPrefix...), k), savePriors)
 					continue
+				}
+			}
+			if savePriors {
+				childKey := segmentsToKey(append(append([]string{}, pathPrefix...), k))
+				if folded, doSave := foldOrSkipPrior(sv, childKey, result.priorValues[k]); doSave {
+					result.priorValues[k] = folded
 				}
 			}
 			// #134: dst's value chains off an outer `${?k}` (a desugared `+=`
@@ -522,7 +541,7 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 					if eo, eok := existing.(*ObjectVal); eok {
 						if io, iok := iv.(*ObjectVal); iok {
 							// both objects → deep merge with included on top
-							obj.set(k, deepMerge(io, eo))
+							obj.set(k, deepMergeAt(io, eo, append(append([]string{}, pathPrefix...), k), true))
 							// #120: save existing as prior even on object+object
 							// merge, so a self-referential `${k}` in the included
 							// file's body (e.g. `o = { history = ${o}, v = 2 }`
@@ -647,7 +666,8 @@ func (r *resolver) resolveObject(node *parser.ObjectNode, fallback *ObjectVal, p
 			if existing, ok := obj.Get(key); ok {
 				if eo, eok := existing.(*ObjectVal); eok {
 					if nv, nok := val.(*ObjectVal); nok {
-						val = deepMerge(nv, eo) // new over existing: nv=dst wins
+						childPath := append(append([]string{}, pathPrefix...), key)
+						val = deepMergeAt(nv, eo, childPath, true) // new over existing: nv=dst wins
 					}
 				}
 				// Always save existing as prior (whether or not val deep-merged
@@ -1537,7 +1557,7 @@ func (r *resolver) setPath(obj *ObjectVal, segments []string, val Val, fullPath 
 		if existing, ok := obj.Get(key); ok {
 			if eo, eok := existing.(*ObjectVal); eok {
 				if nv, nok := val.(*ObjectVal); nok {
-					val = deepMerge(nv, eo) // new over existing: nv=dst wins
+					val = deepMergeAt(nv, eo, fullPath, true) // new over existing: nv=dst wins
 				}
 			}
 			// #120: always save existing as prior (mirror of the top-level

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1202,7 +1202,6 @@ func (r *resolver) resolveEnvList(s *substPlaceholder, segStrs []string, n *pars
 	}
 }
 
-// findPrior looks up the per-object priorValues for a given path in the tree.
 // navigateResolvedVal walks resolved ObjectVal fields by segment text
 // (S13a.12). A missing segment or a walk into a scalar/array is path-absent →
 // nil.
@@ -1222,6 +1221,7 @@ func navigateResolvedVal(v Val, remainder []string) Val {
 	return cur
 }
 
+// findPrior looks up the per-object priorValues for a given path in the tree.
 func (r *resolver) findPrior(root *ObjectVal, segments []string, pathStr string) Val {
 	// Check resolver-level priorValues first (top-level keys).
 	if prior, ok := r.priorValues[pathStr]; ok {

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -777,3 +777,14 @@ func TestSpec_S23_4_ObjectWinsOverString(t *testing.T) {
 		}
 	})
 }
+
+// TestSpec_S13a_12_InteriorSiblingStaysLazy pins the allowPrefix narrowing:
+// a substitution nested inside an object literal that references a sibling
+// branch of the same field is a lazy final-tree lookup (S13a.14), not a
+// below-lookback.
+func TestSpec_S13a_12_InteriorSiblingStaysLazy(t *testing.T) {
+	cfg := mustParseCfg(t, "a = { p : { v : 1 }, x : ${a.p.v} }\na = { y : 2 }")
+	if cfg.GetInt("a.x") != 1 || cfg.GetInt("a.y") != 2 || cfg.GetInt("a.p.v") != 1 {
+		t.Error("interior sibling: expected a = {p:{v:1}, x:1, y:2}")
+	}
+}

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -416,31 +416,13 @@ func TestSpec_S13a_10_MemoizedByInstance(t *testing.T) {
 
 // ── S13a.12: self-ref in path expression resolves to "below" ─────────────────
 
-// TestSpec_S13a_12_SelfRefInPathResolvesBelow_Pin pins the current behaviour:
-// the spec example `foo : { a : { c : 1 } }; foo : ${foo.a}; foo : { a : 2 }`
-// should yield {a:2, c:1} but the impl produces {a:2} (c is lost).
-// Spec HOCON.md L791.
-func TestSpec_S13a_12_SelfRefInPathResolvesBelow_Pin(t *testing.T) {
-	// pin: see #79 — ${foo.a} self-reference does not include {c:1} in the merge
-	_ = specIssueS13a_12_SelfRefPath
-	cfg := mustParseCfg(t, `
-foo : { a : { c : 1 } }
-foo : ${foo.a}
-foo : { a : 2 }
-`)
-	// a=2 is correct regardless
-	if cfg.GetInt("foo.a") != 2 {
-		t.Errorf("[pin] foo.a: expected 2, got %d", cfg.GetInt("foo.a"))
-	}
-	// c should be absent (current buggy behaviour)
-	if cfg.GetIntOption("foo.c").IsSome() {
-		t.Error("[pin] foo.c should be absent in current impl (self-ref-in-path bug)")
-	}
-}
-
-// TestSpec_S13a_12_SelfRefInPathResolvesBelow_Spec is the spec-correct assertion.
+// TestSpec_S13a_12_SelfRefInPathResolvesBelow_Spec asserts the spec behaviour
+// (HOCON.md L791, fixed via #79): a substitution whose target lies inside the
+// field being defined resolves against the field's "below" value — the merge
+// of the stack beneath the substitution — never the final tree. Fixed in
+// lockstep with ts.hocon / py.hocon / rs.hocon (all four shared the gap).
 func TestSpec_S13a_12_SelfRefInPathResolvesBelow_Spec(t *testing.T) {
-	t.Skipf("[skip] spec violation per S13a.12 — ${foo.a} does not include {c:1}; see #%d", specIssueS13a_12_SelfRefPath)
+	_ = specIssueS13a_12_SelfRefPath
 	cfg := mustParseCfg(t, `
 foo : { a : { c : 1 } }
 foo : ${foo.a}
@@ -452,6 +434,62 @@ foo : { a : 2 }
 	}
 	if cfg.GetInt("foo.c") != 1 {
 		t.Errorf("foo.c: expected 1, got %d", cfg.GetInt("foo.c"))
+	}
+}
+
+// TestSpec_S13a_12_PrefixSelfRefEdges covers the surrounding contract: layer
+// merge keeps the below layer's other keys, two-layer forms resolve, a scalar
+// navigation resets the stack, optional misses vanish transparently, required
+// misses take the undefined classification, and non-self-ref shapes are
+// untouched.
+func TestSpec_S13a_12_PrefixSelfRefEdges(t *testing.T) {
+	// Two layers, substitution last: navigated object merges over the below.
+	cfg := mustParseCfg(t, "foo : { a : { c : 1 } }\nfoo : ${foo.a}")
+	if cfg.GetInt("foo.c") != 1 || cfg.GetInt("foo.a.c") != 1 {
+		t.Errorf("two-layer: expected {a:{c:1}, c:1}, got c=%v a.c=%v",
+			cfg.GetIntOption("foo.c"), cfg.GetIntOption("foo.a.c"))
+	}
+
+	// Below layer keys not touched by the sandwich survive.
+	cfg = mustParseCfg(t, "foo : { a : { c : 1 }, keep : 9 }\nfoo : ${foo.a}\nfoo : { a : 2 }")
+	if cfg.GetInt("foo.keep") != 9 || cfg.GetInt("foo.c") != 1 || cfg.GetInt("foo.a") != 2 {
+		t.Error("keep: expected {a:2, keep:9, c:1}")
+	}
+
+	// Navigating to a scalar resets the stack (later object wins alone).
+	cfg = mustParseCfg(t, "foo : { a : 5 }\nfoo : ${foo.a}\nfoo : { b : 2 }")
+	if cfg.GetIntOption("foo.a").IsSome() || cfg.GetInt("foo.b") != 2 {
+		t.Error("scalar-nav: expected {b:2}")
+	}
+
+	// Optional prefix self-ref with nothing below vanishes transparently.
+	cfg = mustParseCfg(t, "foo : { a : 1 }\nfoo : ${?foo.nope}\nfoo : { b : 2 }")
+	if cfg.GetInt("foo.a") != 1 || cfg.GetInt("foo.b") != 2 {
+		t.Error("opt-vanish: expected {a:1, b:2}")
+	}
+
+	// Required prefix self-ref with nothing below is an unresolved error.
+	if _, err := hocon.ParseString("foo : { a : 1 }\nfoo : ${foo.nope}\nfoo : { b : 2 }"); err == nil {
+		t.Error("req-missing: expected unresolved-substitution error, got nil")
+	}
+
+	// Nested paths: the prior lives on the parent scope.
+	cfg = mustParseCfg(t, "srv : { foo : { a : { c : 1 } } }\nsrv : { foo : ${srv.foo.a} }\nsrv : { foo : { a : 2 } }")
+	if cfg.GetInt("srv.foo.a") != 2 || cfg.GetInt("srv.foo.c") != 1 {
+		t.Error("nested: expected srv.foo = {a:2, c:1}")
+	}
+
+	// Regression: a sibling reference in a deeper field's prior still sees the
+	// final tree (rfp span covers prior resolution).
+	cfg = mustParseCfg(t, "bar { nested { x = { q: 10 }\na = ${bar.nested.x}\na = { c: 3 } } }")
+	if cfg.GetInt("bar.nested.a.q") != 10 || cfg.GetInt("bar.nested.a.c") != 3 {
+		t.Error("sibling-prior: expected bar.nested.a = {q:10, c:3}")
+	}
+
+	// Unnavigable below (live subst mid-walk): the optional form stays resolvable.
+	cfg = mustParseCfg(t, "foo : { a : ${x} }\nfoo : ${?foo.a.b}\nfoo : { z : 1 }\nx : { b : 7 }")
+	if cfg.GetInt("foo.z") != 1 {
+		t.Error("unnav-opt: expected {z:1}")
 	}
 }
 

--- a/spec_phase5_test.go
+++ b/spec_phase5_test.go
@@ -493,6 +493,124 @@ func TestSpec_S13a_12_PrefixSelfRefEdges(t *testing.T) {
 	}
 }
 
+// TestSpec_S13a_12_LayerMergeBookkeeping pins the bookkeeping side of the
+// standalone-prefix layer merge: priorValues from BOTH layers survive so
+// per-object look-back keeps working after the fold. Expected values verified
+// against py.hocon (post-#37/#38).
+func TestSpec_S13a_12_LayerMergeBookkeeping(t *testing.T) {
+	// Two object layers below the sandwich: the navigated `a` carries its own
+	// delayed-merge chain (c:1 under c:2), and the below layer carries chains
+	// for a/k — the merged prior must keep both layers' bookkeeping.
+	cfg := mustParseCfg(t, `
+foo : { a : { c : 1 }, k : 1 }
+foo : { a : { c : 2 }, k : 2 }
+foo : ${foo.a}
+foo : { z : 9 }
+`)
+	if cfg.GetInt("foo.a.c") != 2 || cfg.GetInt("foo.k") != 2 ||
+		cfg.GetInt("foo.c") != 2 || cfg.GetInt("foo.z") != 9 {
+		t.Errorf("layered: expected {a:{c:2}, k:2, c:2, z:9}, got a.c=%v k=%v c=%v z=%v",
+			cfg.GetIntOption("foo.a.c"), cfg.GetIntOption("foo.k"),
+			cfg.GetIntOption("foo.c"), cfg.GetIntOption("foo.z"))
+	}
+
+	// Key collision where both sides are objects: the layer merge recurses
+	// instead of letting the navigated side clobber the below object.
+	cfg = mustParseCfg(t, `
+foo : { shared : { p : 1 }, a : { shared : { q : 2 } } }
+foo : ${foo.a}
+foo : { z : 0 }
+`)
+	if cfg.GetInt("foo.shared.p") != 1 || cfg.GetInt("foo.shared.q") != 2 ||
+		cfg.GetInt("foo.a.shared.q") != 2 || cfg.GetInt("foo.z") != 0 {
+		t.Errorf("recurse: expected shared={p:1,q:2}, got p=%v q=%v",
+			cfg.GetIntOption("foo.shared.p"), cfg.GetIntOption("foo.shared.q"))
+	}
+}
+
+// TestSpec_S13a_12_UndefinedClassificationErrors pins the error side of the
+// prefix rule: every way the below-navigation can come up empty or poisoned
+// takes the spec's "undefined" classification (required → error). Expected
+// outcomes verified against py.hocon (post-#37/#38).
+func TestSpec_S13a_12_UndefinedClassificationErrors(t *testing.T) {
+	cases := []struct{ name, src string }{
+		// fold-side: the walk dead-ends in a scalar mid-path at prior-save time
+		{"fold-scalar-deadend", "foo : { a : 5 }\nfoo : ${foo.a.b}\nfoo : { c : 1 }"},
+		// resolve-side (no layer above): the below has no such key
+		{"resolve-key-miss", "foo : { a : 1 }\nfoo : ${foo.b}"},
+		// resolve-side: the walk dead-ends in a scalar mid-path
+		{"resolve-scalar-deadend", "foo : { a : 1 }\nfoo : ${foo.a.b}"},
+		// resolve-side: the below itself fails to resolve — the error propagates
+		{"prior-error-propagates", "foo : { a : ${zz} }\nfoo : ${foo.a}"},
+		// an optional final layer that vanishes falls back to the saved prior,
+		// and the prior's own undefined classification still errors
+		{"optional-final-prior-error", "foo : { a : 1 }\nfoo : ${foo.b}\nfoo : ${?zz}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := hocon.ParseString(tc.src); err == nil {
+				t.Errorf("expected unresolved-substitution error, got nil")
+			}
+		})
+	}
+}
+
+// TestSpec_S13a_12_AllowUnresolvedLenientContract pins the lenient contract
+// for a required prefix self-ref with no below value. Resolve side (the subst
+// IS the field value): the placeholder survives in the tree. Fold side (the
+// knownAbsent sentinel sits in a prior layer under a top object): the
+// unresolvable prior is dropped from the delayed merge and the top layer
+// resolves alone — the same input errors in strict mode (see
+// TestSpec_S13a_12_UndefinedClassificationErrors/fold-scalar-deadend).
+func TestSpec_S13a_12_AllowUnresolvedLenientContract(t *testing.T) {
+	lenientResolve := func(t *testing.T, src string) *hocon.Config {
+		t.Helper()
+		cfg, err := hocon.ParseStringWithOptions(src,
+			hocon.DefaultParseOptions().WithResolveSubstitutions(false))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		resolved, err := cfg.Resolve(hocon.DefaultResolveOptions().WithAllowUnresolved(true))
+		if err != nil {
+			t.Fatalf("Resolve(AllowUnresolved=true): %v", err)
+		}
+		return resolved
+	}
+
+	t.Run("resolve-side", func(t *testing.T) {
+		resolved := lenientResolve(t, "foo : { a : 1 }\nfoo : ${foo.b}")
+		if resolved.IsResolved() {
+			t.Error("expected the required prefix self-ref to remain unresolved")
+		}
+	})
+
+	t.Run("fold-side", func(t *testing.T) {
+		resolved := lenientResolve(t, "foo : { a : 5 }\nfoo : ${foo.a.b}\nfoo : { c : 1 }")
+		if !resolved.IsResolved() {
+			t.Fatal("expected the top layer to resolve with the poisoned prior dropped")
+		}
+		if resolved.GetInt("foo.c") != 1 || resolved.GetIntOption("foo.a").IsSome() {
+			t.Errorf("expected foo={c:1}, got c=%v a=%v",
+				resolved.GetIntOption("foo.c"), resolved.GetIntOption("foo.a"))
+		}
+	})
+
+	t.Run("fold-side-delayed-merge", func(t *testing.T) {
+		// The top layer carries its own placeholder, so phase-2 visits the
+		// field and the delayed merge actually resolves the knownAbsent prior
+		// — the lenient path returns it as a placeholder, which (not being an
+		// object) is dropped from the merge.
+		resolved := lenientResolve(t, "foo : { a : 5 }\nfoo : ${foo.a.b}\nfoo : { c : ${x} }\nx : 1")
+		if !resolved.IsResolved() {
+			t.Fatal("expected the top layer to resolve with the poisoned prior dropped")
+		}
+		if resolved.GetInt("foo.c") != 1 || resolved.GetIntOption("foo.a").IsSome() {
+			t.Errorf("expected foo={c:1}, got c=%v a=%v",
+				resolved.GetIntOption("foo.c"), resolved.GetIntOption("foo.a"))
+		}
+	})
+}
+
 // ── S13a.14: mutually-referring objects resolve lazily without false cycle ─────
 
 // TestSpec_S13a_14_MutualRefNoCycle verifies the spec example:


### PR DESCRIPTION
## Summary

Third of the 4-implementation same-window fixes (same semantics as [ts#188](https://github.com/o3co/ts.hocon/pull/188) / [py#37](https://github.com/o3co/py.hocon/pull/37); the reclassification is [xx#89](https://github.com/o3co/xx.hocon/pull/89)).

The spec L791 example goes from `{a:2}` → **`{a:2, c:1}`**. **go reaches in-scope 100.0% / spec-total 90.5%** (the go cells in "Top spec violations" drop to zero).

## Implementation (ts's design ported onto go's fold/resolver structure)

- **foldselfref.go**: adds `substPrefixRemainder` (segment-boundary-safe prefix check) / `navigateVal` / `foldPrefixSelfRef` / `mergePriorLayers`, extending the 3 fold functions to handle prefixes. A standalone prefix self-ref acts as a merge LAYER that preserves the other keys of the below layer; a missing navigate on an optional one leaves below transparently in place
- **resolver.go**: introduces `resolvingFieldPath` / `resolvingPrefixPriors` (re-entry guards). Extends the field span of `resolveSubstitutions` through prior resolution (split out into `finishField` — prevents false hits on sibling references, with a regression test). `resolveSubst` gains a prefix branch (`findPrior` + remainder navigation, **respecting lenient/AllowUnresolved**). The knownAbsent guard respects optionality (the `+=` sentinel is always optional, unchanged)

## Tests

- The spec example + 8 edges (2-layer / keep preservation / scalar reset / optional transparency / required error / nested / sibling-in-prior regression / unnavigable) pinned in `TestSpec_S13a_12_*`
- `go test -race ./...` + adapters (`make check`) + `golangci-lint` all green. The docs gates (en/ja) verify the rates 90.5 / 100.0
- BREAKING recorded in the CHANGELOG. The old `_Pin` (which pinned the buggy behavior) removed

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
